### PR TITLE
Fix RuntimeError: maximum recursion depth exceeded in cmp happened

### DIFF
--- a/appium/webdriver/webdriver.py
+++ b/appium/webdriver/webdriver.py
@@ -595,10 +595,16 @@ class WebDriver(
 
     # pylint: disable=protected-access
 
-    def _get_mro_subtuple(self, mro):
+    def _get_webdriver_parents(self, mro):
         """
         Get Method Resolution Order after `appium.webdriver.webdriver.WebDriver`
         to avoid __addCommands loop in `appium.webdriver.webdriver.WebDriver`
+
+        :Args:
+            - Tuple of Method Resolution Order
+        :Raises:
+            - ValueError: If the MRO has no 'appium.webdriver.webdriver.WebDriver',
+            it raises 'tuple.index(x): x not in tuple' error
         """
         m = tuple(map(lambda x: '{}.{}'.format(x.__module__, x.__name__), mro))
         wd_index = m.index('{}.WebDriver'.format(__name__))
@@ -609,7 +615,7 @@ class WebDriver(
         # call the overridden command binders from all mixin classes except for
         # appium.webdriver.webdriver.WebDriver and its sub-classes
         # https://github.com/appium/python-client/issues/342
-        for mixin_class in self._get_subtuple(self.__class__.__mro__):
+        for mixin_class in self._get_webdriver_parents(self.__class__.__mro__):
             if hasattr(mixin_class, self._addCommands.__name__):
                 getattr(mixin_class, self._addCommands.__name__, None)(self)
 

--- a/appium/webdriver/webdriver.py
+++ b/appium/webdriver/webdriver.py
@@ -595,27 +595,11 @@ class WebDriver(
 
     # pylint: disable=protected-access
 
-    def _get_webdriver_parents(self, mro):
-        """
-        Get Method Resolution Order after `appium.webdriver.webdriver.WebDriver`
-        to avoid __addCommands loop in `appium.webdriver.webdriver.WebDriver`
-
-        :Args:
-            - Tuple of Method Resolution Order
-        :Raises:
-            - ValueError: If the MRO has no 'appium.webdriver.webdriver.WebDriver',
-            it raises 'tuple.index(x): x not in tuple' error
-        """
-        m = tuple(map(lambda x: '{}.{}'.format(x.__module__, x.__name__), mro))
-        wd_index = m.index('{}.WebDriver'.format(__name__))
-
-        return mro[(wd_index + 1):]
-
     def _addCommands(self):
         # call the overridden command binders from all mixin classes except for
         # appium.webdriver.webdriver.WebDriver and its sub-classes
         # https://github.com/appium/python-client/issues/342
-        for mixin_class in self._get_webdriver_parents(self.__class__.__mro__):
+        for mixin_class in filter(lambda x: not issubclass(x, WebDriver), self.__class__.__mro__):
             if hasattr(mixin_class, self._addCommands.__name__):
                 getattr(mixin_class, self._addCommands.__name__, None)(self)
 

--- a/test/unit/webdriver/webdriver_test.py
+++ b/test/unit/webdriver/webdriver_test.py
@@ -340,3 +340,12 @@ class TestSubModuleWebDriver(object):
             body='{"value": "NATIVE"}'
         )
         assert driver.current_context == 'NATIVE'
+
+    @httpretty.activate
+    def test_compare_commands(self):
+        driver_base = android_w3c_driver()
+        driver_sub = self.android_w3c_driver(SubWebDriver)
+        driver_subsub = self.android_w3c_driver(SubSubWebDriver)
+
+        assert len(driver_base.command_executor._commands) == len(driver_sub.command_executor._commands)
+        assert len(driver_base.command_executor._commands) == len(driver_subsub.command_executor._commands)


### PR DESCRIPTION
Fix _RuntimeError: maximum recursion depth exceeded in cmp happened #342_

`self.__class__.__mro__` returns below:

> (<class 'webdriver_test.SubSubWebDriver'>, <class 'webdriver_test.SubWebDriver'>, <class 'appium.webdriver.webdriver.WebDriver'>, <class 'appium.webdriver.extensions.search_context.AppiumSearchContext'>, <class 'appium.webdriver.extensions.action_helpers.ActionHelpers'>, <class 'appium.webdriver.extensions.activities.Activities'>, <class 'appium.webdriver.extensions.applications.Applications'>, <class 'appium.webdriver.extensions.clipboard.Clipboard'>, <class 'appium.webdriver.extensions.context.Context'>, <class 'appium.webdriver.extensions.device_time.DeviceTime'>, <class 'appium.webdriver.extensions.hw_actions.HardwareActions'>, <class 'appium.webdriver.extensions.images_comparison.ImagesComparison'>, <class 'appium.webdriver.extensions.ime.IME'>, <class 'appium.webdriver.extensions.keyboard.Keyboard'>, <class 'appium.webdriver.extensions.location.Location'>, <class 'appium.webdriver.extensions.network.Network'>, <class 'appium.webdriver.extensions.remote_fs.RemoteFS'>, <class 'appium.webdriver.extensions.screen_record.ScreenRecord'>, <class 'selenium.webdriver.remote.webdriver.WebDriver'>, <class 'appium.webdriver.extensions.search_context.AndroidSearchContext'>, <class 'appium.webdriver.extensions.search_context.BaseSearchContext'>, <type 'object'>)

With current implementation, only `<class 'webdriver_test.SubSubWebDriver'>` is skipped.
`maximum recursion depth exceeded ` error happens if `appium.webdriver.webdriver.WebDriver'` is called.

To avoid the issue, I changed to get `<class 'appium.webdriver.extensions.search_context.AppiumSearchContext'>, <class 'appium.webdriver.extensions.action_helpers.ActionHelpers'>, <class 'appium.webdriver.extensions.activities.Activities'>,....` (get only parents of `appium.webdriver.webdriver.WebDriver`)
