### PR TITLE
Define httpretty last request body to wrap utf-8 decode

### DIFF
--- a/appium/saucetestcase.py
+++ b/appium/saucetestcase.py
@@ -22,7 +22,7 @@ import sys
 from appium import webdriver
 from sauceclient import SauceClient
 
-SAUCE_USERNAME = os.environ.get('SAUCE_USERNAME')
+SAUCE_USERNAME = os.environ.get("SAUCE_USERNAME")
 SAUCE_ACCESS_KEY = os.environ.get('SAUCE_ACCESS_KEY')
 sauce = SauceClient(SAUCE_USERNAME, SAUCE_ACCESS_KEY)
 

--- a/appium/saucetestcase.py
+++ b/appium/saucetestcase.py
@@ -22,7 +22,7 @@ import sys
 from appium import webdriver
 from sauceclient import SauceClient
 
-SAUCE_USERNAME = os.environ.get("SAUCE_USERNAME")
+SAUCE_USERNAME = os.environ.get('SAUCE_USERNAME')
 SAUCE_ACCESS_KEY = os.environ.get('SAUCE_ACCESS_KEY')
 sauce = SauceClient(SAUCE_USERNAME, SAUCE_ACCESS_KEY)
 

--- a/test/unit/helper/test_helper.py
+++ b/test/unit/helper/test_helper.py
@@ -127,3 +127,8 @@ def ios_w3c_driver():
         desired_caps
     )
     return driver
+
+
+def httpretty_last_request_body(last_request):
+    """Returns utf-8 decided request body"""
+    return json.loads(last_request.body.decode('utf-8'))

--- a/test/unit/helper/test_helper.py
+++ b/test/unit/helper/test_helper.py
@@ -129,6 +129,6 @@ def ios_w3c_driver():
     return driver
 
 
-def httpretty_last_request_body(last_request):
-    """Returns utf-8 decided request body"""
-    return json.loads(last_request.body.decode('utf-8'))
+def get_httpretty_request_body(request):
+    """Returns utf-8 decoded request body"""
+    return json.loads(request.body.decode('utf-8'))

--- a/test/unit/webdriver/device/activities_test.py
+++ b/test/unit/webdriver/device/activities_test.py
@@ -12,9 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from test.unit.helper.test_helper import appium_command, android_w3c_driver
+from test.unit.helper.test_helper import (
+    appium_command,
+    android_w3c_driver,
+    httpretty_last_request_body
+)
 
-import json
 import httpretty
 
 
@@ -30,7 +33,7 @@ class TestWebDriverDeviceActivities(object):
         )
         driver.start_activity('com.example.myapp', '.ExampleActivity')
 
-        d = json.loads(httpretty.last_request().body.decode('utf-8'))
+        d = httpretty_last_request_body(httpretty.last_request())
         assert d['sessionId'] == '1234567890'
         assert d['appPackage'] == 'com.example.myapp'
         assert d['appActivity'] == '.ExampleActivity'
@@ -54,7 +57,7 @@ class TestWebDriverDeviceActivities(object):
             dont_stop_app_on_reset=True
         )
 
-        d = json.loads(httpretty.last_request().body.decode('utf-8'))
+        d = httpretty_last_request_body(httpretty.last_request())
         assert d['sessionId'] == '1234567890'
         assert d['appPackage'] == 'com.example.myapp'
         assert d['appActivity'] == '.ExampleActivity'

--- a/test/unit/webdriver/device/activities_test.py
+++ b/test/unit/webdriver/device/activities_test.py
@@ -15,7 +15,7 @@
 from test.unit.helper.test_helper import (
     appium_command,
     android_w3c_driver,
-    httpretty_last_request_body
+    get_httpretty_request_body
 )
 
 import httpretty
@@ -33,7 +33,7 @@ class TestWebDriverDeviceActivities(object):
         )
         driver.start_activity('com.example.myapp', '.ExampleActivity')
 
-        d = httpretty_last_request_body(httpretty.last_request())
+        d = get_httpretty_request_body(httpretty.last_request())
         assert d['sessionId'] == '1234567890'
         assert d['appPackage'] == 'com.example.myapp'
         assert d['appActivity'] == '.ExampleActivity'
@@ -57,7 +57,7 @@ class TestWebDriverDeviceActivities(object):
             dont_stop_app_on_reset=True
         )
 
