### PR TITLE
fix base64 encoded string

### DIFF
--- a/appium/webdriver/webdriver.py
+++ b/appium/webdriver/webdriver.py
@@ -355,7 +355,7 @@ class WebDriver(webdriver.Remote):
         """
         screenshot = self.get_screenshot_as_base64()
         with open(png_img_path, 'rb') as png_file:
-            b64_data = base64.encodestring(png_file.read())
+            b64_data = base64.b64encode(png_file.read()).decode('UTF-8')
         try:
             res = self.find_image_occurrence(screenshot, b64_data,
                                              threshold=match_threshold)


### PR DESCRIPTION
Fix: function `find_element_by_image` always raise an exception: "TypeError: Object of type 'bytes' is not JSON serializable" #228 

`encodestring` generate byte data in Python 3. Thus, we should encode it to string.

## Python2.7

```
>>> import base64
>>> base64.encodestring(b'hello')
'aGVsbG8=\n'
```

## Python3.6

```
>>> import base64
>>> base64.encodestring(b'hello')
b'aGVsbG8=\n'
```

`b64_data` should be base64 encoded string.
This way is as same as https://github.com/SeleniumHQ/selenium/blob/6b5fe890da7d1592693d1dfcf795d882fc0426c5/py/selenium/webdriver/firefox/firefox_profile.py#L180 way.
