### PR TITLE
Fix saucetestcase to run under Python3.

### DIFF
--- a/appium/saucetestcase.py
+++ b/appium/saucetestcase.py
@@ -15,7 +15,6 @@
 import unittest
 import os
 import sys
-import new
 from appium import webdriver
 from sauceclient import SauceClient
 
@@ -28,10 +27,9 @@ def on_platforms(platforms):
     def decorator(base_class):
         module = sys.modules[base_class.__module__].__dict__
         for i, platform in enumerate(platforms):
-            d = dict(base_class.__dict__)
-            d['desired_capabilities'] = platform
             name = "%s_%s" % (base_class.__name__, i + 1)
-            module[name] = new.classobj(name, (base_class,), d)
+            d = {'desired_capabilities' : platform}
+            module[name] = type(name, (base_class,), d)
     return decorator
 
 
@@ -54,3 +52,4 @@ class SauceTestCase(unittest.TestCase):
                 sauce.jobs.update_job(self.driver.session_id, passed=False)
         finally:
             self.driver.quit()
+


### PR DESCRIPTION
The module 'new' was removed. Instead of new.newclass, use type().

This fixed issue #112.