-        d = httpretty_last_request_body(httpretty.last_request())
+        d = get_httpretty_request_body(httpretty.last_request())
         assert d['sessionId'] == '1234567890'
         assert d['appPackage'] == 'com.example.myapp'
         assert d['appActivity'] == '.ExampleActivity'

--- a/test/unit/webdriver/device/clipboard_test.py
+++ b/test/unit/webdriver/device/clipboard_test.py
@@ -12,9 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from test.unit.helper.test_helper import appium_command, android_w3c_driver, ios_w3c_driver
+from test.unit.helper.test_helper import (
+    appium_command,
+    android_w3c_driver,
+    ios_w3c_driver,
+    httpretty_last_request_body
+)
 
-import json
 import httpretty
 
 from appium.webdriver.clipboard_content_type import ClipboardContentType
@@ -34,7 +38,7 @@ class TestWebDriverDeviceClipboard(object):
         driver.set_clipboard(appium_bytes(str('http://appium.io/'), 'UTF-8'),
                              ClipboardContentType.URL, 'label for android')
 
-        d = json.loads(httpretty.last_request().body.decode('utf-8'))
+        d = httpretty_last_request_body(httpretty.last_request())
         assert d['content'] == 'aHR0cDovL2FwcGl1bS5pby8='
         assert d['contentType'] == 'url'
         assert d['label'] == 'label for android'
@@ -49,6 +53,6 @@ class TestWebDriverDeviceClipboard(object):
         )
         driver.set_clipboard_text('hello')
 
-        d = json.loads(httpretty.last_request().body.decode('utf-8'))
+        d = httpretty_last_request_body(httpretty.last_request())
         assert d['content'] == 'aGVsbG8='
         assert d['contentType'] == 'plaintext'

--- a/test/unit/webdriver/device/clipboard_test.py
+++ b/test/unit/webdriver/device/clipboard_test.py
@@ -16,7 +16,7 @@ from test.unit.helper.test_helper import (
     appium_command,
     android_w3c_driver,
     ios_w3c_driver,
-    httpretty_last_request_body
+    get_httpretty_request_body
 )
 
 import httpretty
@@ -38,7 +38,7 @@ class TestWebDriverDeviceClipboard(object):
         driver.set_clipboard(appium_bytes(str('http://appium.io/'), 'UTF-8'),
                              ClipboardContentType.URL, 'label for android')
 
-        d = httpretty_last_request_body(httpretty.last_request())
+        d = get_httpretty_request_body(httpretty.last_request())
         assert d['content'] == 'aHR0cDovL2FwcGl1bS5pby8='
         assert d['contentType'] == 'url'
         assert d['label'] == 'label for android'
@@ -53,6 +53,6 @@ class TestWebDriverDeviceClipboard(object):
         )
         driver.set_clipboard_text('hello')
 
-        d = httpretty_last_request_body(httpretty.last_request())
+        d = get_httpretty_request_body(httpretty.last_request())
         assert d['content'] == 'aGVsbG8='
         assert d['contentType'] == 'plaintext'

--- a/test/unit/webdriver/device/device_time_test.py
+++ b/test/unit/webdriver/device/device_time_test.py
@@ -12,10 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from test.unit.helper.test_helper import appium_command, android_w3c_driver
+from test.unit.helper.test_helper import (
+    appium_command,
+    android_w3c_driver,
+    httpretty_last_request_body
+)
 
 import httpretty
-import json
 
 
 class TestWebDriverDeviceLock(object):
@@ -50,5 +53,5 @@ class TestWebDriverDeviceLock(object):
         )
         assert driver.get_device_time('YYYY-MM-DD') == '2019-01-08'
 
-        d = json.loads(httpretty.last_request().body.decode('utf-8'))
+        d = httpretty_last_request_body(httpretty.last_request())
         assert d['format'] == 'YYYY-MM-DD'

--- a/test/unit/webdriver/device/device_time_test.py
+++ b/test/unit/webdriver/device/device_time_test.py
@@ -15,7 +15,7 @@
 from test.unit.helper.test_helper import (
     appium_command,
     android_w3c_driver,
-    httpretty_last_request_body
+    get_httpretty_request_body
 )
 
 import httpretty
@@ -53,5 +53,5 @@ class TestWebDriverDeviceLock(object):
         )
         assert driver.get_device_time('YYYY-MM-DD') == '2019-01-08'
 
