### PR TITLE
Get rid of sessionId from some tests

### DIFF
--- a/test/unit/webdriver/device/activities_test.py
+++ b/test/unit/webdriver/device/activities_test.py
@@ -34,7 +34,6 @@ class TestWebDriverDeviceActivities(object):
         driver.start_activity('com.example.myapp', '.ExampleActivity')
 
         d = get_httpretty_request_body(httpretty.last_request())
-        assert d['sessionId'] == '1234567890'
         assert d['appPackage'] == 'com.example.myapp'
         assert d['appActivity'] == '.ExampleActivity'
 
@@ -58,7 +57,6 @@ class TestWebDriverDeviceActivities(object):
         )
 
         d = get_httpretty_request_body(httpretty.last_request())
-        assert d['sessionId'] == '1234567890'
         assert d['appPackage'] == 'com.example.myapp'
         assert d['appActivity'] == '.ExampleActivity'
         assert d['appWaitPackage'] == 'com.example.waitapp'

--- a/test/unit/webdriver/device/lock_test.py
+++ b/test/unit/webdriver/device/lock_test.py
@@ -48,7 +48,6 @@ class TestWebDriverDeviceLock(object):
 
         d = get_httpretty_request_body(httpretty.last_request())
         assert len(d.keys()) == 1
-        assert d['sessionId'] == '1234567890'
 
     @httpretty.activate
     def test_islocked_false(self):


### PR DESCRIPTION
fixes https://travis-ci.org/appium/python-client/builds/533748403

They are not necessary to check.
sessionId is handled by MJSONWP mode. 
After https://github.com/appium/python-client/pull/382 , the driver will start as W3C mode. (expected behaviour)