### PR TITLE
Change call to single-gesture tap

### DIFF
--- a/appium/webdriver/webdriver.py
+++ b/appium/webdriver/webdriver.py
@@ -201,7 +201,7 @@ class WebDriver(webdriver.Remote):
                 duration = duration
                 action.long_press(x=x, y=y, duration=duration).release()
             else:
-                action.press(x=x, y=y).release()
+                action.tap(x=x, y=y).release()
             action.perform()
         else:
             ma = MultiAction(self)


### PR DESCRIPTION
Should be calling `tap` instead of `press` when doing single gesture tap through the driver method.
