### PR TITLE
add find_elements w3c for webelement

### DIFF
--- a/appium/webdriver/webdriver.py
+++ b/appium/webdriver/webdriver.py
@@ -202,19 +202,19 @@ class WebDriver(webdriver.Remote):
 
         :rtype: WebElement
         """
+        # TODO: If we need, we should enable below converter for Web context
         # if self.w3c:
-
-        # if by == By.ID:
-        #     by = By.CSS_SELECTOR
-        #     value = '[id="%s"]' % value
-        # elif by == By.TAG_NAME:
-        #     by = By.CSS_SELECTOR
-        # elif by == By.CLASS_NAME:
-        #     by = By.CSS_SELECTOR
-        #     value = ".%s" % value
-        # elif by == By.NAME:
-        #     by = By.CSS_SELECTOR
-        #     value = '[name="%s"]' % value
+        #     if by == By.ID:
+        #         by = By.CSS_SELECTOR
+        #         value = '[id="%s"]' % value
+        #     elif by == By.TAG_NAME:
+        #         by = By.CSS_SELECTOR
+        #     elif by == By.CLASS_NAME:
+        #         by = By.CSS_SELECTOR
+        #         value = ".%s" % value
+        #     elif by == By.NAME:
+        #         by = By.CSS_SELECTOR
+        #         value = '[name="%s"]' % value
 
         return self.execute(RemoteCommand.FIND_ELEMENT, {
             'using': by,
@@ -230,18 +230,19 @@ class WebDriver(webdriver.Remote):
 
         :rtype: list of WebElement
         """
+        # TODO: If we need, we should enable below converter for Web context
         # if self.w3c:
-        # if by == By.ID:
-        #     by = By.CSS_SELECTOR
-        #     value = '[id="%s"]' % value
-        # elif by == By.TAG_NAME:
-        #     by = By.CSS_SELECTOR
-        # elif by == By.CLASS_NAME:
-        #     by = By.CSS_SELECTOR
-        #     value = ".%s" % value
-        # elif by == By.NAME:
-        #     by = By.CSS_SELECTOR
-        #     value = '[name="%s"]' % value
+        #     if by == By.ID:
+        #         by = By.CSS_SELECTOR
+        #         value = '[id="%s"]' % value
+        #     elif by == By.TAG_NAME:
+        #         by = By.CSS_SELECTOR
+        #     elif by == By.CLASS_NAME:
+        #         by = By.CSS_SELECTOR
+        #         value = ".%s" % value
+        #     elif by == By.NAME:
+        #         by = By.CSS_SELECTOR
+        #         value = '[name="%s"]' % value
 
         # Return empty list if driver returns null
         # See https://github.com/SeleniumHQ/selenium/issues/4555

--- a/appium/webdriver/webelement.py
+++ b/appium/webdriver/webelement.py
@@ -142,6 +142,7 @@ class WebElement(SeleniumWebElement):
             element = element.find_element(By.ID, 'foo')
         :rtype: WebElement
         """
+        # TODO: If we need, we should enable below converter for Web context
         # if self._w3c:
         #     if by == By.ID:
         #         by = By.CSS_SELECTOR
@@ -166,6 +167,7 @@ class WebElement(SeleniumWebElement):
             element = element.find_elements(By.CLASS_NAME, 'foo')
         :rtype: list of WebElement
         """
+        # TODO: If we need, we should enable below converter for Web context
         # if self._w3c:
         #     if by == By.ID:
         #         by = By.CSS_SELECTOR

--- a/appium/webdriver/webelement.py
+++ b/appium/webdriver/webelement.py
@@ -14,6 +14,9 @@
 
 from selenium.webdriver.common.by import By
 from selenium.webdriver.remote.webelement import WebElement as SeleniumWebElement
+from selenium.webdriver.remote.command import Command as RemoteCommand
+
+from appium.webdriver.common.mobileby import MobileBy
 
 from .mobilecommand import MobileCommand as Command
 
@@ -28,7 +31,7 @@ class WebElement(SeleniumWebElement):
         :Usage:
             driver.find_element_by_ios_uiautomation('.elements()[1].cells()[2]')
         """
-        return self.find_element(by=By.IOS_UIAUTOMATION, value=uia_string)
+        return self.find_element(by=MobileBy.IOS_UIAUTOMATION, value=uia_string)
 
     def find_elements_by_ios_uiautomation(self, uia_string):
         """Finds elements by uiautomation in iOS.
@@ -39,7 +42,7 @@ class WebElement(SeleniumWebElement):
         :Usage:
             driver.find_elements_by_ios_uiautomation('.elements()[1].cells()[2]')
         """
-        return self.find_elements(by=By.IOS_UIAUTOMATION, value=uia_string)
+        return self.find_elements(by=MobileBy.IOS_UIAUTOMATION, value=uia_string)
 
     def find_element_by_ios_predicate(self, predicate_string):
         """Find an element by ios predicate string.
