### PR TITLE
Fix start_activity for Python 3.x

### DIFF
--- a/appium/webdriver/webdriver.py
+++ b/appium/webdriver/webdriver.py
@@ -550,7 +550,7 @@ class WebDriver(webdriver.Remote):
             'stop_app_on_reset': 'stopAppOnReset'
         }
         for key, value in arguments.items():
-            if opts.has_key(key):
+            if key in opts:
                 data[value] = opts[key]
         self.execute(Command.START_ACTIVITY, data)
         return self


### PR DESCRIPTION
dict.has_key() was removed in Python 3, changed to in.