### PR TITLE
Add travis to run pylint and unit tests

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,549 @@
+[MASTER]
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code
+extension-pkg-whitelist=
+
+# Add files or directories to the blacklist. They should be base names, not
+# paths.
+ignore=CVS
+
+# Add files or directories matching the regex patterns to the blacklist. The
+# regex matches against base names, not paths.
+ignore-patterns=
+
+# Python code to execute, usually for sys.path manipulation such as
+# pygtk.require().
+#init-hook=
+
+# Use multiple processes to speed up Pylint.
+jobs=1
+
+# List of plugins (as comma separated values of python modules names) to load,
+# usually to register additional checkers.
+load-plugins=
+
+# Pickle collected data for later comparisons.
+persistent=yes
+
+# Specify a configuration file.
+#rcfile=
+
+# When enabled, pylint would attempt to guess common misconfiguration and emit
+# user-friendly hints instead of false-positive error messages
+suggestion-mode=yes
+
+# Allow loading of arbitrary C extensions. Extensions are imported into the
+# active Python interpreter and may run arbitrary code.
+unsafe-load-any-extension=no
+
+
+[MESSAGES CONTROL]
+
+# Only show warnings with the listed confidence levels. Leave empty to show
+# all. Valid levels: HIGH, INFERENCE, INFERENCE_FAILURE, UNDEFINED
+confidence=
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once).You can also use "--disable=all" to
+# disable everything first and then reenable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use"--disable=all --enable=classes
+# --disable=W"
+disable=print-statement,
+        parameter-unpacking,
+        unpacking-in-except,
+        old-raise-syntax,
+        backtick,
+        long-suffix,
+        old-ne-operator,
+        old-octal-literal,
+        import-star-module-level,
+        non-ascii-bytes-literal,
+        invalid-unicode-literal,
+        raw-checker-failed,
+        bad-inline-option,
+        locally-disabled,
+        locally-enabled,
+        file-ignored,
+        suppressed-message,
+        useless-suppression,
+        deprecated-pragma,
+        apply-builtin,
+        basestring-builtin,
+        buffer-builtin,
+        cmp-builtin,
+        coerce-builtin,
+        execfile-builtin,
+        file-builtin,
+        long-builtin,
+        raw_input-builtin,
+        reduce-builtin,
+        standarderror-builtin,
+        unicode-builtin,
+        xrange-builtin,
+        coerce-method,
+        delslice-method,
+        getslice-method,
+        setslice-method,
+        no-absolute-import,
+        old-division,
+        dict-iter-method,
+        dict-view-method,
+        next-method-called,
+        metaclass-assignment,
+        indexing-exception,
+        raising-string,
+        reload-builtin,
+        oct-method,
+        hex-method,
+        nonzero-method,
+        cmp-method,
+        input-builtin,
+        round-builtin,
+        intern-builtin,
+        unichr-builtin,
+        map-builtin-not-iterating,
+        zip-builtin-not-iterating,
+        range-builtin-not-iterating,
+        filter-builtin-not-iterating,
+        using-cmp-argument,
+        eq-without-hash,
+        div-method,
+        idiv-method,
+        rdiv-method,
+        exception-message-attribute,
+        invalid-str-codec,
+        sys-max-int,
+        bad-python3-import,
+        deprecated-string-function,
+        deprecated-str-translate-call,
+        deprecated-itertools-function,
+        deprecated-types-field,
+        next-method-defined,
+        dict-items-not-iterating,
+        dict-keys-not-iterating,
+        dict-values-not-iterating,
+        deprecated-operator-function,
+        deprecated-urllib-function,
+        xreadlines-attribute,
+        deprecated-sys-function,
+        exception-escape,
+        comprehension-escape
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time (only on the command line, not in the configuration file where
+# it should appear only once). See also the "--disable" option for examples.
+enable=c-extension-no-member
+
+
+[REPORTS]
+
+# Python expression which should return a note less than 10 (10 is the highest
+# note). You have access to the variables errors warning, statement which
+# respectively contain the number of errors / warnings messages and the total
+# number of statements analyzed. This is used by the global evaluation report
+# (RP0004).
+evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details
+#msg-template=
+
+# Set the output format. Available formats are text, parseable, colorized, json
+# and msvs (visual studio).You can also give a reporter class, eg
+# mypackage.mymodule.MyReporterClass.
+output-format=text
+
+# Tells whether to display a full report or only the messages
+reports=no
+
+# Activate the evaluation score.
+score=yes
+
+
+[REFACTORING]
+
+# Maximum number of nested blocks for function / method body
+max-nested-blocks=5
+
+# Complete name of functions that never returns. When checking for
+# inconsistent-return-statements if a never returning function is called then
+# it will be considered as an explicit return statement and no message will be
+# printed.
+never-returning-functions=optparse.Values,sys.exit
+
+
+[LOGGING]
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format
+logging-modules=logging
+
+
+[SPELLING]
+
+# Limits count of emitted suggestions for spelling mistakes
+max-spelling-suggestions=4
+
+# Spelling dictionary name. Available dictionaries: none. To make it working
+# install python-enchant package.
+spelling-dict=
+
+# List of comma separated words that should not be checked.
+spelling-ignore-words=
+
+# A path to a file that contains private dictionary; one word per line.
+spelling-private-dict-file=
+
+# Tells whether to store unknown words to indicated private dictionary in
+# --spelling-private-dict-file option instead of raising a message.
+spelling-store-unknown-words=no
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=FIXME,
+      XXX,
+      TODO
+
+
+[SIMILARITIES]
+
+# Ignore comments when computing similarities.
+ignore-comments=yes
+
+# Ignore docstrings when computing similarities.
+ignore-docstrings=yes
+
+# Ignore imports when computing similarities.
+ignore-imports=no
+
+# Minimum lines number of a similarity.
+min-similarity-lines=4
+
+
+[TYPECHECK]
+
+# List of decorators that produce context managers, such as
+# contextlib.contextmanager. Add to this list to register other decorators that
+# produce valid context managers.
+contextmanager-decorators=contextlib.contextmanager
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E1101 when accessed. Python regular
+# expressions are accepted.
+generated-members=
+
+# Tells whether missing members accessed in mixin class should be ignored. A
+# mixin class is detected if its name ends with "mixin" (case insensitive).
+ignore-mixin-members=yes
+
+# This flag controls whether pylint should warn about no-member and similar
+# checks whenever an opaque object is returned when inferring. The inference
+# can return multiple potential results while evaluating a Python object, but
+# some branches might not be evaluated, which results in partial inference. In
+# that case, it might be useful to still emit no-member and other checks for
+# the rest of the inferred objects.
+ignore-on-opaque-inference=yes
+
+# List of class names for which member attributes should not be checked (useful
+# for classes with dynamically set attributes). This supports the use of
+# qualified names.
+ignored-classes=optparse.Values,thread._local,_thread._local
+
+# List of module names for which member attributes should not be checked
+# (useful for modules/projects where namespaces are manipulated during runtime
+# and thus existing member attributes cannot be deduced by static analysis. It
+# supports qualified module names, as well as Unix pattern matching.
+ignored-modules=
+
+# Show a hint with possible names when a member name was not found. The aspect
+# of finding the hint is based on edit distance.
+missing-member-hint=yes
+
+# The minimum edit distance a name should have in order to be considered a
+# similar match for a missing member name.
+missing-member-hint-distance=1
+
+# The total number of similar names that should be taken in consideration when
+# showing a hint for a missing member.
+missing-member-max-choices=1
+
+
+[VARIABLES]
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid to define new builtins when possible.
+additional-builtins=
+
+# Tells whether unused global variables should be treated as a violation.
+allow-global-unused-variables=yes
+
+# List of strings which can identify a callback function by name. A callback
+# name must start or end with one of those strings.
+callbacks=cb_,
+          _cb
+
+# A regular expression matching the name of dummy variables (i.e. expectedly
+# not used).
+dummy-variables-rgx=_+$|(_[a-zA-Z0-9_]*[a-zA-Z0-9]+?$)|dummy|^ignored_|^unused_
+
+# Argument names that match this expression will be ignored. Default to name
+# with leading underscore
+ignored-argument-names=_.*|^ignored_|^unused_
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# List of qualified module names which can have objects that can redefine
+# builtins.
+redefining-builtins-modules=six.moves,past.builtins,future.builtins,io,builtins
+
+
+[FORMAT]
+
+# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
+expected-line-ending-format=
+
+# Regexp for a line that is allowed to be longer than the limit.
+ignore-long-lines=^\s*(# )?<?https?://\S+>?$
+
+# Number of spaces of indent required inside a hanging  or continued line.
+indent-after-paren=4
+
+# String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1
+# tab).
+indent-string='    '
+
+# Maximum number of characters on a single line.
+max-line-length=100
+
+# Maximum number of lines in a module
+max-module-lines=1000
+
+# List of optional constructs for which whitespace checking is disabled. `dict-
+# separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
+# `trailing-comma` allows a space between comma and closing bracket: (a, ).
+# `empty-line` allows space-only lines.
+no-space-check=trailing-comma,
+               dict-separator
+
+# Allow the body of a class to be on the same line as the declaration if body
+# contains single statement.
+single-line-class-stmt=no
+
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+single-line-if-stmt=no
+
+
+[BASIC]
+
+# Naming style matching correct argument names
+argument-naming-style=snake_case
+
+# Regular expression matching correct argument names. Overrides argument-
+# naming-style
+#argument-rgx=
+
+# Naming style matching correct attribute names
+attr-naming-style=snake_case
+
+# Regular expression matching correct attribute names. Overrides attr-naming-
+# style
+#attr-rgx=
+
+# Bad variable names which should always be refused, separated by a comma
+bad-names=foo,
+          bar,
+          baz,
+          toto,
+          tutu,
+          tata
+
+# Naming style matching correct class attribute names
+class-attribute-naming-style=any
+
+# Regular expression matching correct class attribute names. Overrides class-
+# attribute-naming-style
+#class-attribute-rgx=
+
+# Naming style matching correct class names
+class-naming-style=PascalCase
+
+# Regular expression matching correct class names. Overrides class-naming-style
+#class-rgx=
+
+# Naming style matching correct constant names
+const-naming-style=UPPER_CASE
+
+# Regular expression matching correct constant names. Overrides const-naming-
+# style
+#const-rgx=
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=-1
+
+# Naming style matching correct function names
+function-naming-style=snake_case
+
+# Regular expression matching correct function names. Overrides function-
+# naming-style
+#function-rgx=
+
+# Good variable names which should always be accepted, separated by a comma
+good-names=i,
+           j,
+           k,
+           ex,
+           Run,
+           _
+
+# Include a hint for the correct naming format with invalid-name
+include-naming-hint=no
+
+# Naming style matching correct inline iteration names
+inlinevar-naming-style=any
+
+# Regular expression matching correct inline iteration names. Overrides
+# inlinevar-naming-style
+#inlinevar-rgx=
+
+# Naming style matching correct method names
+method-naming-style=snake_case
+
+# Regular expression matching correct method names. Overrides method-naming-
+# style
+#method-rgx=
+
+# Naming style matching correct module names
+module-naming-style=snake_case
+
+# Regular expression matching correct module names. Overrides module-naming-
+# style
+#module-rgx=
+
+# Colon-delimited sets of names that determine each other's naming style when
+# the name regexes allow several styles.
+name-group=
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+no-docstring-rgx=^_
+
+# List of decorators that produce properties, such as abc.abstractproperty. Add
+# to this list to register other decorators that produce valid properties.
+property-classes=abc.abstractproperty
+
+# Naming style matching correct variable names
+variable-naming-style=snake_case
+
+# Regular expression matching correct variable names. Overrides variable-
+# naming-style
+#variable-rgx=
+
+
+[DESIGN]
+
+# Maximum number of arguments for function / method
+max-args=5
+
+# Maximum number of attributes for a class (see R0902).
+max-attributes=7
+
+# Maximum number of boolean expressions in a if statement
+max-bool-expr=5
+
+# Maximum number of branch for function / method body
+max-branches=12
+
+# Maximum number of locals for function / method body
+max-locals=15
+
+# Maximum number of parents for a class (see R0901).
+max-parents=7
+
+# Maximum number of public methods for a class (see R0904).
+max-public-methods=20
+
+# Maximum number of return / yield for function / method body
+max-returns=6
+
+# Maximum number of statements in function / method body
+max-statements=50
+
+# Minimum number of public methods for a class (see R0903).
+min-public-methods=2
+
+
+[CLASSES]
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,
+                      __new__,
+                      setUp
+
+# List of member names, which should be excluded from the protected access
+# warning.
+exclude-protected=_asdict,
+                  _fields,
+                  _replace,
+                  _source,
+                  _make
+
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg=cls
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg=mcs
+
+
+[IMPORTS]
+
+# Allow wildcard imports from modules that define __all__.
+allow-wildcard-with-all=no
+
+# Analyse import fallback blocks. This can be used to support both Python 2 and
+# 3 compatible code, which means that the block might have code that exists
+# only in one or another interpreter, leading to false positives when analysed.
+analyse-fallback-blocks=no
+
+# Deprecated modules which should not be used, separated by a comma
+deprecated-modules=regsub,
+                   TERMIOS,
+                   Bastion,
+                   rexec
+
+# Create a graph of external dependencies in the given file (report RP0402 must
+# not be disabled)
+ext-import-graph=
+
+# Create a graph of every (i.e. internal and external) dependencies in the
+# given file (report RP0402 must not be disabled)
+import-graph=
+
+# Create a graph of internal dependencies in the given file (report RP0402 must
+# not be disabled)
+int-import-graph=
+
+# Force import order to recognize a module as part of the standard
+# compatibility libraries.
+known-standard-library=
+
+# Force import order to recognize a module as part of a third party library.
+known-third-party=enchant
+
+
+[EXCEPTIONS]
+
+# Exceptions that will emit a warning when being caught. Defaults to
+# "Exception"
+overgeneral-exceptions=Exception

--- a/.pylintrc
+++ b/.pylintrc
@@ -38,7 +38,6 @@ suggestion-mode=yes
 # active Python interpreter and may run arbitrary code.
 unsafe-load-any-extension=no
 
-
 [MESSAGES CONTROL]
 
 # Only show warnings with the listed confidence levels. Leave empty to show
@@ -137,7 +136,8 @@ disable=print-statement,
         empty-docstring,
         missing-docstring,
         too-few-public-methods,
-        invalid-name
+        invalid-name,
+        duplicate-code
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/.pylintrc
+++ b/.pylintrc
@@ -133,7 +133,11 @@ disable=print-statement,
         xreadlines-attribute,
         deprecated-sys-function,
         exception-escape,
-        comprehension-escape
+        comprehension-escape,
+        empty-docstring,
+        missing-docstring,
+        too-few-public-methods,
+        invalid-name
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option
@@ -323,7 +327,7 @@ indent-after-paren=4
 indent-string='    '
 
 # Maximum number of characters on a single line.
-max-line-length=100
+max-line-length=128
 
 # Maximum number of lines in a module
 max-module-lines=1000
@@ -454,7 +458,7 @@ variable-naming-style=snake_case
 [DESIGN]
 
 # Maximum number of arguments for function / method
-max-args=5
+max-args=6
 
 # Maximum number of attributes for a class (see R0902).
 max-attributes=7
@@ -514,7 +518,7 @@ allow-wildcard-with-all=no
 # Analyse import fallback blocks. This can be used to support both Python 2 and
 # 3 compatible code, which means that the block might have code that exists
 # only in one or another interpreter, leading to false positives when analysed.
-analyse-fallback-blocks=no
+analyse-fallback-blocks=yes
 
 # Deprecated modules which should not be used, separated by a comma
 deprecated-modules=regsub,

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: python
+python:
+  - "2.7"
+  - "3.7"
+
+install:
+  - pip install -r ci-requirements.txt
+
+  script:
+  - pylint appium test

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ install:
   - pip install -r ci-requirements.txt
 
   script:
-  - pylint appium test
+  - pylint --rcfile .pylintrc appium test

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,4 @@ install:
 
   script:
   - pylint --rcfile .pylintrc appium test
+  - pytest test/unit/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,6 @@ python:
 install:
   - pip install -r ci-requirements.txt
 
-  script:
+script:
   - pylint --rcfile .pylintrc appium test
   - pytest test/unit/*

--- a/appium/saucetestcase.py
+++ b/appium/saucetestcase.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import print_function
+
 import unittest
 import os
 import sys
@@ -28,8 +30,8 @@ def on_platforms(platforms):
         module = sys.modules[base_class.__module__].__dict__
         for i, platform in enumerate(platforms):
             name = "%s_%s" % (base_class.__name__, i + 1)
-            d = {'desired_capabilities' : platform}
-            module[name] = type(name, (base_class,), d)
+            d_caps = {'desired_capabilities' : platform}
+            module[name] = type(name, (base_class,), d_caps)
     return decorator
 
 
@@ -42,7 +44,7 @@ class SauceTestCase(unittest.TestCase):
             command_executor=sauce_url % (SAUCE_USERNAME, SAUCE_ACCESS_KEY)
         )
         self.driver.implicitly_wait(30)
-    
+
     def tearDown(self):
         print("Link to your job: https://saucelabs.com/jobs/%s" % self.driver.session_id)
         try:
@@ -52,4 +54,3 @@ class SauceTestCase(unittest.TestCase):
                 sauce.jobs.update_job(self.driver.session_id, passed=False)
         finally:
             self.driver.quit()
-

--- a/appium/saucetestcase.py
+++ b/appium/saucetestcase.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# pylint: disable=import-error,no-member
+
 from __future__ import print_function
 
 import unittest

--- a/appium/webdriver/common/multi_action.py
+++ b/appium/webdriver/common/multi_action.py
@@ -75,5 +75,4 @@ class MultiAction(object):
             actions.append(action.json_wire_gestures)
         if self._element is not None:
             return {'actions': actions, 'elementId': self._element.id}
-        else:
-            return {'actions': actions}
+        return {'actions': actions}

--- a/appium/webdriver/common/touch_action.py
+++ b/appium/webdriver/common/touch_action.py
@@ -21,6 +21,8 @@
 #
 # Theirs is `TouchActions`. Appium's is `TouchAction`.
 
+# pylint: disable=no-self-use
+
 import copy
 
 from appium.webdriver.mobilecommand import MobileCommand as Command
@@ -112,7 +114,7 @@ class TouchAction(object):
         }
         self._actions.append(gesture)
 
-    def _get_opts(self, element, x, y, duration = None):
+    def _get_opts(self, element, x, y, duration=None):
         opts = {}
         if element is not None:
             opts['element'] = element.id

--- a/appium/webdriver/errorhandler.py
+++ b/appium/webdriver/errorhandler.py
@@ -27,4 +27,3 @@ class MobileErrorHandler(errorhandler.ErrorHandler):
                 raise NoSuchContextException(wde.msg, wde.screen, wde.stacktrace)
             else:
                 raise wde
-

--- a/appium/webdriver/imagelement.py
+++ b/appium/webdriver/imagelement.py
@@ -13,7 +13,7 @@
 import math
 
 
-class ImageElement:
+class ImageElement(object):
 
     def __init__(self, driver, x, y, width, height):
         self.driver = driver

--- a/appium/webdriver/imagelement.py
+++ b/appium/webdriver/imagelement.py
@@ -10,8 +10,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import math
+# pylint: disable=no-self-use
 
+import math
 
 class ImageElement(object):
 

--- a/appium/webdriver/webdriver.py
+++ b/appium/webdriver/webdriver.py
@@ -1376,6 +1376,8 @@ class WebDriver(webdriver.Remote):
         """
         return self.execute_script('mobile: batteryInfo')
 
+
+    # pylint: disable=protected-access
     def _addCommands(self):
         self.command_executor._commands[Command.CONTEXTS] = \
             ('GET', '/session/$sessionId/contexts')

--- a/appium/webdriver/webdriver.py
+++ b/appium/webdriver/webdriver.py
@@ -12,28 +12,29 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# pylint: disable=too-many-lines,too-many-public-methods,too-many-statements,no-self-use
+
+import base64
+import copy
+
 from selenium import webdriver
 
-from .mobilecommand import MobileCommand as Command
-from .errorhandler import MobileErrorHandler
-from .switch_to import MobileSwitchTo
-from .webelement import WebElement as MobileWebElement
-from .imagelement import ImageElement
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.common.exceptions import (TimeoutException, WebDriverException, InvalidArgumentException, NoSuchElementException)
+
+from selenium.webdriver.remote.command import Command as RemoteCommand
 
 from appium.webdriver.clipboard_content_type import ClipboardContentType
 from appium.webdriver.common.mobileby import MobileBy
 from appium.webdriver.common.touch_action import TouchAction
 from appium.webdriver.common.multi_action import MultiAction
 
-from selenium.webdriver.common.by import By
-from selenium.webdriver.support.ui import WebDriverWait
-from selenium.common.exceptions import (TimeoutException,
-        WebDriverException, InvalidArgumentException, NoSuchElementException)
-
-from selenium.webdriver.remote.command import Command as RemoteCommand
-
-import base64
-import copy
+from .mobilecommand import MobileCommand as Command
+from .errorhandler import MobileErrorHandler
+from .switch_to import MobileSwitchTo
+from .webelement import WebElement as MobileWebElement
+from .imagelement import ImageElement
 
 DEFAULT_MATCH_THRESHOLD = 0.5
 
@@ -387,29 +388,29 @@ class WebDriver(webdriver.Remote):
             pass
         return els
 
-    def find_element_by_accessibility_id(self, id):
+    def find_element_by_accessibility_id(self, accessibility_id):
         """Finds an element by accessibility id.
 
         :Args:
-         - id - a string corresponding to a recursive element search using the
+         - accessibility_id - a string corresponding to a recursive element search using the
          Id/Name that the native Accessibility options utilize
 
         :Usage:
             driver.find_element_by_accessibility_id()
         """
-        return self.find_element(by=By.ACCESSIBILITY_ID, value=id)
+        return self.find_element(by=By.ACCESSIBILITY_ID, value=accessibility_id)
 
-    def find_elements_by_accessibility_id(self, id):
+    def find_elements_by_accessibility_id(self, accessibility_id):
         """Finds elements by accessibility id.
 
         :Args:
-         - id - a string corresponding to a recursive element search using the
+         - accessibility_id - a string corresponding to a recursive element search using the
          Id/Name that the native Accessibility options utilize
 
         :Usage:
             driver.find_elements_by_accessibility_id()
         """
-        return self.find_elements(by=By.ACCESSIBILITY_ID, value=id)
+        return self.find_elements(by=By.ACCESSIBILITY_ID, value=accessibility_id)
 
     def create_web_element(self, element_id):
         """

--- a/appium/webdriver/webelement.py
+++ b/appium/webdriver/webelement.py
@@ -12,11 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .mobilecommand import MobileCommand as Command
-
 from selenium.webdriver.common.by import By
 from selenium.webdriver.remote.webelement import WebElement as SeleniumWebElement
 
+from .mobilecommand import MobileCommand as Command
 
 class WebElement(SeleniumWebElement):
     def find_element_by_ios_uiautomation(self, uia_string):
@@ -107,29 +106,29 @@ class WebElement(SeleniumWebElement):
         """
         return self.find_elements(by=By.ANDROID_UIAUTOMATOR, value=uia_string)
 
-    def find_element_by_accessibility_id(self, id):
+    def find_element_by_accessibility_id(self, accessibility_id):
         """Finds an element by accessibility id.
 
         :Args:
-         - id - a string corresponding to a recursive element search using the
+         - accessibility_id - a string corresponding to a recursive element search using the
          Id/Name that the native Accessibility options utilize
 
         :Usage:
             driver.find_element_by_accessibility_id()
         """
-        return self.find_element(by=By.ACCESSIBILITY_ID, value=id)
+        return self.find_element(by=By.ACCESSIBILITY_ID, value=accessibility_id)
 
-    def find_elements_by_accessibility_id(self, id):
+    def find_elements_by_accessibility_id(self, accessibility_id):
         """Finds elements by accessibility id.
 
         :Args:
-         - id - a string corresponding to a recursive element search using the
+         - accessibility_id - a string corresponding to a recursive element search using the
          Id/Name that the native Accessibility options utilize
 
         :Usage:
             driver.find_elements_by_accessibility_id()
         """
-        return self.find_elements(by=By.ACCESSIBILITY_ID, value=id)
+        return self.find_elements(by=By.ACCESSIBILITY_ID, value=accessibility_id)
 
     def set_text(self, keys=''):
         """Sends text to the element. Previous text is removed.

--- a/ci-requirements.txt
+++ b/ci-requirements.txt
@@ -1,0 +1,3 @@
+astroid
+isort
+pylint

--- a/test/unit/multi_action_tests.py
+++ b/test/unit/multi_action_tests.py
@@ -36,8 +36,7 @@ class MultiActionTests(unittest.TestCase):
                     {'action': 'moveTo', 'options': {'x': 12, 'y': -300}},
                     {'action': 'release', 'options': {}}
                 ]
-            ],
-            'elementId': 0
+            ]
         }
         t1 = TouchAction(DriverStub()).press(ElementStub(1)).move_to(x=10, y=20).release()
         t2 = TouchAction(DriverStub()).press(ElementStub(5), 11, 30).move_to(x=12, y=-300).release()


### PR DESCRIPTION
This PR is proposal.
📝 I'll ask recommended preferences in python channel

----

Current this repository has no travis preference. No pylint, but this repository has a few unit tests as well. https://pylint.readthedocs.io/en/latest/technical_reference/features.html provide some compatibility checking for Python 2 and 3.

So, what about adding travis and `pylint`?

---

## What I did
- Add travis.yml
- Add template of `.pylintrc`

## we can ignore
- `missing-docstring`
- `empty-docstring`
- `too-few-public-methods`
- `invalid-name`
- `duplicate-code`

## Error
- No
- All unit tests are passed