### PR TITLE
Add toggle_location_services

### DIFF
--- a/appium/webdriver/mobilecommand.py
+++ b/appium/webdriver/mobilecommand.py
@@ -27,6 +27,7 @@ class MobileCommand(object):
     ACTIVATE_IME_ENGINE = 'activateIMEEngine'
     DEACTIVATE_IME_ENGINE = 'deactivateIMEEngine'
     GET_ACTIVE_IME_ENGINE = 'getActiveEngine'
+    TOGGLE_LOCATION_SERVICES = 'toggleLocationServices'
 
     # Appium Commands
     GET_APP_STRINGS = 'getAppStrings'

--- a/appium/webdriver/webdriver.py
+++ b/appium/webdriver/webdriver.py
@@ -672,6 +672,13 @@ class WebDriver(webdriver.Remote):
         self.execute(Command.UPDATE_SETTINGS, data)
         return self
 
+    def toggle_location_services(self):
+        """Toggle the location services on the device. Android only.
+        """
+        self.execute(Command.TOGGLE_LOCATION_SERVICES, {})
+        return self
+
+
     def _addCommands(self):
         self.command_executor._commands[Command.CONTEXTS] = \
             ('GET', '/session/$sessionId/contexts')
@@ -748,6 +755,8 @@ class WebDriver(webdriver.Remote):
             ('GET', '/session/$sessionId/appium/settings')
         self.command_executor._commands[Command.UPDATE_SETTINGS] = \
             ('POST', '/session/$sessionId/appium/settings')
+        self.command_executor._commands[Command.TOGGLE_LOCATION_SERVICES] = \
+            ('POST', '/session/$sessionId/appium/device/toggle_location_services')
 
 
 # monkeypatched method for WebElement

--- a/test/functional/android/appium_tests.py
+++ b/test/functional/android/appium_tests.py
@@ -39,7 +39,7 @@ class AppiumTests(unittest.TestCase):
         self.driver.quit()
 
         # remove zipped file from `test_pull_folder`
-        if os.path.isfile(self.zipfilename):
+        if hasattr(self, 'zipfilename') and os.path.isfile(self.zipfilename):
             os.remove(self.zipfilename)
 
     def test_app_strings(self):
@@ -216,6 +216,10 @@ class AppiumTests(unittest.TestCase):
         self.driver.update_settings({"cyberdelia": "open"})
         settings = self.driver.get_settings()
         self.assertEqual(settings["cyberdelia"], "open")
+
+    def test_toggle_location_services(self):
+        self.driver.toggle_location_services()
+
 
 if __name__ == "__main__":
     suite = unittest.TestLoader().loadTestsFromTestCase(AppiumTests)

--- a/test/functional/android/desired_capabilities.py
+++ b/test/functional/android/desired_capabilities.py
@@ -26,6 +26,7 @@ def get_desired_capabilities(app):
         'platformVersion': '4.2',
         'deviceName': 'Android Emulator',
         'app': PATH('../../apps/' + app),
+        'newCommandTimeout': 240
     }
 
     return desired_caps


### PR DESCRIPTION
Add an Android-only method to toggle location services (`POST` to `/session/$sessionId/appium/device/toggle_location_services`), which can take a while, so extend the `newCommandTimeout`.

Also fix #54.
