### PR TITLE
Support set_network_speed

### DIFF
--- a/appium/webdriver/extensions/android/gsm.py
+++ b/appium/webdriver/extensions/android/gsm.py
@@ -52,7 +52,8 @@ class Gsm(webdriver.Remote):
 
         :Args:
          - phone_number (str): The phone number to call to.
-         - action (str): The call action - GsmCallActions.CALL/ACCEPT/CANCEL/HOLD
+         - action (str): The call action.
+           A member of the const appium.webdriver.extensions.android.gsm.GsmCallActions
 
         :Usage:
             self.driver.make_gsm_call('5551234567', GsmCallActions.CALL)
@@ -69,7 +70,8 @@ class Gsm(webdriver.Remote):
         Android only.
 
         :Args:
-         - strength (int): Signal strength - GsmSignalStrength.NONE_OR_UNKNOWN/POOR/MODERATE/GOOD/GREAT
+         - strength (int): Signal strength.
+           A member of the enum appium.webdriver.extensions.android.gsm.GsmSignalStrength
 
         :Usage:
             self.driver.set_gsm_signal(GsmSignalStrength.GOOD)
@@ -86,7 +88,8 @@ class Gsm(webdriver.Remote):
         Android only.
 
         :Args:
-         - state(str): State of GSM voice - GsmVoiceState.UNREGISTERED/HOME/ROAMING/SEARCHING/DENIED/OFF/ON
+         - state(str): State of GSM voice.
+           A member of the const appium.webdriver.extensions.android.gsm.GsmVoiceState
 
         :Usage:
             self.driver.set_gsm_voice(GsmVoiceState.HOME)

--- a/appium/webdriver/extensions/android/network.py
+++ b/appium/webdriver/extensions/android/network.py
@@ -14,11 +14,13 @@
 
 from selenium import webdriver
 
+from appium.common.helper import extract_const_attributes
+from appium.common.logger import logger
 from appium.webdriver.mobilecommand import MobileCommand as Command
 
 
 class NetSpeed(object):
-    GSM = 'gsm'  # GSM/CSD (up: 14.4, down: 14.4)
+    GSM = 'gsm'  # GSM/CSD (up: 14.4(kbps), down: 14.4(kbps))
     SCSD = 'scsd'  # HSCSD (up: 14.4, down: 57.6)
     GPRS = 'gprs'  # GPRS (up: 28.8, down: 57.6)
     EDGE = 'edge'  # EDGE/EGPRS (up: 473.6, down: 473.6)
@@ -52,7 +54,7 @@ class Network(webdriver.Remote):
         These are available through the enumeration `appium.webdriver.ConnectionType`
 
         :Args:
-         - connectionType - a member of the enum appium.webdriver.ConnectionType
+         - connection_type - a member of the enum appium.webdriver.ConnectionType
         """
         data = {
             'parameters': {
@@ -68,12 +70,23 @@ class Network(webdriver.Remote):
         self.execute(Command.TOGGLE_WIFI, {})
         return self
 
-    def set_network_speed(self, speed):
-        """
+    def set_network_speed(self, speed_type):
+        """Set the network speed emulation.
+        Android Emulator only.
 
-        :return:
+        :Args:
+         - speed_type (str): The network speed type.
+           A member of the const appium.webdriver.extensions.android.network.NetSpeed.
+
+        :Usage:
+            self.driver.set_network_speed(NetSpeed.LTE)
         """
-        self.execute(Command.SET_NETWORK_SPEED, {'netspeed': speed})
+        constants = extract_const_attributes(NetSpeed)
+        if speed_type not in constants.values():
+            logger.warning('{} is unknown. Consider using one of {} constants. (e.g. {}.LTE)'.format(
+                speed_type, list(constants.keys()), NetSpeed.__name__))
+
+        self.execute(Command.SET_NETWORK_SPEED, {'netspeed': speed_type})
         return self
 
     # pylint: disable=protected-access

--- a/appium/webdriver/extensions/android/network.py
+++ b/appium/webdriver/extensions/android/network.py
@@ -61,8 +61,7 @@ class Network(webdriver.Remote):
                 'type': connection_type
             }
         }
