### PR TITLE
Moving reset method from WebDriver to Applications

### DIFF
--- a/appium/webdriver/extensions/applications.py
+++ b/appium/webdriver/extensions/applications.py
@@ -183,6 +183,12 @@ class Applications(webdriver.Remote):
             data['stringFile'] = string_file
         return self.execute(Command.GET_APP_STRINGS, data)['value']
 
+    def reset(self):
+        """Resets the current application on the device.
+        """
+        self.execute(Command.RESET)
+        return self
+
     # pylint: disable=protected-access
 
     def _addCommands(self):
@@ -202,3 +208,5 @@ class Applications(webdriver.Remote):
             ('POST', '/session/$sessionId/appium/device/app_state')
         self.command_executor._commands[Command.GET_APP_STRINGS] = \
             ('POST', '/session/$sessionId/appium/app/strings')
+        self.command_executor._commands[Command.RESET] = \
+            ('POST', '/session/$sessionId/appium/app/reset')

--- a/appium/webdriver/webdriver.py
+++ b/appium/webdriver/webdriver.py
@@ -555,12 +555,6 @@ class WebDriver(
         """
         return MobileWebElement(self, element_id)
 
-    def reset(self):
-        """Resets the current application on the device.
-        """
-        self.execute(Command.RESET)
-        return self
-
     def press_button(self, button_name):
         """Sends a physical button name to the device to simulate the user pressing.
 
@@ -678,8 +672,6 @@ class WebDriver(
             ('POST', '/session/$sessionId/appium/app/close')
         self.command_executor._commands[Command.END_TEST_COVERAGE] = \
             ('POST', '/session/$sessionId/appium/app/end_test_coverage')
-        self.command_executor._commands[Command.RESET] = \
-            ('POST', '/session/$sessionId/appium/app/reset')
         self.command_executor._commands[Command.OPEN_NOTIFICATIONS] = \
             ('POST', '/session/$sessionId/appium/device/open_notifications')
         self.command_executor._commands[Command.REPLACE_KEYS] = \


### PR DESCRIPTION
## Change list

Move reset(self) method from webdriver.py to applications.py
 
## Types of changes
- [ ] No changes in production code.
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Details

This is in reference to #325 . Moved the reset app method from Webdriver.py to applications.py

Already test is added for this method in app_test.py
