### PR TITLE
Add direct connect flag to be able to handle directConnectXxxxc

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,10 +154,34 @@ desired_caps['app'] = PATH('../../apps/UICatalog.app.zip')
 self.driver = webdriver.Remote('http://localhost:4723/wd/hub', desired_caps)
 ```
 
-
 ## Changed or added functionality
 
 The methods that do change are...
+
+### Direct Connect URLs
+
+If your Selenium/Appium server decorates the new session capabilities response with the following keys:
+
+- `directConnectProtocol`
+- `directConnectHost`
+- `directConnectPort`
+- `directConnectPath`
+
+Then python client will switch its endpoint to the one specified by the values of those keys.
+
+```python
+import unittest
+from appium import webdriver
+
+desired_caps = {}
+desired_caps['platformName'] = 'iOS'
+desired_caps['platformVersion'] = '11.4'
+desired_caps['automationName'] = 'xcuitest'
+desired_caps['deviceName'] = 'iPhone Simulator'
+desired_caps['app'] = PATH('../../apps/UICatalog.app.zip')
+
+self.driver = webdriver.Remote('http://localhost:4723/wd/hub', desired_caps, direct_connection=True)
+```
 
 
 ### Switching between 'Native' and 'Webview'

--- a/appium/common/logger.py
+++ b/appium/common/logger.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import sys
+
+
+def setup_logger(level=logging.NOTSET):
+    logger.propagate = False
+    logger.setLevel(level)
+    handler = logging.StreamHandler(stream=sys.stderr)
+    logger.addHandler(handler)
+
+
+# global logger
+logger = logging.getLogger(__name__)
+setup_logger()

--- a/appium/webdriver/webdriver.py
+++ b/appium/webdriver/webdriver.py
@@ -129,7 +129,7 @@ class WebDriver(
             proxy
         )
 
-        if self.command_executor is not None:  # pylint: disable=access-member-before-definition
+        if hasattr(self, 'command_executor'):
             self._addCommands()
 
         self.error_handler = MobileErrorHandler()
@@ -156,13 +156,9 @@ class WebDriver(
         direct_path = 'directConnectPath'
 
         if (not {direct_protocol, direct_host, direct_port, direct_path}.issubset(set(self.capabilities))):
-            message = 'Direct connect capabilities from server were:\n'\
-                '{protocol}: {protocol_get},  {host}: {host_get}, {port}: {port_get}, {path}: {path_get}'.format(
-                    protocol=direct_protocol, protocol_get=self.capabilities.get(direct_protocol, ''),
-                    host=direct_host, host_get=self.capabilities.get(direct_host, ''),
-                    port=direct_port, port_get=self.capabilities.get(direct_port, ''),
-                    path=direct_path, path_get=self.capabilities.get(direct_path, ''),
-                )
+            message = 'Direct connect capabilities from server were:\n'
+            for key in [direct_protocol, direct_host, direct_port, direct_path]:
+                message += '{}: \'{}\'\n'.format(key, self.capabilities.get(key, ''))
             logger.warning(message)
             return
 

--- a/appium/webdriver/webdriver.py
+++ b/appium/webdriver/webdriver.py
@@ -150,10 +150,26 @@ class WebDriver(
 
     def _update_command_executor(self, keep_alive):
         """Update command executor following directConnect feature"""
-        protocol = self.capabilities['directConnectProtocol']
-        hostname = self.capabilities['directConnectHost']
-        port = self.capabilities['directConnectPort']
-        path = self.capabilities['directConnectPath']
+        direct_protocol = 'directConnectProtocol'
+        direct_host = 'directConnectHost'
+        direct_port = 'directConnectPort'
+        direct_path = 'directConnectPath'
+
+        if (not {direct_protocol, direct_host, direct_port, direct_path}.issubset(set(self.capabilities))):
+            message = 'Could get direct capabilities:\n'\
+                '{protocol}: {protocol_get},  {host}: {host_get}, {port}: {port_get}, {path}: {path_get}'.format(
+                    protocol=direct_protocol, protocol_get=self.capabilities.get(direct_protocol, ''),
+                    host=direct_host, host_get=self.capabilities.get(direct_host, ''),
+                    port=direct_port, port_get=self.capabilities.get(direct_port, ''),
+                    path=direct_path, path_get=self.capabilities.get(direct_path, ''),
+                )
+            logger.warning(message)
+            return
+
+        protocol = self.capabilities[direct_protocol]
+        hostname = self.capabilities[direct_host]
+        port = self.capabilities[direct_port]
+        path = self.capabilities[direct_path]
         executor = '{scheme}://{hostname}:{port}{path}'.format(
             scheme=protocol,
             hostname=hostname,
@@ -161,7 +177,7 @@ class WebDriver(
             path=path
         )
 
-        logger.info('Update request endpoint to %s', executor)
+        logger.info('Updated request endpoint to %s', executor)
         # Override command executor
         self.command_executor = RemoteConnection(executor, keep_alive=keep_alive)
         self._addCommands()

--- a/appium/webdriver/webdriver.py
+++ b/appium/webdriver/webdriver.py
@@ -156,7 +156,7 @@ class WebDriver(
         direct_path = 'directConnectPath'
 
         if (not {direct_protocol, direct_host, direct_port, direct_path}.issubset(set(self.capabilities))):
-            message = 'Could get direct capabilities:\n'\
+            message = 'Direct connect capabilities from server were:\n'\
                 '{protocol}: {protocol_get},  {host}: {host_get}, {port}: {port_get}, {path}: {path_get}'.format(
                     protocol=direct_protocol, protocol_get=self.capabilities.get(direct_protocol, ''),
                     host=direct_host, host_get=self.capabilities.get(direct_host, ''),

--- a/appium/webdriver/webdriver.py
+++ b/appium/webdriver/webdriver.py
@@ -161,7 +161,7 @@ class WebDriver(
             path=path
         )
 
-        logger.error('Update request endpoint to %s', executor)
+        logger.info('Update request endpoint to %s', executor)
         # Override command executor
         self.command_executor = RemoteConnection(executor, keep_alive=keep_alive)
         self._addCommands()

--- a/appium/webdriver/webdriver.py
+++ b/appium/webdriver/webdriver.py
@@ -135,19 +135,7 @@ class WebDriver(
         self._switch_to = MobileSwitchTo(self)
 
         if direct_connection:
-            protocol = self.capabilities['directConnectProtocol']
-            hostname = self.capabilities['directConnectHost']
-            port = self.capabilities['directConnectPort']
-            path = self.capabilities['directConnectPath']
-            executor = '{scheme}://{hostname}:{port}{path}'.format(
-                scheme=protocol,
-                hostname=hostname,
-                port=port,
-                path=path
-            )
-            # Override command executor
-            self.command_executor = RemoteConnection(executor, keep_alive=keep_alive)
-            self._addCommands()
+            self._update_command_executor(keep_alive=keep_alive)
 
         # add new method to the `find_by_*` pantheon
         By.IOS_UIAUTOMATION = MobileBy.IOS_UIAUTOMATION
@@ -158,6 +146,22 @@ class WebDriver(
         By.ACCESSIBILITY_ID = MobileBy.ACCESSIBILITY_ID
         By.IMAGE = MobileBy.IMAGE
         By.CUSTOM = MobileBy.CUSTOM
+
+    def _update_command_executor(self, keep_alive):
+        """Update command executor following directConnect feature"""
+        protocol = self.capabilities['directConnectProtocol']
+        hostname = self.capabilities['directConnectHost']
+        port = self.capabilities['directConnectPort']
+        path = self.capabilities['directConnectPath']
+        executor = '{scheme}://{hostname}:{port}{path}'.format(
+            scheme=protocol,
+            hostname=hostname,
+            port=port,
+            path=path
+        )
+        # Override command executor
+        self.command_executor = RemoteConnection(executor, keep_alive=keep_alive)
+        self._addCommands()
 
     def start_session(self, capabilities, browser_profile=None):
         """

--- a/appium/webdriver/webdriver.py
+++ b/appium/webdriver/webdriver.py
@@ -45,6 +45,7 @@ from .mobilecommand import MobileCommand as Command
 from .switch_to import MobileSwitchTo
 from .webelement import WebElement as MobileWebElement
 
+from appium.common.logger import logger
 
 # From remote/webdriver.py
 _W3C_CAPABILITY_NAMES = frozenset([
@@ -159,6 +160,8 @@ class WebDriver(
             port=port,
             path=path
         )
+
+        logger.error('Update request endpoint to %s', executor)
         # Override command executor
         self.command_executor = RemoteConnection(executor, keep_alive=keep_alive)
         self._addCommands()

--- a/appium/webdriver/webdriver.py
+++ b/appium/webdriver/webdriver.py
@@ -139,7 +139,6 @@ class WebDriver(
             hostname = self.capabilities['directConnectHost']
             port = self.capabilities['directConnectPort']
             path = self.capabilities['directConnectPath']
-            # TODO: create a new client to the above params
             executor = '{scheme}://{hostname}:{port}{path}'.format(
                 scheme=protocol,
                 hostname=hostname,

--- a/test/unit/webdriver/webdriver_test.py
+++ b/test/unit/webdriver/webdriver_test.py
@@ -214,3 +214,40 @@ class TestWebDriverWebDriver(object):
 
         assert 'http://localhost2:4800/special/path/wd/hub' == driver.command_executor._url
         assert ['NATIVE_APP', 'CHROMIUM'] == driver.contexts
+
+    @httpretty.activate
+    def test_create_session_register_uridirect_no_direct_connect_path(self):
+        httpretty.register_uri(
+            httpretty.POST,
+            'http://localhost:4723/wd/hub/session',
+            body=json.dumps({'value': {
+                'sessionId': 'session-id',
+                'capabilities': {
+                    'deviceName': 'Android Emulator',
+                    'directConnectProtocol': 'http',
+                    'directConnectHost': 'localhost2',
+                    'directConnectPort': 4800
+                }
+            }})
+        )
+
+        httpretty.register_uri(
+            httpretty.GET,
+            'http://localhost:4723/wd/hub/session/session-id/contexts',
+            body=json.dumps({'value': ['NATIVE_APP', 'CHROMIUM']})
+        )
+
+        desired_caps = {
+            'platformName': 'Android',
+            'deviceName': 'Android Emulator',
+            'app': 'path/to/app',
+            'automationName': 'UIAutomator2'
+        }
+        driver = webdriver.Remote(
+            'http://localhost:4723/wd/hub',
+            desired_caps,
+            direct_connection=True
+        )
+
+        assert 'http://localhost:4723/wd/hub' == driver.command_executor._url
+        assert ['NATIVE_APP', 'CHROMIUM'] == driver.contexts


### PR DESCRIPTION
This feature is the same as https://github.com/projectxyzio/web2driver#direct-connect-urls and https://www.rubydoc.info/github/appium/ruby_lib_core/Appium/Core/Driver#direct_connect-instance_method

Use case:

- If a user has a proxy server such as SeleniumGrid as below, an Appium client communicate with Appium servers via the proxy every command.
    ```
    # via proxy server in session creation
    client <--> proxy server <---> appium server <-> devices
                                                 `-> appium server <-> devices
    ```
    - Then, the communication takes additional seconds between the client and servers. The proxy server is if in the US and the Appium server is in Europ, the time increases more.
    - To reduce the delay, we can distribute the proxy server to each reason, but it increases the complexity of the proxy server management.
- If we can make such communication directly with the client and servers, it can reduce the time easily.
    ```
    # communicate directly after the session creation
    client <--------> appium server <-> devices
                       `---> appium server <-> devices
    ```
    - The first create session command takes the additional time, but the following commands can communicate with servers directly with less communication latency.
        - We can manage a bunch of custom urls in a client side, but it increases management complexity in the client side.


I've added `direct_connection` flag, and it is false by default, to be able to handle the flag.

Different as SeleniumGrid, mobile apps tie to physical locations. Measuring performance including network latency is necessary to manage devices in various locations, for example. In such case, one proxy server and Appium servers in various locations make easy to manage the complexity. The proxy has device selection logic. The client only sends a session creation command to the proxy, no many URLs.

---

cc @jlipps 