### PR TITLE
add necessary ios attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ import unittest
 from appium import webdriver
 
 desired_caps = {}
+desired_caps['platformName'] = 'iOS'
+desired_caps['platformVerison'] = '7.1'
+desired_caps['deviceName'] = 'iPhone Simulator'
 desired_caps['app'] = PATH('../../apps/UICatalog.app.zip')
 
 self.driver = webdriver.Remote('http://localhost:4723/wd/hub', desired_caps)


### PR DESCRIPTION
I was setting up this library and I felt that this piece of the README could be expanded to more fully explain the iOS example. For me, it didn't work without these lines.
