### PR TITLE
Remove dependency on enum

### DIFF
--- a/appium/webdriver/connectiontype.py
+++ b/appium/webdriver/connectiontype.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from enum import Enum
-
 
 """
 Connection types are specified here:
@@ -26,7 +24,7 @@ Connection types are specified here:
     4 (Data only)      | 1    | 0    | 0
     6 (All network on) | 1    | 1    | 0
 """
-class ConnectionType(Enum):
+class ConnectionType(object):
     NO_CONNECTION = 0
     AIRPLANE_MODE = 1
     WIFI_ONLY = 2

--- a/appium/webdriver/webdriver.py
+++ b/appium/webdriver/webdriver.py
@@ -14,7 +14,6 @@
 
 from selenium import webdriver
 
-from .connectiontype import ConnectionType
 from .mobilecommand import MobileCommand as Command
 from .errorhandler import MobileErrorHandler
 from .switch_to import MobileSwitchTo
@@ -638,7 +637,7 @@ class WebDriver(webdriver.Remote):
         """
         data = {
             'parameters': {
-                'type': connectionType.value
+                'type': connectionType
             }
         }
         return self.execute(Command.SET_NETWORK_CONNECTION, data)['value']

--- a/setup.py
+++ b/setup.py
@@ -50,5 +50,5 @@ setup(
         'Topic :: Software Development :: Quality Assurance',
         'Topic :: Software Development :: Testing'
     ],
-    install_requires=['selenium>=2.41.0', 'enum34']
+    install_requires=['selenium>=2.47.0']
 )

--- a/test/functional/android/network_connection_tests.py
+++ b/test/functional/android/network_connection_tests.py
@@ -41,7 +41,7 @@ class NetworkConnectionTests(unittest.TestCase):
     def test_set_network_connection(self):
         nc = self.driver.set_network_connection(ConnectionType.DATA_ONLY)
         self.assertIsInstance(nc, int)
-        self.assertEqual(nc, ConnectionType.DATA_ONLY.value)
+        self.assertEqual(nc, ConnectionType.DATA_ONLY)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
[enum34](https://pypi.python.org/pypi/enum34) does not, and will not, support Python 3.5, so the client can't be installed. Remove the dependency and just use a set of predefined constants on a class.

Resolves #102 