### PR TITLE
Support get_display_density

### DIFF
--- a/appium/webdriver/extensions/android/display.py
+++ b/appium/webdriver/extensions/android/display.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from selenium import webdriver
+
+from appium.webdriver.mobilecommand import MobileCommand as Command
+
+
+class Display(webdriver.Remote):
+
+    def get_display_density(self):
+        """
+        """
+        return self.execute(Command.GET_DISPLAY_DENSITY)['value']
+
+    # pylint: disable=protected-access
+
+    def _addCommands(self):
+        self.command_executor._commands[Command.GET_DISPLAY_DENSITY] = \
+            ('GET', '/session/$sessionId/appium/device/display_density')

--- a/appium/webdriver/extensions/android/display.py
+++ b/appium/webdriver/extensions/android/display.py
@@ -22,6 +22,9 @@ class Display(webdriver.Remote):
     def get_display_density(self):
         """Get the display density, Android only
 
+        :Returns:
+            int: The display density of the Android device(dpi)
+
         :Usage:
             self.driver.get_display_density()
         """

--- a/appium/webdriver/extensions/android/display.py
+++ b/appium/webdriver/extensions/android/display.py
@@ -20,7 +20,10 @@ from appium.webdriver.mobilecommand import MobileCommand as Command
 class Display(webdriver.Remote):
 
     def get_display_density(self):
-        """
+        """Get the display density, Android only
+
+        :Usage:
+            self.driver.get_display_density()
         """
         return self.execute(Command.GET_DISPLAY_DENSITY)['value']
 

--- a/appium/webdriver/mobilecommand.py
+++ b/appium/webdriver/mobilecommand.py
@@ -78,6 +78,7 @@ class MobileCommand(object):
     GET_CURRENT_ACTIVITY = 'getCurrentActivity'
     GET_CURRENT_PACKAGE = 'getCurrentPackage'
     GET_SYSTEM_BARS = 'getSystemBars'
+    GET_DISPLAY_DENSITY = 'getDisplayDensity'
     TOGGLE_WIFI = 'toggleWiFi'
     TOGGLE_LOCATION_SERVICES = 'toggleLocationServices'
     END_TEST_COVERAGE = 'endTestCoverage'

--- a/appium/webdriver/mobilecommand.py
+++ b/appium/webdriver/mobilecommand.py
@@ -86,13 +86,13 @@ class MobileCommand(object):
     GET_PERFORMANCE_DATA = 'getPerformanceData'
     GET_NETWORK_CONNECTION = 'getNetworkConnection'
     SET_NETWORK_CONNECTION = 'setNetworkConnection'
-    SET_NETWORK_SPEED = 'setNetworkSpeed'
 
     # Android Emulator
     SEND_SMS = 'sendSms'
     MAKE_GSM_CALL = 'makeGsmCall'
     SET_GSM_SIGNAL = 'setGsmSignal'
     SET_GSM_VOICE = 'setGsmVoice'
+    SET_NETWORK_SPEED = 'setNetworkSpeed'
     SET_POWER_CAPACITY = 'setPowerCapacity'
     SET_POWER_AC = 'setPowerAc'
 

--- a/appium/webdriver/webdriver.py
+++ b/appium/webdriver/webdriver.py
@@ -29,6 +29,7 @@ from .appium_connection import AppiumConnection
 from .errorhandler import MobileErrorHandler
 from .extensions.action_helpers import ActionHelpers
 from .extensions.android.activities import Activities
+from .extensions.android.display import Display
 from .extensions.android.gsm import Gsm
 from .extensions.android.network import Network
 from .extensions.android.performance import Performance
@@ -114,6 +115,7 @@ class WebDriver(
     Clipboard,
     Context,
     DeviceTime,
+    Display,
     Gsm,
     HardwareActions,
     ImagesComparison,

--- a/test/unit/webdriver/device/display.py
+++ b/test/unit/webdriver/device/display.py
@@ -12,11 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from test.unit.helper.test_helper import (
-    android_w3c_driver,
-    appium_command,
-    get_httpretty_request_body
-)
+from test.unit.helper.test_helper import android_w3c_driver, appium_command
 
 import httpretty
 

--- a/test/unit/webdriver/device/display.py
+++ b/test/unit/webdriver/device/display.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from test.unit.helper.test_helper import (
+    android_w3c_driver,
+    appium_command,
+    get_httpretty_request_body
+)
+
+import httpretty
+
+
+class TestWebDriverDisplay(object):
+
+    @httpretty.activate
+    def test_get_display_density(self):
+        driver = android_w3c_driver()
+        httpretty.register_uri(
+            httpretty.GET,
+            appium_command('/session/1234567890/appium/device/display_density'),
+            body='{"value": 560}'
+        )
+        assert driver.get_display_density() == 560


### PR DESCRIPTION
It's missing api support.
(It's the last one for now, I would say.)

I've noticed by comparing below 2 files.
* https://github.com/appium/python-client/blob/master/appium/webdriver/mobilecommand.py
* https://github.com/appium/ruby_lib_core/blob/fd2cbde5466a144ce8dccfc6cf330b969bcc8fd3/lib/appium_lib_core/common/command/common.rb