### PR TITLE
add tests for ios class chain and rename find_elements_by_class_chain  method

### DIFF
--- a/appium/webdriver/webdriver.py
+++ b/appium/webdriver/webdriver.py
@@ -129,18 +129,18 @@ class WebDriver(webdriver.Remote):
          - class_chain_string - The class chain string
 
         :Usage:
-            driver.find_element_by_class_chain('XCUIElementTypeWindow/XCUIElementTypeButton[3]')
+            driver.find_element_by_ios_class_chain('XCUIElementTypeWindow/XCUIElementTypeButton[3]')
         """
         return self.find_element(by=By.IOS_CLASS_CHAIN, value=class_chain_string)
 
-    def find_elements_by_class_chain(self, class_chain_string):
+    def find_elements_by_ios_class_chain(self, class_chain_string):
         """Finds elements by ios class chain string.
 
         :Args:
          - class_chain_string - The class chain string
 
         :Usage:
-            driver.find_elements_by_class_chain('XCUIElementTypeWindow[2]/XCUIElementTypeAny[-2]')
+            driver.find_elements_by_ios_class_chain('XCUIElementTypeWindow[2]/XCUIElementTypeAny[-2]')
         """
         return self.find_elements(by=By.IOS_CLASS_CHAIN, value=class_chain_string)
 

--- a/appium/webdriver/webelement.py
+++ b/appium/webdriver/webelement.py
@@ -70,18 +70,18 @@ class WebElement(SeleniumWebElement):
          - class_chain_string - The class chain string
 
         :Usage:
-            driver.find_element_by_class_chain('XCUIElementTypeWindow/XCUIElementTypeButton[3]')
+            driver.find_element_by_ios_class_chain('XCUIElementTypeWindow/XCUIElementTypeButton[3]')
         """
         return self.find_element(by=By.IOS_CLASS_CHAIN, value=class_chain_string)
 
-    def find_elements_by_class_chain(self, class_chain_string):
+    def find_elements_by_ios_class_chain(self, class_chain_string):
         """Finds elements by ios class chain string.
 
         :Args:
          - class_chain_string - The class chain string
 
         :Usage:
-            driver.find_elements_by_class_chain('XCUIElementTypeWindow[2]/XCUIElementTypeAny[-2]')
+            driver.find_elements_by_ios_class_chain('XCUIElementTypeWindow[2]/XCUIElementTypeAny[-2]')
         """
         return self.find_elements(by=By.IOS_CLASS_CHAIN, value=class_chain_string)
 

--- a/test/functional/ios/desired_capabilities.py
+++ b/test/functional/ios/desired_capabilities.py
@@ -21,9 +21,9 @@ PATH = lambda p: os.path.abspath(
 
 def get_desired_capabilities(app):
     desired_caps = {
-        'deviceName': 'iPhone 5s',
+        'deviceName': 'iPhone 6s',
         'platformName': 'iOS',
-        'platformVersion': '10.2',
+        'platformVersion': '10.3',
         'app': PATH('../../apps/' + app),
         'automationName': 'XCUITest',
         'allowTouchIdEnroll': True

--- a/test/functional/ios/find_by_ios_class_chain_tests.py
+++ b/test/functional/ios/find_by_ios_class_chain_tests.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from appium import webdriver
+import desired_capabilities
+
+class FindByIOClassChainTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(self):
+        desired_caps = desired_capabilities.get_desired_capabilities('UICatalog.app.zip')
+        self.driver = webdriver.Remote('http://localhost:4723/wd/hub', desired_caps)
+
+    @classmethod
+    def tearDownClass(self):
+        self.driver.quit()
+
+    def test_find_element_by_path(self):
+        el = self.driver.find_element_by_ios_class_chain('XCUIElementTypeWindow/*/*/XCUIElementTypeStaticText')
+        self.assertEqual('UICatalog', el.get_attribute('name'))
+
+    def test_find_multiple_elements_by_path(self):
+        el = self.driver.find_elements_by_ios_class_chain('XCUIElementTypeWindow/*/*')
+        self.assertEqual(len(el), 2)
+        self.assertEqual('UICatalog', el[0].get_attribute('name'))
+        self.assertEqual(None, el[1].get_attribute('name'))
+
+if __name__ == "__main__":
+    suite = unittest.TestLoader().loadTestsFromTestCase(FindByIOClassChainTests)
+    unittest.TextTestRunner(verbosity=2).run(suite)


### PR DESCRIPTION
Update for add class chain #172

- add tests for `find_element_by_ios_class_chain`/`find_elements_by_ios_class_chain`
- rename the method name, `find_elements_by_class_chain`, to `find_elements_by_ios_class_chain `