### PR TITLE
fix poll_url in Python 3

### DIFF
--- a/appium/webdriver/appium_service.py
+++ b/appium/webdriver/appium_service.py
@@ -13,12 +13,11 @@
 # limitations under the License.
 
 
-import httplib
 import os
 import subprocess
 import sys
 import time
-
+import urllib3
 
 DEFAULT_HOST = '127.0.0.1'
 DEFAULT_PORT = 4723
@@ -49,9 +48,10 @@ def poll_url(host, port, path, timeout_ms):
     time_started_sec = time.time()
     while time.time() < time_started_sec + timeout_ms / 1000.0:
         try:
-            conn = httplib.HTTPConnection(host=host, port=port, timeout=1.0)
-            conn.request('HEAD', path)
-            if conn.getresponse().status < 400:
+            conn = urllib3.PoolManager(timeout=1.0)
+            resp = conn.request('HEAD', 'http://{host}:{port}{path}'.format(
+                host=host, port=port, path=path))
+            if resp.status < 400:
                 return True
         except Exception:
             pass

--- a/test/unit/webdriver/appium_service_test.py
+++ b/test/unit/webdriver/appium_service_test.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from appium.webdriver.appium_service import AppiumService
+
+
+class TestAppiumService(object):
+    def test_get_instance(self):
+        assert AppiumService()


### PR DESCRIPTION
closes https://github.com/appium/python-client/issues/369

`httplib` is available only in Python 2 environment.
SImply, I replaced the http request checking with `PoolManager`.

I tested locally in both Python 2 and 3 env.
Added a simple test case to ensure it can load in both python 2 and 3 environments. 