-        d = httpretty_last_request_body(httpretty.last_request())
+        d = get_httpretty_request_body(httpretty.last_request())
         assert d['format'] == 'YYYY-MM-DD'

--- a/test/unit/webdriver/device/lock_test.py
+++ b/test/unit/webdriver/device/lock_test.py
@@ -16,7 +16,7 @@ from test.unit.helper.test_helper import (
     appium_command,
     android_w3c_driver,
     ios_w3c_driver,
-    httpretty_last_request_body
+    get_httpretty_request_body
 )
 
 import json
@@ -35,7 +35,7 @@ class TestWebDriverDeviceLock(object):
         )
         driver.lock(1)
 
-        d = httpretty_last_request_body(httpretty.last_request())
+        d = get_httpretty_request_body(httpretty.last_request())
         assert d['seconds'] == 1
 
     @httpretty.activate
@@ -48,7 +48,7 @@ class TestWebDriverDeviceLock(object):
         )
         driver.lock()
 
-        d = httpretty_last_request_body(httpretty.last_request())
+        d = get_httpretty_request_body(httpretty.last_request())
         assert len(d.keys()) == 1
         assert d['sessionId'] == '1234567890'
 

--- a/test/unit/webdriver/device/lock_test.py
+++ b/test/unit/webdriver/device/lock_test.py
@@ -12,7 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from test.unit.helper.test_helper import appium_command, android_w3c_driver, ios_w3c_driver
+from test.unit.helper.test_helper import (
+    appium_command,
+    android_w3c_driver,
+    ios_w3c_driver,
+    httpretty_last_request_body
+)
 
 import json
 import httpretty
@@ -29,7 +34,8 @@ class TestWebDriverDeviceLock(object):
             body='{"value": ""}'
         )
         driver.lock(1)
-        d = json.loads(httpretty.last_request().body.decode('utf-8'))
+
+        d = httpretty_last_request_body(httpretty.last_request())
         assert d['seconds'] == 1
 
     @httpretty.activate
@@ -41,8 +47,8 @@ class TestWebDriverDeviceLock(object):
             body='{"value": ""}'
         )
         driver.lock()
-        d = json.loads(httpretty.last_request().body.decode('utf-8'))
 
+        d = httpretty_last_request_body(httpretty.last_request())
         assert len(d.keys()) == 1
         assert d['sessionId'] == '1234567890'
 

--- a/test/unit/webdriver/device/network_test.py
+++ b/test/unit/webdriver/device/network_test.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 
-from appium.webdriver.webdriver import WebDriver
 from test.unit.helper.test_helper import (
     appium_command,
     android_w3c_driver,
@@ -21,6 +20,8 @@ from test.unit.helper.test_helper import (
 )
 
 import httpretty
+
+from appium.webdriver.webdriver import WebDriver
 
 
 class TestWebDriverNetwork(object):

--- a/test/unit/webdriver/device/network_test.py
+++ b/test/unit/webdriver/device/network_test.py
@@ -16,7 +16,7 @@
 from test.unit.helper.test_helper import (
     appium_command,
     android_w3c_driver,
-    httpretty_last_request_body
+    get_httpretty_request_body
 )
 
 import httpretty
@@ -46,7 +46,7 @@ class TestWebDriverNetwork(object):
         )
         driver.set_network_connection(2)
 
-        d = httpretty_last_request_body(httpretty.last_request())
+        d = get_httpretty_request_body(httpretty.last_request())
         assert d['parameters']['type'] == 2
 
     @httpretty.activate

--- a/test/unit/webdriver/device/network_test.py
+++ b/test/unit/webdriver/device/network_test.py
@@ -12,11 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
 from appium.webdriver.webdriver import WebDriver
-from test.unit.helper.test_helper import appium_command, android_w3c_driver
+from test.unit.helper.test_helper import (
+    appium_command,
+    android_w3c_driver,
+    httpretty_last_request_body
+)
 
 import httpretty
-import json
 
 
 class TestWebDriverNetwork(object):
@@ -41,7 +45,7 @@ class TestWebDriverNetwork(object):
         )
         driver.set_network_connection(2)
 
-        d = json.loads(httpretty.last_request().body.decode('utf-8'))
+        d = httpretty_last_request_body(httpretty.last_request())
         assert d['parameters']['type'] == 2
 
     @httpretty.activate


### PR DESCRIPTION
Add a shortcut to decode `httpretty.last_request().body` with utf-8 in order to reduce writing `decode('utf-8')` everytime