### PR TITLE
Add string file argument to driver.app_strings

### DIFF
--- a/appium/webdriver/webdriver.py
+++ b/appium/webdriver/webdriver.py
@@ -309,16 +309,19 @@ class WebDriver(webdriver.Remote):
         self.execute_script('mobile: pinchOpen', opts)
         return self
 
-    def app_strings(self, language=None):
+    def app_strings(self, language=None, string_file=None):
         """Returns the application strings from the device for the specified
         language.
 
         :Args:
          - language - strings language code
+         - string_file - the name of the string file to query
         """
         data = {}
         if language != None:
             data['language'] = language
+        if string_file != None:
+            data['stringFile'] = string_file
         return self.execute(Command.GET_APP_STRINGS, data)['value']
 
     def reset(self):

--- a/test/functional/android/appium_tests.py
+++ b/test/functional/android/appium_tests.py
@@ -47,7 +47,11 @@ class AppiumTests(unittest.TestCase):
         self.assertEqual(u'You can\'t wipe my data, you are a monkey!', strings[u'monkey_wipe_data'])
 
     def test_app_strings_with_language(self):
-        strings = self.driver.app_strings("en")
+        strings = self.driver.app_strings('en')
+        self.assertEqual(u'You can\'t wipe my data, you are a monkey!', strings[u'monkey_wipe_data'])
+
+    def test_app_strings_with_language_and_file(self):
+        strings = self.driver.app_strings('en', 'some_file')
         self.assertEqual(u'You can\'t wipe my data, you are a monkey!', strings[u'monkey_wipe_data'])
 
     def test_press_keycode(self):


### PR DESCRIPTION
The Appium server supports sending in the name of the file to query for strings. Add the parameter to the client method.

Resolves #93.