### PR TITLE
Add a new method app_strings(language) to get the strings for a specific language

### DIFF
--- a/appium/webdriver/webdriver.py
+++ b/appium/webdriver/webdriver.py
@@ -311,14 +311,17 @@ class WebDriver(webdriver.Remote):
         self.execute_script('mobile: pinchOpen', opts)
         return self
 
-    @property
-    def app_strings(self):
-        """Returns the application strings from the device.
+    def app_strings(self, language=None):
+        """Returns the application strings from the device for the specified
+        language.
 
-        :Usage:
-            strings = driver.app_strings
+        :Args:
+         - language - strings language code
         """
-        return self.execute(Command.GET_APP_STRINGS)['value']
+        data = {}
+        if language != None:
+            data['language'] = language
+        return self.execute(Command.GET_APP_STRINGS, data)['value']
 
     def reset(self):
         """Resets the current application on the device.
@@ -518,7 +521,7 @@ class WebDriver(webdriver.Remote):
         self.command_executor._commands[Command.MULTI_ACTION] = \
             ('POST', '/session/$sessionId/touch/multi/perform')
         self.command_executor._commands[Command.GET_APP_STRINGS] = \
-            ('GET', '/session/$sessionId/appium/app/strings')
+            ('POST', '/session/$sessionId/appium/app/strings')
         self.command_executor._commands[Command.KEY_EVENT] = \
             ('POST', '/session/$sessionId/appium/device/keyevent')
         self.command_executor._commands[Command.GET_CURRENT_ACTIVITY] = \

--- a/test/functional/android/appium_tests.py
+++ b/test/functional/android/appium_tests.py
@@ -34,7 +34,11 @@ class AppiumTests(unittest.TestCase):
         self.driver.quit()
 
     def test_app_strings(self):
-        strings = self.driver.app_strings
+        strings = self.driver.app_strings()
+        self.assertEqual(u'You can\'t wipe my data, you are a monkey!', strings[u'monkey_wipe_data'])
+
+    def test_app_strings_with_language(self):
+        strings = self.driver.app_strings("en")
         self.assertEqual(u'You can\'t wipe my data, you are a monkey!', strings[u'monkey_wipe_data'])
 
     def test_keyevent(self):


### PR DESCRIPTION
The Appium command 'session/:sessionId?/appium/app/strings' has changed: https://github.com/appium/appium/commit/af89c299473617b7980770102f07a1205c25627b

Now it's a post command and allows an optional parameter _language_ to get strings for a specific language.
