### PR TITLE
fix python3 set_clipboard error

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,8 @@ from appium import webdriver
 
 desired_caps = {}
 desired_caps['platformName'] = 'Android'
-desired_caps['platformVersion'] = '4.2'
+desired_caps['platformVersion'] = '8.1'
+desired_caps['automationName'] = 'uiautomator2'
 desired_caps['deviceName'] = 'Android Emulator'
 desired_caps['app'] = PATH('../../../apps/selendroid-test-app.apk')
 
@@ -116,7 +117,8 @@ from appium import webdriver
 
 desired_caps = {}
 desired_caps['platformName'] = 'iOS'
-desired_caps['platformVersion'] = '7.1'
+desired_caps['platformVersion'] = '11.4'
+desired_caps['automationName'] = 'xcuitest'
 desired_caps['deviceName'] = 'iPhone Simulator'
 desired_caps['app'] = PATH('../../apps/UICatalog.app.zip')
 

--- a/appium/webdriver/webdriver.py
+++ b/appium/webdriver/webdriver.py
@@ -1288,9 +1288,9 @@ class WebDriver(webdriver.Remote):
 
         def _bytes(value, encoding):
             try:
-                return bytes(value, encoding) # Python 3
+                return bytes(value, encoding)  # Python 3
             except TypeError:
-                return value # Python 2
+                return value  # Python 2
 
         self.set_clipboard(_bytes(str(text), 'UTF-8'), ClipboardContentType.PLAINTEXT, label)
 

--- a/appium/webdriver/webdriver.py
+++ b/appium/webdriver/webdriver.py
@@ -1271,7 +1271,7 @@ class WebDriver(webdriver.Remote):
         :param label: Optional label argument, which only works for Android
         """
         options = {
-            'content': base64.b64encode(content),
+            'content': base64.b64encode(content).decode('UTF-8'),
             'contentType': content_type,
         }
         if label:
@@ -1285,7 +1285,14 @@ class WebDriver(webdriver.Remote):
         :param text: The text to be set
         :param label: Optional label argument, which only works for Android
         """
-        self.set_clipboard(bytes(text.encode('UTF-8')), ClipboardContentType.PLAINTEXT, label)
+
+        def _bytes(value, encoding):
+            try:
+                return bytes(value, encoding) # Python 3
+            except TypeError:
+                return value # Python 2
+
+        self.set_clipboard(_bytes(str(text), 'UTF-8'), ClipboardContentType.PLAINTEXT, label)
 
     def get_clipboard(self, content_type=ClipboardContentType.PLAINTEXT):
         """


### PR DESCRIPTION
Python 3 requires encoding in `bytes`. Python 2 doesn't.
close https://github.com/appium/python-client/issues/265

## Python 3

```
>>> driver = webdriver.Remote('http://localhost:4723/wd/hub', desired_caps)
>>> driver.set_clipboard_text("hello")
>>> b = driver.get_clipboard()
>>> b.decode()
'hello'
>>> driver.set_clipboard_text("ありがとう")
>>> b = driver.get_clipboard()
>>> b.decode()
'ありがとう'
```

## Python 2

```
>>> driver = webdriver.Remote('http://localhost:4723/wd/hub', desired_caps)
>>> driver.set_clipboard_text("ありがとう")
>>> b = driver.get_clipboard()
>>> print(unicode(b.decode('UTF-8')))
ありがとう
>>> driver.set_clipboard_text("hello")
>>> b = driver.get_clipboard()
>>> print(unicode(b.decode('UTF-8')))
hello
```
