### PR TITLE
Resolve ci exception log on py37

### DIFF
--- a/ci-requirements-py2.txt
+++ b/ci-requirements-py2.txt
@@ -1,0 +1,2 @@
+astroid==1.6.5
+pylint==1.9.3

--- a/ci-requirements-py3.txt
+++ b/ci-requirements-py3.txt
@@ -1,0 +1,2 @@
+astroid==2.2.5
+pylint==2.3.1

--- a/ci-requirements.txt
+++ b/ci-requirements.txt
@@ -1,7 +1,5 @@
 selenium==3.141.0
-astroid==1.6.5
 isort==4.3.4
-pylint==1.9.3
 autopep8==1.4.3
 httpretty==0.9.6
 pytest==4.0.2

--- a/tox.ini
+++ b/tox.ini
@@ -7,8 +7,16 @@ envlist =
     py36,
     py37
 
+[testenv:py27]
+deps =
+    -r ci-requirements.txt
+    -r ci-requirements-py2.txt
+commands =
+    ./ci.sh
+
 [testenv]
 deps =
     -r ci-requirements.txt
+    -r ci-requirements-py3.txt
 commands =
     ./ci.sh


### PR DESCRIPTION
* Exception log
   * https://travis-ci.org/appium/python-client/jobs/527252733
   * Actually, this exception log is no impact to results.

* Resolved exception log
   * https://travis-ci.org/appium/python-client/jobs/527311285

* How to resolve
   * Upgraded astroid and pylint for python3
   * Can't be upgraded for python2 since the latest astroid is unavailable on python2.