### PR TITLE
Fix issue with single tap

### DIFF
--- a/appium/webdriver/webdriver.py
+++ b/appium/webdriver/webdriver.py
@@ -202,7 +202,7 @@ class WebDriver(webdriver.Remote):
                 duration = duration
                 action.long_press(x=x, y=y, duration=duration).release()
             else:
-                action.tap(x=x, y=y).release()
+                action.tap(x=x, y=y)
             action.perform()
         else:
             ma = MultiAction(self)


### PR DESCRIPTION
`tap` method was sending `release`, thereby bypassing the special logic for single taps on the server.

Fixes appium/appium#4111