### PR TITLE
Added support for setting device_time

### DIFF
--- a/appium/webdriver/mobilecommand.py
+++ b/appium/webdriver/mobilecommand.py
@@ -60,4 +60,5 @@ class MobileCommand(object):
     UPDATE_SETTINGS = 'updateSettings'
     SET_LOCATION = 'setLocation'
     GET_DEVICE_TIME = 'getDeviceTime'
+    SET_DEVICE_TIME = 'setDeviceTime'
     CLEAR = 'clear'

--- a/appium/webdriver/webdriver.py
+++ b/appium/webdriver/webdriver.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import datetime
 from selenium import webdriver
 
 from .mobilecommand import MobileCommand as Command
@@ -801,6 +801,15 @@ class WebDriver(webdriver.Remote):
         """
         return self.execute(Command.GET_DEVICE_TIME, {})['value']
 
+    @device_time.setter
+    def device_time(self, time):
+        """ Sets date and time
+        """
+        adb_date_format = "%m%d%H%M%Y.%S"
+        if isinstance(time, datetime.datetime):
+            time = time.strftime(adb_date_format)
+        return self.execute(Command.SET_DEVICE_TIME, {'datetime': time})['value']
+
     def _addCommands(self):
         self.command_executor._commands[Command.CONTEXTS] = \
             ('GET', '/session/$sessionId/contexts')
@@ -891,5 +900,7 @@ class WebDriver(webdriver.Remote):
             ('GET', '/session/$sessionId/element/$id/location_in_view')
         self.command_executor._commands[Command.GET_DEVICE_TIME] = \
             ('GET', '/session/$sessionId/appium/device/system_time')
+        self.command_executor._commands[Command.SET_DEVICE_TIME] = \
+            ('POST', '/session/$sessionId/appium/device/system_time')
         self.command_executor._commands[Command.CLEAR] = \
             ('POST', '/session/$sessionId/element/$id/clear')

--- a/test/functional/android/appium_tests.py
+++ b/test/functional/android/appium_tests.py
@@ -19,6 +19,8 @@ import json
 import os
 import random
 from time import sleep
+
+import datetime
 from dateutil.parser import parse
 
 from selenium.common.exceptions import NoSuchElementException
@@ -239,6 +241,41 @@ class AppiumTests(unittest.TestCase):
         date_time = self.driver.device_time
         # convert to date ought to work
         parse(date_time)
+
+    def test_set_device_time(self):
+        """
+        Test setting device time in format %m%d%H%M%Y.%S / MMDDhhmmYYYY.ss / MonthDayHourMinuteYear.Second
+        :return:
+        """
+        date_time = self.driver.device_time
+        date_time_obj = parse(date_time) # type: datetime.datetime
+
+        # Change the datetime year
+        past_date_time_obj = date_time_obj.replace(year=2016)
+
+        self.driver.device_time = past_date_time_obj
+
+        # Retrieve the current device datetime
+        updated_date = self.driver.device_time
+        updated_date_obj = parse(updated_date) # type: datetime.datetime
+
+        # Verify the year and hour are correct
+        self.assertEqual(updated_date_obj.year, 2016, msg="Year was updated correctly")
+        self.assertEqual(updated_date_obj.hour, date_time_obj.hour, "Hour is correct")
+
+        # Add one to the original dates year
+        new_hour = date_time_obj.hour + 1
+        changed_hour = date_time_obj.replace(hour=new_hour)
+
+        # Set device to new datetime
+        self.driver.device_time = changed_hour
+
+        # Retrieve device time
+        updated_date = parse(self.driver.device_time)
+
+        # Verify hour is correct
+        self.assertEqual(updated_date.hour, new_hour, msg="Hour updated correctly")
+
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Implementing setting device time for the Android platform across this repo, appium-android-driver and appium-base-driver.  