@@ -50,7 +53,7 @@ class WebElement(SeleniumWebElement):
         :Usage:
             driver.find_element_by_ios_predicate('label == "myLabel"')
         """
-        return self.find_element(by=By.IOS_PREDICATE, value=predicate_string)
+        return self.find_element(by=MobileBy.IOS_PREDICATE, value=predicate_string)
 
     def find_elements_by_ios_predicate(self, predicate_string):
         """Finds elements by ios predicate string.
@@ -61,7 +64,7 @@ class WebElement(SeleniumWebElement):
         :Usage:
             driver.find_elements_by_ios_predicate('label == "myLabel"')
         """
-        return self.find_elements(by=By.IOS_PREDICATE, value=predicate_string)
+        return self.find_elements(by=MobileBy.IOS_PREDICATE, value=predicate_string)
 
     def find_element_by_ios_class_chain(self, class_chain_string):
         """Find an element by ios class chain string.
@@ -72,7 +75,7 @@ class WebElement(SeleniumWebElement):
         :Usage:
             driver.find_element_by_ios_class_chain('XCUIElementTypeWindow/XCUIElementTypeButton[3]')
         """
-        return self.find_element(by=By.IOS_CLASS_CHAIN, value=class_chain_string)
+        return self.find_element(by=MobileBy.IOS_CLASS_CHAIN, value=class_chain_string)
 
     def find_elements_by_ios_class_chain(self, class_chain_string):
         """Finds elements by ios class chain string.
@@ -83,7 +86,7 @@ class WebElement(SeleniumWebElement):
         :Usage:
             driver.find_elements_by_ios_class_chain('XCUIElementTypeWindow[2]/XCUIElementTypeAny[-2]')
         """
-        return self.find_elements(by=By.IOS_CLASS_CHAIN, value=class_chain_string)
+        return self.find_elements(by=MobileBy.IOS_CLASS_CHAIN, value=class_chain_string)
 
     def find_element_by_android_uiautomator(self, uia_string):
         """Finds element by uiautomator in Android.
@@ -94,7 +97,7 @@ class WebElement(SeleniumWebElement):
         :Usage:
             driver.find_element_by_android_uiautomator('.elements()[1].cells()[2]')
         """
-        return self.find_element(by=By.ANDROID_UIAUTOMATOR, value=uia_string)
+        return self.find_element(by=MobileBy.ANDROID_UIAUTOMATOR, value=uia_string)
 
     def find_elements_by_android_uiautomator(self, uia_string):
         """Finds elements by uiautomator in Android.
@@ -105,7 +108,7 @@ class WebElement(SeleniumWebElement):
         :Usage:
             driver.find_elements_by_android_uiautomator('.elements()[1].cells()[2]')
         """
-        return self.find_elements(by=By.ANDROID_UIAUTOMATOR, value=uia_string)
+        return self.find_elements(by=MobileBy.ANDROID_UIAUTOMATOR, value=uia_string)
 
     def find_element_by_accessibility_id(self, accessibility_id):
         """Finds an element by accessibility id.
@@ -117,7 +120,7 @@ class WebElement(SeleniumWebElement):
         :Usage:
             driver.find_element_by_accessibility_id()
         """
-        return self.find_element(by=By.ACCESSIBILITY_ID, value=accessibility_id)
+        return self.find_element(by=MobileBy.ACCESSIBILITY_ID, value=accessibility_id)
 
     def find_elements_by_accessibility_id(self, accessibility_id):
         """Finds elements by accessibility id.
@@ -129,7 +132,55 @@ class WebElement(SeleniumWebElement):
         :Usage:
             driver.find_elements_by_accessibility_id()
         """
-        return self.find_elements(by=By.ACCESSIBILITY_ID, value=accessibility_id)
+        return self.find_elements(by=MobileBy.ACCESSIBILITY_ID, value=accessibility_id)
+
+    def find_element(self, by=By.ID, value=None):
+        """
+        Find an element given a By strategy and locator. Prefer the find_element_by_* methods when
+        possible.
+        :Usage:
+            element = element.find_element(By.ID, 'foo')
+        :rtype: WebElement
+        """
+        # if self._w3c:
+        #     if by == By.ID:
+        #         by = By.CSS_SELECTOR
+        #         value = '[id="%s"]' % value
+        #     elif by == By.TAG_NAME:
+        #         by = By.CSS_SELECTOR
+        #     elif by == By.CLASS_NAME:
+        #         by = By.CSS_SELECTOR
+        #         value = ".%s" % value
+        #     elif by == By.NAME:
+        #         by = By.CSS_SELECTOR
+        #         value = '[name="%s"]' % value
+
+        return self._execute(RemoteCommand.FIND_CHILD_ELEMENT,
+                             {"using": by, "value": value})['value']
+
+    def find_elements(self, by=By.ID, value=None):
+        """
+        Find elements given a By strategy and locator. Prefer the find_elements_by_* methods when
+        possible.
+        :Usage:
+            element = element.find_elements(By.CLASS_NAME, 'foo')
+        :rtype: list of WebElement
+        """
+        # if self._w3c:
+        #     if by == By.ID:
+        #         by = By.CSS_SELECTOR
+        #         value = '[id="%s"]' % value
+        #     elif by == By.TAG_NAME:
+        #         by = By.CSS_SELECTOR
+        #     elif by == By.CLASS_NAME:
+        #         by = By.CSS_SELECTOR
+        #         value = ".%s" % value
+        #     elif by == By.NAME:
+        #         by = By.CSS_SELECTOR
+        #         value = '[name="%s"]' % value
+
+        return self._execute(RemoteCommand.FIND_CHILD_ELEMENTS,
+                             {"using": by, "value": value})['value']
 
     def set_text(self, keys=''):
         """Sends text to the element. Previous text is removed.

