### PR TITLE
Fix handling of sauce test case so ImportError is suppressed

### DIFF
--- a/appium/__init__.py
+++ b/appium/__init__.py
@@ -15,5 +15,9 @@
 """
 Appium Python Client
 """
-from .saucetestcase import SauceTestCase
-from .saucetestcase import on_platforms
+try:
+    from .saucetestcase import SauceTestCase
+    from .saucetestcase import on_platforms
+except ImportError:
+    # SauceClient not found
+    pass


### PR DESCRIPTION
Catch `ImportError` if the user does not have the [SauceClient](https://pypi.python.org/pypi/sauceclient/0.1.0) installed. Resolves #69.