### PR TITLE
add appium prefix in create session and fix find_elements for W3C

### DIFF
--- a/appium/webdriver/webdriver.py
+++ b/appium/webdriver/webdriver.py
@@ -107,11 +107,12 @@ class WebDriver(webdriver.Remote):
         Creates a new session with the desired capabilities.
 
         :Args:
-         - browser_name - The name of the browser to request.
-         - version - Which browser version to request.
-         - platform - Which platform to request the browser on.
-         - javascript_enabled - Whether the new session should support JavaScript.
-         - browser_profile - A selenium.webdriver.firefox.firefox_profile.FirefoxProfile object. Only used if Firefox is requested.
+         - automation_name - The name of automation engine to use.
+         - platform_name - The name of target platform.
+         - platform_version - The kind of mobile device or emulator to use
+         - app - The absolute local path or remote http URL to an .ipa or .apk file, or a .zip containing one of these.
+
+        Read https://github.com/appium/appium/blob/master/docs/en/writing-running-appium/caps.md for more details.
         """
         if not isinstance(capabilities, dict):
             raise InvalidArgumentException('Capabilities must be a dictionary')

--- a/test/functional/ios/appium_tests.py
+++ b/test/functional/ios/appium_tests.py
@@ -30,10 +30,10 @@ class AppiumTests(unittest.TestCase):
         self.driver.quit()
 
     def test_lock(self):
-        el = self.driver.find_element_by_id('ButtonsExplain')
+        el = self.driver.find_element_by_id('Buttons')
         self.assertIsNotNone(el)
         self.driver.lock(0)
-        self.assertRaises(NoSuchElementException, self.driver.find_element_by_id, 'ButtonsExplain')
+        self.assertRaises(NoSuchElementException, self.driver.find_element_by_id, 'Buttons')
         sleep(10)
 
         # # this does not seem to ever unlock, so the assertion fails
@@ -54,7 +54,7 @@ class AppiumTests(unittest.TestCase):
         self.driver.toggle_touch_id_enrollment()
 
     def test_hide_keyboard(self):
-        el = self.driver.find_element_by_name('TextFields, Uses of UITextField')
+        el = self.driver.find_element_by_name('Uses of UITextField')
         el.click()
 
         # get focus on text field, so keyboard comes up
@@ -69,7 +69,7 @@ class AppiumTests(unittest.TestCase):
         self.assertFalse(el.is_displayed())
 
     def test_hide_keyboard_presskey_strategy(self):
-        el = self.driver.find_element_by_name('TextFields, Uses of UITextField')
+        el = self.driver.find_element_by_name('Uses of UITextField')
         el.click()
 
         # get focus on text field, so keyboard comes up
@@ -84,7 +84,7 @@ class AppiumTests(unittest.TestCase):
         self.assertFalse(el.is_displayed())
 
     def test_hide_keyboard_no_key_name(self):
-        el = self.driver.find_element_by_name('TextFields, Uses of UITextField')
+        el = self.driver.find_element_by_name('Uses of UITextField')
         el.click()
 
         # get focus on text field, so keyboard comes up

--- a/test/functional/ios/find_by_ios_class_chain_tests.py
+++ b/test/functional/ios/find_by_ios_class_chain_tests.py
@@ -28,12 +28,12 @@ class FindByIOClassChainTests(unittest.TestCase):
         self.driver.quit()
 
     def test_find_element_by_path(self):
-        el = self.driver.find_element_by_ios_class_chain('XCUIElementTypeWindow/*/*/XCUIElementTypeStaticText')
+        el = self.driver.find_element_by_ios_class_chain('XCUIElementTypeWindow/**/XCUIElementTypeStaticText')
         self.assertEqual('UICatalog', el.get_attribute('name'))
 
     def test_find_multiple_elements_by_path(self):
-        el = self.driver.find_elements_by_ios_class_chain('XCUIElementTypeWindow/*/*')
-        self.assertEqual(len(el), 2)
+        el = self.driver.find_elements_by_ios_class_chain('XCUIElementTypeWindow/*/*/*')
+        self.assertEqual(6, len(el))
         self.assertEqual('UICatalog', el[0].get_attribute('name'))
         self.assertEqual(None, el[1].get_attribute('name'))
 


### PR DESCRIPTION
## What do I do in this PR

- Add `appium:` prefix for capabilities except for items defined by W3C
- Add `forceMjsonwp` capability to force request format MJSONWP format.
    - By default, the client send `{'firstMatch': [{}], 'alwaysMatch': always_match}` style
    - We can remove this process after finishing migrating from MJSONWP to W3C completely.
- Change some logic from WebDriver's w3c spec
    - `find_element/s` related methos since in W3C, `id` is convert to `css selector` style
    - https://github.com/appium/python-client/pull/196/files#diff-30b129e415d9d5342e47b17ebdea5536R194
- Change some test cases to work the latest appium server(1.7.2)

----

- Run with W3C
```
[debug] [MJSONWP] Responding to client with driver.getSize() result: {"width":93,"height":33}
[HTTP] <-- GET /wd/hub/session/a92ddc72-1b53-47b1-a34b-0a55bdca5ca4/element/4680CB2D-24F2-4CC7-844D-917A6D607AE4/size 200 206 ms - 85
[HTTP] --> POST /wd/hub/session {"capabilities":{"firstMatch":[{}],"alwaysMatch":{"appium:deviceName":"iPhone 6s","platformName":"iOS","appium:platformVersion":"10.3","appium:app":"/Users/kazuaki/GitHub/python-client/test/apps/UICatalog.app.zip","appium:automationName":"XCUITest","appium:allowTouchIdEnroll":true}},"desiredCapabilities":{"deviceName":"iPhone 6s","platformName":"iOS","platformVersion":"10.3","app":"/Users/kazuaki/GitHub/python-client/test/apps/UICatalog.app.zip","automationName":"XCUITest","allowTouchIdEnroll":true}}
[debug] [MJSONWP] Calling AppiumDriver.createSession() with args: [{"deviceName":"iPhone 6s","platformName":"iOS","platformVersion":"10.3","app":"/Users/kazuaki/GitHub/python-client/test/apps/UICatalog.app.zip","automationName":"XCUITest","allowTouchIdEnroll":true},null,{"firstMatch":[{}],"alwaysMatch":{"appium:deviceName":"iPhone 6s","platformName":"iOS","appium:platformVersion":"10.3","appium:app":"/Users/kazuaki/GitHub/python-client/test/apps/UICatalog.app.zip","appium:automationName":"XCUITest","appium:allowTouchIdEnroll":true}}]
[debug] [BaseDriver] Event 'newSessionRequested' logged at 1515072504260 (22:28:24 GMT+0900 (JST))
[Appium] Creating new XCUITestDriver (v2.63.0) session
[Appium] Capabilities:
[Appium]   deviceName: iPhone 6s
[Appium]   platformName: iOS
[Appium]   platformVersion: 10.3
[Appium]   app: /Users/kazuaki/GitHub/python-client/test/apps/UICatalog.app.zip
[Appium]   automationName: XCUITest
[Appium]   allowTouchIdEnroll: true
[BaseDriver] The following capabilities were provided, but are not recognized by appium: allowTouchIdEnroll.
[BaseDriver] Session created with session id: 422d1dd0-5ff8-4778-b0db-2d19e4d6a44c
```

- set `'forceMjsonwp': True`
```
[HTTP] <-- DELETE /wd/hub/session/7d0e0141-8bff-48ea-99cd-e8bae0f3362d 200 279 ms - 76
[HTTP] --> POST /wd/hub/session {"desiredCapabilities":{"deviceName":"iPhone 6s","platformName":"iOS","platformVersion":"10.3","app":"/Users/kazuaki/GitHub/python-client/test/apps/UICatalog.app.zip","automationName":"XCUITest","allowTouchIdEnroll":true}}
[debug] [MJSONWP] Calling AppiumDriver.createSession() with args: [{"deviceName":"iPhone 6s","platformName":"iOS","platformVersion":"10.3","app":"/Users/kazuaki/GitHub/python-client/test/apps/UICatalog.app.zip","automationName":"XCUITest","allowTouchIdEnroll":true},null,null]
[debug] [BaseDriver] Event 'newSessionRequested' logged at 1515075790469 (23:23:10 GMT+0900 (JST))
[Appium] Creating new XCUITestDriver (v2.63.0) session
[Appium] Capabilities:
[Appium]   deviceName: iPhone 6s
[Appium]   platformName: iOS
[Appium]   platformVersion: 10.3
[Appium]   app: /Users/kazuaki/GitHub/python-client/test/apps/UICatalog.app.zip
[Appium]   automationName: XCUITest
[Appium]   allowTouchIdEnroll: true
[BaseDriver] The following capabilities were provided, but are not recognized by appium: allowTouchIdEnroll.
[BaseDriver] Session created with session id: 3a5d313d-e482-4292-a273-c741d406fbcf
```
  
  
 ## related
- Ruby: https://github.com/appium/ruby_lib_core/blob/master/lib/appium_lib_core/common/base/bridge.rb#L174