### PR TITLE
bump selenium 3.14.1, call RemoteCommand without workaround

### DIFF
--- a/appium/webdriver/webelement.py
+++ b/appium/webdriver/webelement.py
@@ -26,6 +26,7 @@ try:
 except NameError:
     pass
 
+
 class WebElement(SeleniumWebElement):
     # Override
     def get_attribute(self, name):

--- a/appium/webdriver/webelement.py
+++ b/appium/webdriver/webelement.py
@@ -20,6 +20,11 @@ from appium.webdriver.common.mobileby import MobileBy
 
 from .mobilecommand import MobileCommand as Command
 
+# Python 3 imports
+try:
+    str = basestring
+except NameError:
+    pass
 
 class WebElement(SeleniumWebElement):
     # Override
@@ -53,7 +58,7 @@ class WebElement(SeleniumWebElement):
             return None
 
         if not isinstance(attributeValue, str):
-            attributeValue = str(attributeValue)
+            attributeValue = unicode(attributeValue)
 
         if attributeValue.lower() in ('true', 'false'):
             return attributeValue.lower()

--- a/appium/webdriver/webelement.py
+++ b/appium/webdriver/webelement.py
@@ -22,6 +22,43 @@ from .mobilecommand import MobileCommand as Command
 
 
 class WebElement(SeleniumWebElement):
+    # Override
+    def get_attribute(self, name):
+        """Gets the given attribute or property of the element.
+
+        This method will first try to return the value of a property with the
+        given name. If a property with that name doesn't exist, it returns the
+        value of the attribute with the same name. If there's no attribute with
+        that name, ``None`` is returned.
+
+        Values which are considered truthy, that is equals "true" or "false",
+        are returned as booleans.  All other non-``None`` values are returned
+        as strings.  For attributes or properties which do not exist, ``None``
+        is returned.
+
+        :Args:
+            - name - Name of the attribute/property to retrieve.
+
+        Example::
+
+            # Check if the "active" CSS class is applied to an element.
+            is_active = "active" in target_element.get_attribute("class")
+
+        """
+
+        attributeValue = ''
+        resp = self._execute(RemoteCommand.GET_ELEMENT_ATTRIBUTE, {'name': name})
+        attributeValue = resp.get('value')
+        if attributeValue is not None:
+            if name != 'value' and attributeValue.lower() in ('true', 'false'):
+                attributeValue = attributeValue.lower()
+        return attributeValue
+
+    # Override
+    def is_displayed(self):
+        """Whether the element is visible to a user."""
+        return self._execute(RemoteCommand.IS_ELEMENT_DISPLAYED)['value']
+
     def find_element_by_ios_uiautomation(self, uia_string):
         """Finds an element by uiautomation in iOS.
 

--- a/appium/webdriver/webelement.py
+++ b/appium/webdriver/webelement.py
@@ -46,12 +46,18 @@ class WebElement(SeleniumWebElement):
 
         """
 
-        attributeValue = ''
         resp = self._execute(RemoteCommand.GET_ELEMENT_ATTRIBUTE, {'name': name})
         attributeValue = resp.get('value')
-        if attributeValue is not None:
-            if name != 'value' and attributeValue.lower() in ('true', 'false'):
-                attributeValue = attributeValue.lower()
+
+        if attributeValue is None:
+            return None
+
+        if not isinstance(attributeValue, str):
+            attributeValue = str(attributeValue)
+
+        if attributeValue.lower() in ('true', 'false'):
+            return attributeValue.lower()
+
         return attributeValue
 
     # Override

--- a/appium/webdriver/webelement.py
+++ b/appium/webdriver/webelement.py
@@ -61,7 +61,7 @@ class WebElement(SeleniumWebElement):
         if not isinstance(attributeValue, str):
             attributeValue = unicode(attributeValue)
 
-        if attributeValue.lower() in ('true', 'false'):
+        if name != 'value' and attributeValue.lower() in ('true', 'false'):
             return attributeValue.lower()
 
         return attributeValue

--- a/setup.py
+++ b/setup.py
@@ -50,5 +50,5 @@ setup(
         'Topic :: Software Development :: Quality Assurance',
         'Topic :: Software Development :: Testing'
     ],
-    install_requires=['selenium>=2.47.0']
+    install_requires=['selenium>=3.14.1']
 )

--- a/test/functional/ios/desired_capabilities.py
+++ b/test/functional/ios/desired_capabilities.py
@@ -28,7 +28,7 @@ def get_desired_capabilities(app):
     desired_caps = {
         'deviceName': iphone_device_name(),
         'platformName': 'iOS',
-        'platformVersion': '10.3',
+        'platformVersion': '11.4',
         'app': PATH('../../apps/' + app),
         'automationName': 'XCUITest',
         'allowTouchIdEnroll': True,
@@ -66,8 +66,8 @@ def wda_port():
 
 def iphone_device_name():
     if PytestXdistWorker.NUMBER == PytestXdistWorker.gw(0):
-        return 'iPhone 6s - 8100'
+        return 'iPhone 8 - 8100'
     elif PytestXdistWorker.NUMBER == PytestXdistWorker.gw(1):
-        return 'iPhone 6s - 8101'
+        return 'iPhone 8 - 8101'
 
-    return 'iPhone 6s'
+    return 'iPhone 8'


### PR DESCRIPTION
closes https://github.com/appium/python-client/issues/258

selenium 3.14.1 has workaround, calling JavaScript, for `get_attribute` and `is_displayed` in W3C.
In this PR, I override them in `webelement.py` to remove the workaround for Appium

I tested on my locale for each command.

```
Processing selenium-3.14.1-py2.py3-none-any.whl
Installing selenium-3.14.1-py2.py3-none-any.whl to /usr/local/lib/python2.7/site-packages
writing requirements to /usr/local/lib/python2.7/site-packages/selenium-3.14.1-py2.7.egg/EGG-INFO/requires.txt
Adding selenium 3.14.1 to easy-install.pth file

Installed /usr/local/lib/python2.7/site-packages/selenium-3.14.1-py2.7.egg
Searching for urllib3==1.23
Best match: urllib3 1.23
Adding urllib3 1.23 to easy-install.pth file

Using /usr/local/lib/python2.7/site-packages
Finished processing dependencies for Appium-Python-Client==0.28
$ py.test test/functional/ios/appium_tests.py
====================================== test session starts =======================================
platform darwin -- Python 3.7.0, pytest-3.7.1, py-1.5.4, pluggy-0.7.1
rootdir: /Users/kazu/GitHub/python-client, inifile:
collected 11 items

test/functional/ios/appium_tests.py ...........                                            [100%]

================================== 11 passed in 178.38 seconds ===================================
```