### PR TITLE
Fix: installed selenium4 when 'setup.py install'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,5 +54,5 @@ setup(
         'Topic :: Software Development :: Quality Assurance',
         'Topic :: Software Development :: Testing'
     ],
-    install_requires=['selenium<4']
+    install_requires=['selenium >= 3.14.1, < 4']
 )

--- a/setup.py
+++ b/setup.py
@@ -54,5 +54,5 @@ setup(
         'Topic :: Software Development :: Quality Assurance',
         'Topic :: Software Development :: Testing'
     ],
-    install_requires=['selenium>=3.14.1']
+    install_requires=['selenium<4']
 )


### PR DESCRIPTION
## Problem
When `Appium-Python-Client` is installed by `setup.py install`, `selenium4` is installed unexpectedly as resolving dependency.

It's problem when to setup environments on ci.

(But `pip install Appium-Python-Client` installs `selenium3` as resolving dependency.)

## Log

* Before

```
➜  python-client git:(fix-installed-selenium4) ✗ pip list
Package    Version
---------- -------
appdirs    1.4.3  
colorama   0.4.1  
pip        19.1.1 
setuptools 39.0.1 
➜  python-client git:(fix-installed-selenium4) ✗ python setup.py install                                                 
/Users/atsushimori/.pyenv/versions/3.7.1/lib/python3.7/distutils/dist.py:274: UserWarning: Unknown distribution option: 'long_description_content_type'
  warnings.warn(msg)
running install
(---snip---)
Searching for selenium>=3.14.1
Reading https://pypi.python.org/simple/selenium/
Downloading https://files.pythonhosted.org/packages/1d/f6/53b5244d8b39dfab61a1b11b20df7017d99e8b5aa9392297641a0322c2d4/selenium-4.0.0a1-py2.py3-none-any.whl#sha256=ea4afaf158108dfd77de848f7d57bb8152b22d862481468150206dec957bc13f
Best match: selenium 4.0.0a1
Processing selenium-4.0.0a1-py2.py3-none-any.whl
Installing selenium-4.0.0a1-py2.py3-none-any.whl to /Users/atsushimori/.pyenv/versions/3.7.1/lib/python3.7/site-packages
writing requirements to /Users/atsushimori/.pyenv/versions/3.7.1/lib/python3.7/site-packages/selenium-4.0.0a1-py3.7.egg/EGG-INFO/requires.txt
Adding selenium 4.0.0a1 to easy-install.pth file

Installed /Users/atsushimori/.pyenv/versions/3.7.1/lib/python3.7/site-packages/selenium-4.0.0a1-py3.7.egg
(---snip---)

Installed /Users/atsushimori/.pyenv/versions/3.7.1/lib/python3.7/site-packages/urllib3-1.25.2-py3.7.egg
Finished processing dependencies for Appium-Python-Client==0.43
```

* After

```
➜  python-client git:(fix-installed-selenium4) ✗ python setup.py install                            
/Users/atsushimori/.pyenv/versions/3.7.1/lib/python3.7/distutils/dist.py:274: UserWarning: Unknown distribution option: 'long_description_content_type'
  warnings.warn(msg)
running install
(---snip---)
Searching for selenium<4
Reading https://pypi.python.org/simple/selenium/
Downloading https://files.pythonhosted.org/packages/80/d6/4294f0b4bce4de0abf13e17190289f9d0613b0a44e5dd6a7f5ca98459853/selenium-3.141.0-py2.py3-none-any.whl#sha256=2d7131d7bc5a5b99a2d9b04aaf2612c411b03b8ca1b1ee8d3de5845a9be2cb3c
Best match: selenium 3.141.0
Processing selenium-3.141.0-py2.py3-none-any.whl
Installing selenium-3.141.0-py2.py3-none-any.whl to /Users/atsushimori/.pyenv/versions/3.7.1/lib/python3.7/site-packages
writing requirements to /Users/atsushimori/.pyenv/versions/3.7.1/lib/python3.7/site-packages/selenium-3.141.0-py3.7.egg/EGG-INFO/requires.txt
Adding selenium 3.141.0 to easy-install.pth file

Installed /Users/atsushimori/.pyenv/versions/3.7.1/lib/python3.7/site-packages/selenium-3.141.0-py3.7.egg
(---snip---)

Installed /Users/atsushimori/.pyenv/versions/3.7.1/lib/python3.7/site-packages/urllib3-1.25.2-py3.7.egg
Finished processing dependencies for Appium-Python-Client==0.43

```