### PR TITLE
Allow different strategies for hide_keyboard

### DIFF
--- a/appium/webdriver/webdriver.py
+++ b/appium/webdriver/webdriver.py
@@ -388,8 +388,7 @@ class WebDriver(webdriver.Remote):
             data['keyName'] = key_name
         elif key is not None:
             data['key'] = key
-        else:
-            # defaults to `tapOutside` strategy
+        elif strategy is None:
             strategy = 'tapOutside'
         data['strategy'] = strategy
         self.execute(Command.HIDE_KEYBOARD, data)


### PR DESCRIPTION
Only if key_name, key, and strategy are None do we need to set the strategy to 'tapOutside'. This change allows setting just the strategy to some other value, like 'swipeDown'.