### PR TITLE
Assign w3c property on the command executor.

### DIFF
--- a/appium/webdriver/webdriver.py
+++ b/appium/webdriver/webdriver.py
@@ -226,6 +226,7 @@ class WebDriver(
 
         # Double check to see if we have a W3C Compliant browser
         self.w3c = response.get('status') is None
+        self.command_executor.w3c = self.w3c
 
     def _merge_capabilities(self, capabilities):
         """


### PR DESCRIPTION
When we call `start_session()` on the webdriver we assign the w3c capabilities on the driver but not on the command_executor which then means that when we execute a command we do not remove the sessionId from the request which regresses from this change https://github.com/SeleniumHQ/selenium/commit/e6c2e7069c10852917846231439eeb807cd2e821.