### PR TITLE
Add location_in_view property

### DIFF
--- a/appium/webdriver/mobilecommand.py
+++ b/appium/webdriver/mobilecommand.py
@@ -28,6 +28,7 @@ class MobileCommand(object):
     DEACTIVATE_IME_ENGINE = 'deactivateIMEEngine'
     GET_ACTIVE_IME_ENGINE = 'getActiveEngine'
     TOGGLE_LOCATION_SERVICES = 'toggleLocationServices'
+    LOCATION_IN_VIEW = 'locationInView'
 
     # Appium Commands
     GET_APP_STRINGS = 'getAppStrings'

--- a/appium/webdriver/webdriver.py
+++ b/appium/webdriver/webdriver.py
@@ -782,7 +782,7 @@ class WebDriver(webdriver.Remote):
         self.command_executor._commands[Command.GET_ACTIVE_IME_ENGINE] = \
             ('GET', '/session/$sessionId/ime/active_engine')
         self.command_executor._commands[Command.REPLACE_KEYS] = \
-            ('POST', '/session/$sessionId/appium/element/$elementId/replace_value')
+            ('POST', '/session/$sessionId/appium/element/$id/replace_value')
         self.command_executor._commands[Command.GET_SETTINGS] = \
             ('GET', '/session/$sessionId/appium/settings')
         self.command_executor._commands[Command.UPDATE_SETTINGS] = \
@@ -791,6 +791,8 @@ class WebDriver(webdriver.Remote):
             ('POST', '/session/$sessionId/appium/device/toggle_location_services')
         self.command_executor._commands[Command.SET_LOCATION] = \
             ('POST', '/session/$sessionId/location')
+        self.command_executor._commands[Command.LOCATION_IN_VIEW] = \
+            ('GET', '/session/$sessionId/element/$id/location_in_view')
 
 
 # monkeypatched method for WebElement

--- a/appium/webdriver/webdriver.py
+++ b/appium/webdriver/webdriver.py
@@ -793,15 +793,3 @@ class WebDriver(webdriver.Remote):
             ('POST', '/session/$sessionId/location')
         self.command_executor._commands[Command.LOCATION_IN_VIEW] = \
             ('GET', '/session/$sessionId/element/$id/location_in_view')
-
-
-# monkeypatched method for WebElement
-def set_value(self, value):
-    """Set the value on this element in the application
-    """
-    data = {
-        'elementId': self.id,
-        'value': [value],
-    }
-    self._execute(Command.SET_IMMEDIATE_VALUE, data)
-    return self

--- a/appium/webdriver/webelement.py
+++ b/appium/webdriver/webelement.py
@@ -112,3 +112,13 @@ class WebElement(SeleniumWebElement):
             location = element.location_in_view
         """
         return self._execute(Command.LOCATION_IN_VIEW)['value']
+
+    def set_value(self, value):
+        """Set the value on this element in the application
+        """
+        data = {
+            'elementId': self.id,
+            'value': [value],
+        }
+        self._execute(Command.SET_IMMEDIATE_VALUE, data)
+        return self

--- a/appium/webdriver/webelement.py
+++ b/appium/webdriver/webelement.py
@@ -103,3 +103,12 @@ class WebElement(SeleniumWebElement):
         }
         self._execute(Command.REPLACE_KEYS, data)
         return self
+
+    @property
+    def location_in_view(self):
+        """Gets the location of an element relative to the view.
+
+        :Usage:
+            location = element.location_in_view
+        """
+        return self._execute(Command.LOCATION_IN_VIEW)['value']

--- a/test/functional/android/appium_tests.py
+++ b/test/functional/android/appium_tests.py
@@ -220,6 +220,12 @@ class AppiumTests(unittest.TestCase):
     def test_toggle_location_services(self):
         self.driver.toggle_location_services()
 
+    def test_element_location_in_view(self):
+        el = self.driver.find_element_by_name('Content')
+        loc = el.location_in_view
+        self.assertIsNotNone(loc['x'])
+        self.assertIsNotNone(loc['y'])
+
 
 if __name__ == "__main__":
     suite = unittest.TestLoader().loadTestsFromTestCase(AppiumTests)


### PR DESCRIPTION
`WebElement` needs a `location_in_view` method to replace `location`, which is deprecated. Resolves #86.

Also fix a couple of bugs.