-        self.execute(Command.SET_NETWORK_CONNECTION, data)
-        return self
+        return self.execute(Command.SET_NETWORK_CONNECTION, data)['value']
 
     def toggle_wifi(self):
         """Toggle the wifi on the device, Android only.

--- a/appium/webdriver/extensions/android/network.py
+++ b/appium/webdriver/extensions/android/network.py
@@ -17,6 +17,18 @@ from selenium import webdriver
 from appium.webdriver.mobilecommand import MobileCommand as Command
 
 
+class NetSpeed(object):
+    GSM = 'gsm'  # GSM/CSD (up: 14.4, down: 14.4)
+    SCSD = 'scsd'  # HSCSD (up: 14.4, down: 57.6)
+    GPRS = 'gprs'  # GPRS (up: 28.8, down: 57.6)
+    EDGE = 'edge'  # EDGE/EGPRS (up: 473.6, down: 473.6)
+    UMTS = 'umts'  # UMTS/3G (up: 384.0, down: 384.0)
+    HSDPA = 'hsdpa'  # HSDPA (up: 5760.0, down: 13,980.0)
+    LTE = 'lte'  # LTE (up: 58,000, down: 173,000)
+    EVDO = 'evdo'  # EVDO (up: 75,000, down: 280,000)
+    FULL = 'full'  # No limit, the default (up: 0.0, down: 0.0)
+
+
 class Network(webdriver.Remote):
 
     @property
@@ -47,12 +59,21 @@ class Network(webdriver.Remote):
                 'type': connection_type
             }
         }
-        return self.execute(Command.SET_NETWORK_CONNECTION, data)['value']
+        self.execute(Command.SET_NETWORK_CONNECTION, data)
+        return self
 
     def toggle_wifi(self):
         """Toggle the wifi on the device, Android only.
         """
         self.execute(Command.TOGGLE_WIFI, {})
+        return self
+
+    def set_network_speed(self, speed):
+        """
+
+        :return:
+        """
+        self.execute(Command.SET_NETWORK_SPEED, {'netspeed': speed})
         return self
 
     # pylint: disable=protected-access
@@ -64,3 +85,5 @@ class Network(webdriver.Remote):
             ('GET', '/session/$sessionId/network_connection')
         self.command_executor._commands[Command.SET_NETWORK_CONNECTION] = \
             ('POST', '/session/$sessionId/network_connection')
+        self.command_executor._commands[Command.SET_NETWORK_SPEED] = \
+            ('POST', '/session/$sessionId/appium/device/network_speed')

--- a/appium/webdriver/mobilecommand.py
+++ b/appium/webdriver/mobilecommand.py
@@ -85,6 +85,7 @@ class MobileCommand(object):
     GET_PERFORMANCE_DATA = 'getPerformanceData'
     GET_NETWORK_CONNECTION = 'getNetworkConnection'
     SET_NETWORK_CONNECTION = 'setNetworkConnection'
+    SET_NETWORK_SPEED = 'setNetworkSpeed'
 
     # Android Emulator
     SEND_SMS = 'sendSms'

--- a/test/unit/webdriver/device/network_test.py
+++ b/test/unit/webdriver/device/network_test.py
@@ -21,6 +21,7 @@ from test.unit.helper.test_helper import (
 
 import httpretty
 
+from appium.webdriver.extensions.android.network import NetSpeed
 from appium.webdriver.webdriver import WebDriver
 
 
@@ -44,10 +45,22 @@ class TestWebDriverNetwork(object):
             appium_command('/session/1234567890/network_connection'),
             body='{"value": ""}'
         )
-        driver.set_network_connection(2)
+        assert isinstance(driver.set_network_connection(2), WebDriver)
 
         d = get_httpretty_request_body(httpretty.last_request())
         assert d['parameters']['type'] == 2
+
+    @httpretty.activate
+    def test_set_network_speed(self):
+        driver = android_w3c_driver()
+        httpretty.register_uri(
+            httpretty.POST,
+            appium_command('/session/1234567890/appium/device/network_speed'),
+        )
+        assert isinstance(driver.set_network_speed(NetSpeed.LTE), WebDriver)
+
+        d = get_httpretty_request_body(httpretty.last_request())
+        assert d['netspeed'] == NetSpeed.LTE
 
     @httpretty.activate
     def test_toggle_wifi(self):

--- a/test/unit/webdriver/device/network_test.py
+++ b/test/unit/webdriver/device/network_test.py
@@ -45,7 +45,7 @@ class TestWebDriverNetwork(object):
             appium_command('/session/1234567890/network_connection'),
             body='{"value": ""}'
         )
-        assert isinstance(driver.set_network_connection(2), WebDriver)
+        driver.set_network_connection(2)
 
         d = get_httpretty_request_body(httpretty.last_request())
         assert d['parameters']['type'] == 2


### PR DESCRIPTION
It's missing api support.

I've noticed by comparing below 2 files.
* https://github.com/appium/python-client/blob/master/appium/webdriver/mobilecommand.py
* https://github.com/appium/ruby_lib_core/blob/fd2cbde5466a144ce8dccfc6cf330b969bcc8fd3/lib/appium_lib_core/common/command/common.rb