### PR TITLE
Set None as default value to lock device

### DIFF
--- a/appium/webdriver/webdriver.py
+++ b/appium/webdriver/webdriver.py
@@ -940,11 +940,11 @@ class WebDriver(webdriver.Remote):
         }
         return self.execute(Command.END_TEST_COVERAGE, data)['value']
 
-    def lock(self, seconds):
+    def lock(self, seconds=0):
         """Lock the device. No changes are made if the device is already unlocked.
 
         :Args:
-         - seconds - the duration to lock the device, in seconds.
+         - seconds - (optional) the duration to lock the device, in seconds.
          The device is going to be locked forever until `unlock` is called
          if it equals or is less than zero, otherwise this call blocks until
          the timeout expires and unlocks the screen automatically.

--- a/appium/webdriver/webdriver.py
+++ b/appium/webdriver/webdriver.py
@@ -940,7 +940,7 @@ class WebDriver(webdriver.Remote):
         }
         return self.execute(Command.END_TEST_COVERAGE, data)['value']
 
-    def lock(self, seconds=0):
+    def lock(self, seconds=None):
         """Lock the device. No changes are made if the device is already unlocked.
 
         :Args:
@@ -949,7 +949,11 @@ class WebDriver(webdriver.Remote):
          if it equals or is less than zero, otherwise this call blocks until
          the timeout expires and unlocks the screen automatically.
         """
-        self.execute(Command.LOCK, {'seconds': seconds})
+        if seconds is None:
+            self.execute(Command.LOCK)
+        else:
+            self.execute(Command.LOCK, {'seconds': seconds})
+
         return self
 
     def unlock(self):


### PR DESCRIPTION
To lock forever until `unlock()` is called:

    device.lock()

To lock for 5 seconds:

    device.lock(5)