### PR TITLE
remove always_match and use first_match instead

### DIFF
--- a/appium/webdriver/webdriver.py
+++ b/appium/webdriver/webdriver.py
@@ -67,26 +67,26 @@ def _make_w3c_caps(caps):
 
     caps = copy.deepcopy(caps)
     profile = caps.get('firefox_profile')
-    always_match = {}
+    first_match = {}
     if caps.get('proxy') and caps['proxy'].get('proxyType'):
         caps['proxy']['proxyType'] = caps['proxy']['proxyType'].lower()
     for k, v in caps.items():
         if v and k in _OSS_W3C_CONVERSION:
-            always_match[_OSS_W3C_CONVERSION[k]] = v.lower() if k == 'platform' else v
+            first_match[_OSS_W3C_CONVERSION[k]] = v.lower() if k == 'platform' else v
         if k in _W3C_CAPABILITY_NAMES or _EXTENSION_CAPABILITY in k:
-            always_match[k] = v
+            first_match[k] = v
         else:
             if not k.startswith(appium_prefix):
-                always_match[appium_prefix + k] = v
+                first_match[appium_prefix + k] = v
     if profile:
-        moz_opts = always_match.get('moz:firefoxOptions', {})
+        moz_opts = first_match.get('moz:firefoxOptions', {})
         # If it's already present, assume the caller did that intentionally.
         if 'profile' not in moz_opts:
             # Don't mutate the original capabilities.
             new_opts = copy.deepcopy(moz_opts)
             new_opts['profile'] = profile
-            always_match['moz:firefoxOptions'] = new_opts
-    return {'firstMatch': [{}], 'alwaysMatch': always_match}
+            first_match['moz:firefoxOptions'] = new_opts
+    return {'firstMatch': [first_match]}
 
 
 class WebDriver(webdriver.Remote):


### PR DESCRIPTION
related: https://github.com/appium/ruby_lib_core/pull/138

```
[HTTP]
[HTTP] --> POST /wd/hub/session
[HTTP] {"capabilities":{"firstMatch":[{"appium:newCommandTimeout":240,"appium:app":"/Users/kazuaki/GitHub/python-client/test/apps/ApiDemos-debug.apk","appium:deviceName":"Android Emulator","platformName":"Android"}]},"desiredCapabilities":{"deviceName":"Android Emulator","app":"/Users/kazuaki/GitHub/python-client/test/apps/ApiDemos-debug.apk","platformName":"Android","newCommandTimeout":240}}
[debug] [W3C] Calling AppiumDriver.createSession() with args: [{"deviceName":"Android Emulator","app":"/Users/kazuaki/GitHub/python-client/test/apps/ApiDemos-debug.apk","platformName":"Android","newCommandTimeout":240},null,{"firstMatch":[{"appium:newCommandTimeout":240,"appium:app":"/Users/kazuaki/GitHub/python-client/test/apps/ApiDemos-debug.apk","appium:deviceName":"Android Emulator","platformName":"Android"}]}]
[debug] [BaseDriver] Event 'newSessionRequested' logged at 1535471693372 (00:54:53 GMT+0900 (JST))
[Appium] Creating new AndroidDriver (v3.6.0) session
```