### PR TITLE
Add xdist port handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,11 @@ $ python -m autopep8 -r --global-config .config-pep8 -i .
 ```
 
 ## Run tests
+
+```
+$ py.test test/functional/ios/find_by_ios_class_chain_tests.py
+```
+
 ### In parallel for iOS
 1. Create simulators named 'iPhone 6s - 8100' and 'iPhone 6s - 8101'
 2. Install test libraries via pip

--- a/README.md
+++ b/README.md
@@ -47,13 +47,16 @@ $ python -m autopep8 -r --global-config .config-pep8 -i .
 ```
 
 ## Run tests
-
-### parallel
-
-```
-$ pip install pytest pytest-xdist
-$ py.test -n 2 test/functional/ios/find_by_ios_class_chain_tests.py
-```
+### In parallel for iOS
+1. Create simulators named 'iPhone 6s - 8100' and 'iPhone 6s - 8101'
+2. Install test libraries via pip
+    ```
+    $ pip install pytest pytest-xdist
+    ```
+3. Run tests
+    ```
+    $ py.test -n 2 test/functional/ios/find_by_ios_class_chain_tests.py
+    ```
 
 # Usage
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,15 @@ download and unarchive the source tarball (Appium-Python-Client-X.X.tar.gz).
 $ python -m autopep8 -r --global-config .config-pep8 -i .
 ```
 
+## Run tests
+
+### parallel
+
+```
+$ pip install pytest pytest-xdist
+$ py.test -n 2 test/functional/ios/find_by_ios_class_chain_tests.py
+```
+
 # Usage
 
 The Appium Python Client is fully compliant with the Selenium 3.0 specification

--- a/test/functional/ios/desired_capabilities.py
+++ b/test/functional/ios/desired_capabilities.py
@@ -37,11 +37,19 @@ def get_desired_capabilities(app):
 
     return desired_caps
 
+
+class PytestXdistWorker(object):
+    NUMBER = os.getenv('PYTEST_XDIST_WORKER')
+
+    @staticmethod
+    def gw(number):
+        return 'gw{}'.format(number)
+
 # If you run tests with pytest-xdist, you can run tests in parallel.
 
 
 def wda_port():
-    if os.getenv('PYTEST_XDIST_WORKER') == 'gw1':
+    if PytestXdistWorker.NUMBER == PytestXdistWorker.gw(1):
         return 8101
 
     return 8100
@@ -50,9 +58,9 @@ def wda_port():
 
 
 def iphone_device_name():
-    if os.getenv('PYTEST_XDIST_WORKER') == 'gw0':
+    if PytestXdistWorker.NUMBER == PytestXdistWorker.gw(0):
         return 'iPhone 6s - 8100'
-    elif os.getenv('PYTEST_XDIST_WORKER') == 'gw1':
+    elif PytestXdistWorker.NUMBER == PytestXdistWorker.gw(1):
         return 'iPhone 6s - 8101'
 
     return 'iPhone 6s'

--- a/test/functional/ios/desired_capabilities.py
+++ b/test/functional/ios/desired_capabilities.py
@@ -40,9 +40,13 @@ def get_desired_capabilities(app):
 
 class PytestXdistWorker(object):
     NUMBER = os.getenv('PYTEST_XDIST_WORKER')
+    COUNT = os.getenv('PYTEST_XDIST_WORKER_COUNT')  # Return 2 if `-n 2` is passed
 
     @staticmethod
     def gw(number):
+        if number >= PytestXdistWorker.COUNT:
+            return 'gw0'
+
         return 'gw{}'.format(number)
 
 # If you run tests with pytest-xdist, you can run tests in parallel.

--- a/test/functional/ios/desired_capabilities.py
+++ b/test/functional/ios/desired_capabilities.py
@@ -26,12 +26,29 @@ BUNDLE_ID = 'com.example.apple-samplecode.UICatalog'
 
 def get_desired_capabilities(app):
     desired_caps = {
-        'deviceName': 'iPhone 6s',
+        'deviceName': iphone_device_name(),
         'platformName': 'iOS',
         'platformVersion': '10.3',
         'app': PATH('../../apps/' + app),
         'automationName': 'XCUITest',
-        'allowTouchIdEnroll': True
+        'allowTouchIdEnroll': True,
+        'wdaLocalPort': wda_port(),
     }
 
     return desired_caps
+
+# If you run tests with pytest-xdist, you can run tests in parallel.
+def wda_port():
+    if os.getenv('PYTEST_XDIST_WORKER') == 'gw1':
+        return 8101
+
+    return 8100
+
+#Before running tests, you must have iOS simulators named 'iPhone 6s - 8100' and 'iPhone 6s - 8101'
+def iphone_device_name():
+    if os.getenv('PYTEST_XDIST_WORKER') == 'gw0':
+        return 'iPhone 6s - 8100'
+    elif os.getenv('PYTEST_XDIST_WORKER') == 'gw1':
+        return 'iPhone 6s - 8101'
+
+    return 'iPhone 6s'

--- a/test/functional/ios/desired_capabilities.py
+++ b/test/functional/ios/desired_capabilities.py
@@ -38,13 +38,17 @@ def get_desired_capabilities(app):
     return desired_caps
 
 # If you run tests with pytest-xdist, you can run tests in parallel.
+
+
 def wda_port():
     if os.getenv('PYTEST_XDIST_WORKER') == 'gw1':
         return 8101
 
     return 8100
 
-#Before running tests, you must have iOS simulators named 'iPhone 6s - 8100' and 'iPhone 6s - 8101'
+# Before running tests, you must have iOS simulators named 'iPhone 6s - 8100' and 'iPhone 6s - 8101'
+
+
 def iphone_device_name():
     if os.getenv('PYTEST_XDIST_WORKER') == 'gw0':
         return 'iPhone 6s - 8100'


### PR DESCRIPTION
This is an example to show how to handle port numbers to run tests in parallel. This will help users when they'd ike to run tests in parallel. The example has only two simulator case.
(This parallel running also help our test running.)

Run test in parallel as an example for parallel running #247 

```
$ python -m py.test -n 2 test/functional/ios/find_by_ios_class_chain_tests.py
=================================== test session starts ===================================
platform darwin -- Python 2.7.15, pytest-3.7.1, py-1.5.4, pluggy-0.7.1
rootdir: /Users/kazu/GitHub/python-client, inifile:
plugins: xdist-1.23.0, forked-0.2
gw0 [2] / gw1 [2]
scheduling tests via LoadScheduling
..                                                                                  [100%]
================================ 2 passed in 17.26 seconds ================================
```