--- a/test/functional/android/appium_tests.py
+++ b/test/functional/android/appium_tests.py
@@ -21,7 +21,7 @@ import random
 from time import sleep
 from dateutil.parser import parse
 
-from webdriver.applicationstate import ApplicationState
+from appium.webdriver.applicationstate import ApplicationState
 from selenium.common.exceptions import NoSuchElementException
 
 from appium import webdriver

--- a/test/functional/ios/appium_tests.py
+++ b/test/functional/ios/appium_tests.py
@@ -15,7 +15,7 @@
 import unittest
 from time import sleep
 
-from webdriver.applicationstate import ApplicationState
+from appium.webdriver.applicationstate import ApplicationState
 from appium import webdriver
 import desired_capabilities
 

--- a/test/functional/ios/desired_capabilities.py
+++ b/test/functional/ios/desired_capabilities.py
@@ -44,6 +44,9 @@ class PytestXdistWorker(object):
 
     @staticmethod
     def gw(number):
+        if PytestXdistWorker.COUNT is None:
+            return '0'
+
         if number >= PytestXdistWorker.COUNT:
             return 'gw0'
 

--- a/test/functional/ios/find_by_element_webelement_tests.py
+++ b/test/functional/ios/find_by_element_webelement_tests.py
@@ -17,6 +17,7 @@ import unittest
 from appium import webdriver
 import desired_capabilities
 
+
 class FindByElementWebelementTests(unittest.TestCase):
 
     @classmethod
@@ -40,6 +41,7 @@ class FindByElementWebelementTests(unittest.TestCase):
 
         c_el = el.find_elements_by_accessibility_id('UICatalog')
         self.assertEqual('UICatalog', c_el[0].get_attribute('name'))
+
 
 if __name__ == "__main__":
     suite = unittest.TestLoader().loadTestsFromTestCase(FindByElementWebelementTests)

--- a/test/functional/ios/find_by_element_webelement_tests.py
+++ b/test/functional/ios/find_by_element_webelement_tests.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from appium import webdriver
+import desired_capabilities
+
+class FindByElementWebelementTests(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(self):
+        desired_caps = desired_capabilities.get_desired_capabilities('UICatalog.app.zip')
+        self.driver = webdriver.Remote('http://localhost:4723/wd/hub', desired_caps)
+
+    @classmethod
+    def tearDownClass(self):
+        self.driver.quit()
+
+    def test_find_element_by_path(self):
+        el = self.driver.find_element_by_ios_predicate('wdName == "UICatalog"')
+        self.assertEqual('UICatalog', el.get_attribute('name'))
+
+        c_el = el.find_elements_by_ios_predicate('label == "TextFields"')
+        self.assertEqual('TextFields', c_el[0].get_attribute('name'))
+
+        c_el = el.find_elements_by_ios_class_chain('**/XCUIElementTypeStaticText')
+        self.assertEqual('UICatalog', c_el[0].get_attribute('name'))
+
+        c_el = el.find_elements_by_accessibility_id('UICatalog')
+        self.assertEqual('UICatalog', c_el[0].get_attribute('name'))
+
+if __name__ == "__main__":
+    suite = unittest.TestLoader().loadTestsFromTestCase(FindByElementWebelementTests)
+    unittest.TextTestRunner(verbosity=2).run(suite)


### PR DESCRIPTION
# TODO
- [x] Add tests for `element.find_element/s_by_xxxx`

---

https://github.com/appium/appium/issues/10874#issuecomment-419973320

`driver.find_element/s_by_xxxx` works well. But `element.find_element/s_by_xxxx` doesn't since find selectors are converted to `css selector` by selenium-webdriver.

