### PR TITLE
Fix android flaky tests

### DIFF
--- a/ci-jobs/functional/run_android_test.yml
+++ b/ci-jobs/functional/run_android_test.yml
@@ -4,6 +4,7 @@ jobs:
       vmImage: ${{ parameters.vmImage }}
     variables:
       ANDROID_SDK_VERSION: ${{ parameters.sdkVer }}
+      CI: ${{ parameters.ci }}
     steps:
       - template: ./run_appium.yml
       - script: bash ci-jobs/functional/start-emulator.sh
@@ -13,3 +14,6 @@ jobs:
           py.test ${{ parameters.testFiles}} ${{ parameters.pytestOpt }}
         displayName: Run Android functional tests
       - template: ./publish_test_result.yml
+      - template: ./save_appium_log.yml
+        parameters:
+          name: ${{ parameters.name }}

--- a/ci-jobs/functional/run_appium.yml
+++ b/ci-jobs/functional/run_appium.yml
@@ -24,5 +24,5 @@ steps:
     appium --version
     node --version
   displayName: Check versions
-- script: nohup appium --relaxed-security &
+- script: nohup appium --relaxed-security > appium_log.txt &
   displayName: Run Appium in background

--- a/ci-jobs/functional/run_appium.yml
+++ b/ci-jobs/functional/run_appium.yml
@@ -3,7 +3,7 @@ steps:
   inputs:
     versionSpec: '11.x'
   displayName: Install Node 11.x
-- script: npm install -g appium --chromedriver_version='2.44'
+- script: npm install -g appium@beta --chromedriver_version='2.44'
   displayName: Install appium
 - task: UsePythonVersion@0
   inputs:

--- a/ci-jobs/functional/run_ios_test.yml
+++ b/ci-jobs/functional/run_ios_test.yml
@@ -2,6 +2,8 @@ jobs:
   - job: ${{ parameters.name }}
     pool:
       vmImage: ${{ parameters.vmImage }}
+    variables:
+      CI: ${{ parameters.ci }}
     steps:
       - template: ./run_appium.yml
       - script: |

--- a/ci-jobs/functional/save_appium_log.yml
+++ b/ci-jobs/functional/save_appium_log.yml
@@ -1,0 +1,18 @@
+steps:
+- task: CopyFiles@2
+  condition: succeededOrFailed()
+  inputs:
+    contents:
+      '**/appium_log.txt'
+    targetFolder: $(Build.ArtifactStagingDirectory)
+- task: CopyFiles@2
+  condition: succeededOrFailed()
+  inputs:
+    contents:
+      '**/test_*.png'
+    targetFolder: $(Build.ArtifactStagingDirectory)
+- task: PublishBuildArtifacts@1
+  condition: succeededOrFailed()
+  inputs:
+    pathToPublish: $(Build.ArtifactStagingDirectory)
+    artifactName: ${{ parameters.name }}

--- a/ci-jobs/functional_test.yml
+++ b/ci-jobs/functional_test.yml
@@ -1,6 +1,7 @@
 parameters:
   vmImage: 'macOS-10.14'
   pytestOpt: '--doctest-modules --junitxml=junit/test-results.xml --cov=com --cov-report=xml --cov-report=html'
+  androidSdkVer: 28
 
 jobs:
   - template: ./functional/run_ios_test.yml
@@ -8,7 +9,7 @@ jobs:
       name: 'func_test_ios1'
       vmImage: ${{ parameters.vmImage }}
       pytestOpt: ${{ parameters.pytestOpt }}
-      testFiles: 'find_*.py remote_fs_tests.py safari_tests.py'
+      testFiles: 'find_*.py remote_fs_tests.py safari_tests.py execute_driver_tests.py'
   - template: ./functional/run_ios_test.yml
     parameters:
       name: 'func_test_ios2'
@@ -20,5 +21,54 @@ jobs:
       name: 'func_test_android1'
       vmImage: ${{ parameters.vmImage }}
       pytestOpt: ${{ parameters.pytestOpt }}
-      testFiles: 'location_tests.py'
-      sdkVer: 28
+      testFiles: 'device_time_tests.py find_by_accessibility_id_tests.py find_by_image_tests.py find_by_uiautomator_tests.py'
+      sdkVer: ${{ parameters.androidSdkVer }}
+  - template: ./functional/run_android_test.yml
+    parameters:
+      name: 'func_test_android2'
+      vmImage: ${{ parameters.vmImage }}
+      pytestOpt: ${{ parameters.pytestOpt }}
+      testFiles: 'hw_actions_tests.py ime_tests.py keyboard_tests.py location_tests.py'
+      sdkVer: ${{ parameters.androidSdkVer }}
+  - template: ./functional/run_android_test.yml
+    parameters:
+      name: 'func_test_android3'
+      vmImage: ${{ parameters.vmImage }}
+      pytestOpt: ${{ parameters.pytestOpt }}
+      testFiles: 'activities_tests.py'
+      sdkVer: ${{ parameters.androidSdkVer }}
+  - template: ./functional/run_android_test.yml
+    parameters:
+      name: 'func_test_android4'
+      vmImage: ${{ parameters.vmImage }}
+      pytestOpt: ${{ parameters.pytestOpt }}
+      testFiles: 'finger_print_tests.py screen_record_tests.py settings_tests.py'
+      sdkVer: ${{ parameters.androidSdkVer }}
+  - template: ./functional/run_android_test.yml
+    parameters:
+      name: 'func_test_android5'
+      vmImage: ${{ parameters.vmImage }}
+      pytestOpt: ${{ parameters.pytestOpt }}
+      testFiles: 'context_switching_tests.py remote_fs_tests.py'
+      sdkVer: ${{ parameters.androidSdkVer }}
+  - template: ./functional/run_android_test.yml
+    parameters:
+      name: 'func_test_android6'
+      vmImage: ${{ parameters.vmImage }}
+      pytestOpt: ${{ parameters.pytestOpt }}
+      testFiles: 'webdriver_tests.py'
+      sdkVer: ${{ parameters.androidSdkVer }}
+  - template: ./functional/run_android_test.yml
+    parameters:
+      name: 'func_test_android7'
+      vmImage: ${{ parameters.vmImage }}
+      pytestOpt: ${{ parameters.pytestOpt }}
+      testFiles: 'applications_tests.py'
+      sdkVer: ${{ parameters.androidSdkVer }}
+  - template: ./functional/run_android_test.yml
+    parameters:
+      name: 'func_test_android8'
+      vmImage: ${{ parameters.vmImage }}
+      pytestOpt: ${{ parameters.pytestOpt }}
+      testFiles: 'network_connection_tests.py'
+      sdkVer: ${{ parameters.androidSdkVer }}

--- a/ci-jobs/functional_test.yml
+++ b/ci-jobs/functional_test.yml
@@ -1,7 +1,8 @@
 parameters:
   vmImage: 'macOS-10.14'
   pytestOpt: '--doctest-modules --junitxml=junit/test-results.xml --cov=com --cov-report=xml --cov-report=html'
-  androidSdkVer: 27
+  androidSdkVer: 28
+  CI: true
 
 jobs:
   - template: ./functional/run_ios_test.yml
@@ -10,12 +11,14 @@ jobs:
       vmImage: ${{ parameters.vmImage }}
       pytestOpt: ${{ parameters.pytestOpt }}
       testFiles: 'find_*.py remote_fs_tests.py safari_tests.py execute_driver_tests.py'
+      CI: ${{ parameters.ci }}
   - template: ./functional/run_ios_test.yml
     parameters:
       name: 'func_test_ios2'
       vmImage: ${{ parameters.vmImage }}
       pytestOpt: ${{ parameters.pytestOpt }}
       testFiles: 'applications_tests.py hw_actions_tests.py keyboard_tests.py screen_record_tests.py webdriver_tests.py'
+      CI: ${{ parameters.ci }}
   - template: ./functional/run_android_test.yml
     parameters:
       name: 'func_test_android1'
@@ -23,20 +26,23 @@ jobs:
       pytestOpt: ${{ parameters.pytestOpt }}
       testFiles: 'device_time_tests.py find_by_accessibility_id_tests.py find_by_image_tests.py find_by_uiautomator_tests.py'
       sdkVer: ${{ parameters.androidSdkVer }}
+      CI: ${{ parameters.ci }}
   - template: ./functional/run_android_test.yml
     parameters:
       name: 'func_test_android2'
       vmImage: ${{ parameters.vmImage }}
       pytestOpt: ${{ parameters.pytestOpt }}
-      testFiles: 'hw_actions_tests.py ime_tests.py keyboard_tests.py location_tests.py'
+      testFiles: 'ime_tests.py keyboard_tests.py location_tests.py'
       sdkVer: ${{ parameters.androidSdkVer }}
+      CI: ${{ parameters.ci }}
   - template: ./functional/run_android_test.yml
     parameters:
       name: 'func_test_android3'
       vmImage: ${{ parameters.vmImage }}
       pytestOpt: ${{ parameters.pytestOpt }}
-      testFiles: 'activities_tests.py'
+      testFiles: 'activities_tests.py chrome_tests.py'
       sdkVer: ${{ parameters.androidSdkVer }}
+      CI: ${{ parameters.ci }}
   - template: ./functional/run_android_test.yml
     parameters:
       name: 'func_test_android4'
@@ -44,6 +50,7 @@ jobs:
       pytestOpt: ${{ parameters.pytestOpt }}
       testFiles: 'finger_print_tests.py screen_record_tests.py settings_tests.py'
       sdkVer: ${{ parameters.androidSdkVer }}
+      CI: ${{ parameters.ci }}
   - template: ./functional/run_android_test.yml
     parameters:
       name: 'func_test_android5'
@@ -51,6 +58,7 @@ jobs:
       pytestOpt: ${{ parameters.pytestOpt }}
       testFiles: 'context_switching_tests.py remote_fs_tests.py'
       sdkVer: ${{ parameters.androidSdkVer }}
+      CI: ${{ parameters.ci }}
   - template: ./functional/run_android_test.yml
     parameters:
       name: 'func_test_android6'
@@ -58,6 +66,7 @@ jobs:
       pytestOpt: ${{ parameters.pytestOpt }}
       testFiles: 'webdriver_tests.py'
       sdkVer: ${{ parameters.androidSdkVer }}
+      CI: ${{ parameters.ci }}
   - template: ./functional/run_android_test.yml
     parameters:
       name: 'func_test_android7'
@@ -65,6 +74,7 @@ jobs:
       pytestOpt: ${{ parameters.pytestOpt }}
       testFiles: 'applications_tests.py'
       sdkVer: ${{ parameters.androidSdkVer }}
+      CI: ${{ parameters.ci }}
   - template: ./functional/run_android_test.yml
     parameters:
       name: 'func_test_android8'
@@ -72,3 +82,4 @@ jobs:
       pytestOpt: ${{ parameters.pytestOpt }}
       testFiles: 'network_connection_tests.py'
       sdkVer: ${{ parameters.androidSdkVer }}
+      CI: ${{ parameters.ci }}

--- a/ci-jobs/functional_test.yml
+++ b/ci-jobs/functional_test.yml
@@ -1,7 +1,7 @@
 parameters:
   vmImage: 'macOS-10.14'
   pytestOpt: '--doctest-modules --junitxml=junit/test-results.xml --cov=com --cov-report=xml --cov-report=html'
-  androidSdkVer: 28
+  androidSdkVer: 27
 
 jobs:
   - template: ./functional/run_ios_test.yml

--- a/ci-jobs/functional_test.yml
+++ b/ci-jobs/functional_test.yml
@@ -4,6 +4,8 @@ parameters:
   androidSdkVer: 28
   CI: true
 
+# [Android] Need to fix and add flaky tests for activities_tests, find_by_uiautomator_tests
+
 jobs:
   - template: ./functional/run_ios_test.yml
     parameters:
@@ -24,7 +26,7 @@ jobs:
       name: 'func_test_android1'
       vmImage: ${{ parameters.vmImage }}
       pytestOpt: ${{ parameters.pytestOpt }}
-      testFiles: 'device_time_tests.py find_by_accessibility_id_tests.py find_by_image_tests.py find_by_uiautomator_tests.py'
+      testFiles: 'device_time_tests.py find_by_accessibility_id_tests.py find_by_image_tests.py'
       sdkVer: ${{ parameters.androidSdkVer }}
       CI: ${{ parameters.ci }}
   - template: ./functional/run_android_test.yml
@@ -40,7 +42,7 @@ jobs:
       name: 'func_test_android3'
       vmImage: ${{ parameters.vmImage }}
       pytestOpt: ${{ parameters.pytestOpt }}
-      testFiles: 'activities_tests.py chrome_tests.py'
+      testFiles: 'chrome_tests.py'
       sdkVer: ${{ parameters.androidSdkVer }}
       CI: ${{ parameters.ci }}
   - template: ./functional/run_android_test.yml

--- a/test/functional/android/activities_tests.py
+++ b/test/functional/android/activities_tests.py
@@ -18,10 +18,10 @@ import unittest
 from appium import webdriver
 
 from .helper import desired_capabilities
-from .helper.test_helper import BaseTest
+from .helper.test_helper import BaseTestCase
 
 
-class ActivitiesTests(BaseTest):
+class ActivitiesTests(BaseTestCase):
     def setUp(self):
         desired_caps = desired_capabilities.get_desired_capabilities('ApiDemos-debug.apk')
         self.driver = webdriver.Remote('http://localhost:4723/wd/hub', desired_caps)

--- a/test/functional/android/activities_tests.py
+++ b/test/functional/android/activities_tests.py
@@ -15,12 +15,16 @@
 
 import unittest
 
+import pytest
+
 from appium import webdriver
 
 from .helper import desired_capabilities
+from .helper.test_helper import BaseTest
 
 
-class ActivitiesTests(unittest.TestCase):
+@pytest.mark.skip(reason='Need to fix flaky test during running on CI')
+class ActivitiesTests(BaseTest):
     def setUp(self):
         desired_caps = desired_capabilities.get_desired_capabilities('ApiDemos-debug.apk')
         self.driver = webdriver.Remote('http://localhost:4723/wd/hub', desired_caps)

--- a/test/functional/android/activities_tests.py
+++ b/test/functional/android/activities_tests.py
@@ -15,15 +15,12 @@
 
 import unittest
 
-import pytest
-
 from appium import webdriver
 
 from .helper import desired_capabilities
 from .helper.test_helper import BaseTest
 
 
-@pytest.mark.skip(reason='Need to fix flaky test during running on CI')
 class ActivitiesTests(BaseTest):
     def setUp(self):
         desired_caps = desired_capabilities.get_desired_capabilities('ApiDemos-debug.apk')

--- a/test/functional/android/applications_tests.py
+++ b/test/functional/android/applications_tests.py
@@ -16,19 +16,12 @@
 import unittest
 from time import sleep
 
-from appium import webdriver
 from appium.webdriver.applicationstate import ApplicationState
 
-from .helper import desired_capabilities
+from .helper.test_helper import BaseTest
 
 
-class ApplicationsTests(unittest.TestCase):
-    def setUp(self):
-        desired_caps = desired_capabilities.get_desired_capabilities('ApiDemos-debug.apk')
-        self.driver = webdriver.Remote('http://localhost:4723/wd/hub', desired_caps)
-
-    def tearDown(self):
-        self.driver.quit()
+class ApplicationsTests(BaseTest):
 
     def test_background_app(self):
         self.driver.background_app(1)

--- a/test/functional/android/applications_tests.py
+++ b/test/functional/android/applications_tests.py
@@ -18,10 +18,10 @@ from time import sleep
 
 from appium.webdriver.applicationstate import ApplicationState
 
-from .helper.test_helper import BaseTest
+from .helper.test_helper import BaseTestCase
 
 
-class ApplicationsTests(BaseTest):
+class ApplicationsTests(BaseTestCase):
 
     def test_background_app(self):
         self.driver.background_app(1)

--- a/test/functional/android/chrome_tests.py
+++ b/test/functional/android/chrome_tests.py
@@ -23,7 +23,9 @@ class ChromeTests(unittest.TestCase):
             'platformName': 'Android',
             'platformVersion': '9',
             'deviceName': 'Android Emulator',
-            'browserName': 'Chrome'
+            'browserName': 'Chrome',
+            'uiautomator2ServerInstallTimeout': 120000,
+            'adbExecTimeout': 120000
         }
         self.driver = webdriver.Remote('http://localhost:4723/wd/hub', desired_caps)
 

--- a/test/functional/android/device_time_tests.py
+++ b/test/functional/android/device_time_tests.py
@@ -17,10 +17,10 @@ import unittest
 
 from dateutil.parser import parse
 
-from .helper.test_helper import BaseTest
+from .helper.test_helper import BaseTestCase
 
 
-class DeviceTimeTests(BaseTest):
+class DeviceTimeTests(BaseTestCase):
     def test_device_time(self):
         date_time = self.driver.device_time
         # convert to date ought to work

--- a/test/functional/android/device_time_tests.py
+++ b/test/functional/android/device_time_tests.py
@@ -17,19 +17,10 @@ import unittest
 
 from dateutil.parser import parse
 
-from appium import webdriver
-
-from .helper import desired_capabilities
+from .helper.test_helper import BaseTest
 
 
-class DeviceTimeTests(unittest.TestCase):
-    def setUp(self):
-        desired_caps = desired_capabilities.get_desired_capabilities('ApiDemos-debug.apk')
-        self.driver = webdriver.Remote('http://localhost:4723/wd/hub', desired_caps)
-
-    def tearDown(self):
-        self.driver.quit()
-
+class DeviceTimeTests(BaseTest):
     def test_device_time(self):
         date_time = self.driver.device_time
         # convert to date ought to work

--- a/test/functional/android/find_by_accessibility_id_tests.py
+++ b/test/functional/android/find_by_accessibility_id_tests.py
@@ -14,24 +14,12 @@
 
 import unittest
 
-import pytest
-
-from appium import webdriver
 from appium.webdriver.common.mobileby import MobileBy
 
-from .helper import desired_capabilities
-from .helper.test_helper import wait_for_element
+from .helper.test_helper import BaseTest, is_ci, wait_for_element
 
 
-@pytest.mark.skip(reason="Need to fix flaky test during running on CI")
-class FindByAccessibilityIDTests(unittest.TestCase):
-    def setUp(self):
-        desired_caps = desired_capabilities.get_desired_capabilities('ApiDemos-debug.apk')
-        self.driver = webdriver.Remote('http://localhost:4723/wd/hub', desired_caps)
-
-    def tearDown(self):
-        self.driver.quit()
-
+class FindByAccessibilityIDTests(BaseTest):
     def test_find_single_element(self):
         wait_for_element(self.driver, MobileBy.ANDROID_UIAUTOMATOR, 'new UiSelector().text("Accessibility")').click()
         wait_for_element(self.driver, MobileBy.ANDROID_UIAUTOMATOR,
@@ -44,6 +32,8 @@ class FindByAccessibilityIDTests(unittest.TestCase):
         self.assertIsInstance(els, list)
 
     def test_element_find_single_element(self):
+        if is_ci():
+            self.skipTest('Need to fix flaky test during running on CI')
         wait_for_element(self.driver, MobileBy.ANDROID_UIAUTOMATOR, 'new UiSelector().text("Accessibility")').click()
         wait_for_element(self.driver, MobileBy.ANDROID_UIAUTOMATOR,
                          'new UiSelector().text("Accessibility Node Querying")').click()

--- a/test/functional/android/find_by_accessibility_id_tests.py
+++ b/test/functional/android/find_by_accessibility_id_tests.py
@@ -15,8 +15,10 @@
 import unittest
 
 from appium import webdriver
+from appium.webdriver.common.mobileby import MobileBy
 
 from .helper import desired_capabilities
+from .helper.test_helper import wait_for_element
 
 
 class FindByAccessibilityIDTests(unittest.TestCase):
@@ -28,9 +30,10 @@ class FindByAccessibilityIDTests(unittest.TestCase):
         self.driver.quit()
 
     def test_find_single_element(self):
-        self.driver.find_element_by_android_uiautomator('new UiSelector().text("Accessibility")').click()
-        self.driver.find_element_by_android_uiautomator('new UiSelector().text("Accessibility Node Querying")').click()
-        el = self.driver.find_element_by_accessibility_id('Task Take out Trash')
+        wait_for_element(self.driver, MobileBy.ANDROID_UIAUTOMATOR, 'new UiSelector().text("Accessibility")').click()
+        wait_for_element(self.driver, MobileBy.ANDROID_UIAUTOMATOR,
+                         'new UiSelector().text("Accessibility Node Querying")').click()
+        el = wait_for_element(self.driver, MobileBy.ACCESSIBILITY_ID, 'Task Take out Trash')
         self.assertIsNotNone(el)
 
     def test_find_multiple_elements(self):
@@ -38,14 +41,17 @@ class FindByAccessibilityIDTests(unittest.TestCase):
         self.assertIsInstance(els, list)
 
     def test_element_find_single_element(self):
-        self.driver.find_element_by_android_uiautomator('new UiSelector().text("Accessibility")').click()
-        self.driver.find_element_by_android_uiautomator('new UiSelector().text("Accessibility Node Querying")').click()
-        el = self.driver.find_element_by_class_name('android.widget.ListView')
+        self.skipTest('Need to fix flaky test during running on CI')
+        wait_for_element(self.driver, MobileBy.ANDROID_UIAUTOMATOR, 'new UiSelector().text("Accessibility")').click()
+        wait_for_element(self.driver, MobileBy.ANDROID_UIAUTOMATOR,
+                         'new UiSelector().text("Accessibility Node Querying")').click()
+        el = wait_for_element(self.driver, MobileBy.CLASS_NAME, 'android.widget.ListView')
 
         sub_el = el.find_element_by_accessibility_id('Task Take out Trash')
         self.assertIsNotNone(sub_el)
 
     def test_element_find_multiple_elements(self):
+        wait_for_element(self.driver, MobileBy.CLASS_NAME, 'android.widget.ListView')
         el = self.driver.find_element_by_class_name('android.widget.ListView')
 
         sub_els = el.find_elements_by_accessibility_id('Animation')

--- a/test/functional/android/find_by_accessibility_id_tests.py
+++ b/test/functional/android/find_by_accessibility_id_tests.py
@@ -16,10 +16,10 @@ import unittest
 
 from appium.webdriver.common.mobileby import MobileBy
 
-from .helper.test_helper import BaseTest, is_ci, wait_for_element
+from .helper.test_helper import BaseTestCase, is_ci, wait_for_element
 
 
-class FindByAccessibilityIDTests(BaseTest):
+class FindByAccessibilityIDTests(BaseTestCase):
     def test_find_single_element(self):
         wait_for_element(self.driver, MobileBy.ANDROID_UIAUTOMATOR, 'new UiSelector().text("Accessibility")').click()
         wait_for_element(self.driver, MobileBy.ANDROID_UIAUTOMATOR,

--- a/test/functional/android/find_by_accessibility_id_tests.py
+++ b/test/functional/android/find_by_accessibility_id_tests.py
@@ -14,6 +14,8 @@
 
 import unittest
 
+import pytest
+
 from appium import webdriver
 from appium.webdriver.common.mobileby import MobileBy
 
@@ -21,6 +23,7 @@ from .helper import desired_capabilities
 from .helper.test_helper import wait_for_element
 
 
+@pytest.mark.skip(reason="Need to fix flaky test during running on CI")
 class FindByAccessibilityIDTests(unittest.TestCase):
     def setUp(self):
         desired_caps = desired_capabilities.get_desired_capabilities('ApiDemos-debug.apk')
@@ -41,7 +44,6 @@ class FindByAccessibilityIDTests(unittest.TestCase):
         self.assertIsInstance(els, list)
 
     def test_element_find_single_element(self):
-        self.skipTest('Need to fix flaky test during running on CI')
         wait_for_element(self.driver, MobileBy.ANDROID_UIAUTOMATOR, 'new UiSelector().text("Accessibility")').click()
         wait_for_element(self.driver, MobileBy.ANDROID_UIAUTOMATOR,
                          'new UiSelector().text("Accessibility Node Querying")').click()

--- a/test/functional/android/find_by_uiautomator_tests.py
+++ b/test/functional/android/find_by_uiautomator_tests.py
@@ -14,11 +14,14 @@
 
 import unittest
 
+import pytest
+
 from appium import webdriver
 
 from .helper import desired_capabilities
 
 
+@pytest.mark.skip(reason="Need to fix flaky test during running on CI")
 class FindByUIAutomatorTests(unittest.TestCase):
     def setUp(self):
         desired_caps = desired_capabilities.get_desired_capabilities('ApiDemos-debug.apk')

--- a/test/functional/android/find_by_uiautomator_tests.py
+++ b/test/functional/android/find_by_uiautomator_tests.py
@@ -14,12 +14,9 @@
 
 import unittest
 
-import pytest
-
 from .helper.test_helper import BaseTest
 
 
-@pytest.mark.skip(reason='Need to fix flaky test during running on CI')  # Due to "System UI isn't responding" dialog
 class FindByUIAutomatorTests(BaseTest):
     def test_find_single_element(self):
         el = self.driver.find_element_by_android_uiautomator('new UiSelector().text("Animation")')

--- a/test/functional/android/find_by_uiautomator_tests.py
+++ b/test/functional/android/find_by_uiautomator_tests.py
@@ -16,20 +16,11 @@ import unittest
 
 import pytest
 
-from appium import webdriver
-
-from .helper import desired_capabilities
+from .helper.test_helper import BaseTest
 
 
-@pytest.mark.skip(reason="Need to fix flaky test during running on CI")
-class FindByUIAutomatorTests(unittest.TestCase):
-    def setUp(self):
-        desired_caps = desired_capabilities.get_desired_capabilities('ApiDemos-debug.apk')
-        self.driver = webdriver.Remote('http://localhost:4723/wd/hub', desired_caps)
-
-    def tearDown(self):
-        self.driver.quit()
-
+@pytest.mark.skip(reason='Need to fix flaky test during running on CI')  # Due to "System UI isn't responding" dialog
+class FindByUIAutomatorTests(BaseTest):
     def test_find_single_element(self):
         el = self.driver.find_element_by_android_uiautomator('new UiSelector().text("Animation")')
         self.assertIsNotNone(el)

--- a/test/functional/android/find_by_uiautomator_tests.py
+++ b/test/functional/android/find_by_uiautomator_tests.py
@@ -14,10 +14,10 @@
 
 import unittest
 
-from .helper.test_helper import BaseTest
+from .helper.test_helper import BaseTestCase
 
 
-class FindByUIAutomatorTests(BaseTest):
+class FindByUIAutomatorTests(BaseTestCase):
     def test_find_single_element(self):
         el = self.driver.find_element_by_android_uiautomator('new UiSelector().text("Animation")')
         self.assertIsNotNone(el)

--- a/test/functional/android/finger_print_tests.py
+++ b/test/functional/android/finger_print_tests.py
@@ -15,19 +15,10 @@
 
 import unittest
 
-from appium import webdriver
-
-from .helper import desired_capabilities
+from .helper.test_helper import BaseTest
 
 
-class FingerPrintTests(unittest.TestCase):
-    def setUp(self):
-        desired_caps = desired_capabilities.get_desired_capabilities('ApiDemos-debug.apk')
-        self.driver = webdriver.Remote('http://localhost:4723/wd/hub', desired_caps)
-
-    def tearDown(self):
-        self.driver.quit()
-
+class FingerPrintTests(BaseTest):
     def test_finger_print(self):
         result = self.driver.finger_print(1)
         self.assertEqual(None, result)

--- a/test/functional/android/finger_print_tests.py
+++ b/test/functional/android/finger_print_tests.py
@@ -15,10 +15,10 @@
 
 import unittest
 
-from .helper.test_helper import BaseTest
+from .helper.test_helper import BaseTestCase
 
 
-class FingerPrintTests(BaseTest):
+class FingerPrintTests(BaseTestCase):
     def test_finger_print(self):
         result = self.driver.finger_print(1)
         self.assertEqual(None, result)

--- a/test/functional/android/helper/desired_capabilities.py
+++ b/test/functional/android/helper/desired_capabilities.py
@@ -28,7 +28,9 @@ def get_desired_capabilities(app):
         'deviceName': 'Android Emulator',
         'app': PATH('../../apps/{}'.format(app)),
         'newCommandTimeout': 240,
-        'automationName': 'UIAutomator2'
+        'automationName': 'UIAutomator2',
+        'uiautomator2ServerInstallTimeout': 120000,
+        'adbExecTimeout': 120000
     }
 
     return desired_caps

--- a/test/functional/android/helper/test_helper.py
+++ b/test/functional/android/helper/test_helper.py
@@ -16,7 +16,7 @@ from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.ui import WebDriverWait
 
 # the emulator is sometimes slow and needs time to think
-SLEEPY_TIME = 3
+SLEEPY_TIME = 10
 
 
 def wait_for_element(driver, locator, value, timeout=SLEEPY_TIME):

--- a/test/functional/android/helper/test_helper.py
+++ b/test/functional/android/helper/test_helper.py
@@ -12,8 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
+import os
+import unittest
+
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.ui import WebDriverWait
+
+from appium import webdriver
+
+from . import desired_capabilities
 
 # the emulator is sometimes slow and needs time to think
 SLEEPY_TIME = 10
@@ -38,3 +46,19 @@ def wait_for_element(driver, locator, value, timeout=SLEEPY_TIME):
     return WebDriverWait(driver, timeout).until(
         EC.presence_of_element_located((locator, value))
     )
+
+
+def is_ci():
+    return os.getenv('CI', 'false') == 'true'
+
+
+class BaseTest(unittest.TestCase):
+
+    def setUp(self):
+        desired_caps = desired_capabilities.get_desired_capabilities('ApiDemos-debug.apk')
+        self.driver = webdriver.Remote('http://localhost:4723/wd/hub', desired_caps)
+
+    def tearDown(self):
+        img_path = os.path.join(os.getcwd(), self._testMethodName + '.png')
+        self.driver.get_screenshot_as_file(img_path)
+        self.driver.quit()

--- a/test/functional/android/helper/test_helper.py
+++ b/test/functional/android/helper/test_helper.py
@@ -49,10 +49,15 @@ def wait_for_element(driver, locator, value, timeout=SLEEPY_TIME):
 
 
 def is_ci():
+    """Returns if current execution is running on CI
+
+    Returns:
+        bool: `True` if current executions is on CI
+    """
     return os.getenv('CI', 'false') == 'true'
 
 
-class BaseTest(unittest.TestCase):
+class BaseTestCase(unittest.TestCase):
 
     def setUp(self):
         desired_caps = desired_capabilities.get_desired_capabilities('ApiDemos-debug.apk')

--- a/test/functional/android/hw_actions_tests.py
+++ b/test/functional/android/hw_actions_tests.py
@@ -16,10 +16,10 @@
 import unittest
 from time import sleep
 
-from .helper.test_helper import BaseTest
+from .helper.test_helper import BaseTestCase
 
 
-class HwActionsTests(BaseTest):
+class HwActionsTests(BaseTestCase):
     def test_lock(self):
         self.driver.lock(-1)
         sleep(10)

--- a/test/functional/android/hw_actions_tests.py
+++ b/test/functional/android/hw_actions_tests.py
@@ -14,22 +14,15 @@
 # limitations under the License.
 
 import unittest
+from time import sleep
 
-from appium import webdriver
-
-from .helper import desired_capabilities
+from .helper.test_helper import BaseTest
 
 
-class HwActionsTests(unittest.TestCase):
-    def setUp(self):
-        desired_caps = desired_capabilities.get_desired_capabilities('ApiDemos-debug.apk')
-        self.driver = webdriver.Remote('http://localhost:4723/wd/hub', desired_caps)
-
-    def tearDown(self):
-        self.driver.quit()
-
+class HwActionsTests(BaseTest):
     def test_lock(self):
         self.driver.lock(-1)
+        sleep(10)
         try:
             self.assertTrue(self.driver.is_locked())
         finally:

--- a/test/functional/android/ime_tests.py
+++ b/test/functional/android/ime_tests.py
@@ -16,22 +16,13 @@
 import unittest
 from time import sleep
 
-from appium import webdriver
-
-from .helper import desired_capabilities
+from .helper.test_helper import BaseTest
 
 ANDROID_LATIN = 'com.android.inputmethod.latin/.LatinIME'  # Android L/M/N
 GOOGLE_LATIN = 'com.google.android.inputmethod.latin/com.android.inputmethod.latin.LatinIME'  # Android O/P
 
 
-class IMETests(unittest.TestCase):
-    def setUp(self):
-        desired_caps = desired_capabilities.get_desired_capabilities('ApiDemos-debug.apk')
-        self.driver = webdriver.Remote('http://localhost:4723/wd/hub', desired_caps)
-
-    def tearDown(self):
-        self.driver.quit()
-
+class IMETests(BaseTest):
     def test_available_ime_engines(self):
         engines = self.driver.available_ime_engines
         self.assertIsInstance(engines, list)

--- a/test/functional/android/ime_tests.py
+++ b/test/functional/android/ime_tests.py
@@ -16,13 +16,13 @@
 import unittest
 from time import sleep
 
-from .helper.test_helper import BaseTest
+from .helper.test_helper import BaseTestCase
 
 ANDROID_LATIN = 'com.android.inputmethod.latin/.LatinIME'  # Android L/M/N
 GOOGLE_LATIN = 'com.google.android.inputmethod.latin/com.android.inputmethod.latin.LatinIME'  # Android O/P
 
 
-class IMETests(BaseTest):
+class IMETests(BaseTestCase):
     def test_available_ime_engines(self):
         engines = self.driver.available_ime_engines
         self.assertIsInstance(engines, list)

--- a/test/functional/android/keyboard_tests.py
+++ b/test/functional/android/keyboard_tests.py
@@ -15,19 +15,10 @@
 
 import unittest
 
-from appium import webdriver
-
-from .helper import desired_capabilities
+from .helper.test_helper import BaseTest
 
 
-class KeyboardTests(unittest.TestCase):
-    def setUp(self):
-        desired_caps = desired_capabilities.get_desired_capabilities('ApiDemos-debug.apk')
-        self.driver = webdriver.Remote('http://localhost:4723/wd/hub', desired_caps)
-
-    def tearDown(self):
-        self.driver.quit()
-
+class KeyboardTests(BaseTest):
     def test_press_keycode(self):
         # not sure how to test this.
         self.driver.press_keycode(176)

--- a/test/functional/android/keyboard_tests.py
+++ b/test/functional/android/keyboard_tests.py
@@ -15,10 +15,10 @@
 
 import unittest
 
-from .helper.test_helper import BaseTest
+from .helper.test_helper import BaseTestCase
 
 
-class KeyboardTests(BaseTest):
+class KeyboardTests(BaseTestCase):
     def test_press_keycode(self):
         # not sure how to test this.
         self.driver.press_keycode(176)

--- a/test/functional/android/location_tests.py
+++ b/test/functional/android/location_tests.py
@@ -15,19 +15,10 @@
 
 import unittest
 
-from appium import webdriver
-
-from .helper import desired_capabilities
+from .helper.test_helper import BaseTest
 
 
-class LocationTests(unittest.TestCase):
-    def setUp(self):
-        desired_caps = desired_capabilities.get_desired_capabilities('ApiDemos-debug.apk')
-        self.driver = webdriver.Remote('http://localhost:4723/wd/hub', desired_caps)
-
-    def tearDown(self):
-        self.driver.quit()
-
+class LocationTests(BaseTest):
     def test_toggle_location_services(self):
         self.driver.toggle_location_services()
 

--- a/test/functional/android/location_tests.py
+++ b/test/functional/android/location_tests.py
@@ -15,10 +15,10 @@
 
 import unittest
 
-from .helper.test_helper import BaseTest
+from .helper.test_helper import BaseTestCase
 
 
-class LocationTests(BaseTest):
+class LocationTests(BaseTestCase):
     def test_toggle_location_services(self):
         self.driver.toggle_location_services()
 

--- a/test/functional/android/multi_action_tests.py
+++ b/test/functional/android/multi_action_tests.py
@@ -15,23 +15,14 @@
 import unittest
 from time import sleep
 
-from appium import webdriver
 from appium.webdriver.common.mobileby import MobileBy
 from appium.webdriver.common.multi_action import MultiAction
 from appium.webdriver.common.touch_action import TouchAction
 
-from .helper import desired_capabilities
-from .helper.test_helper import wait_for_element
+from .helper.test_helper import BaseTest, wait_for_element
 
 
-class MultiActionTests(unittest.TestCase):
-    def setUp(self):
-        desired_caps = desired_capabilities.get_desired_capabilities('ApiDemos-debug.apk')
-        self.driver = webdriver.Remote('http://localhost:4723/wd/hub', desired_caps)
-
-    def tearDown(self):
-        self.driver.quit()
-
+class MultiActionTests(BaseTest):
     def test_parallel_actions(self):
         el1 = self.driver.find_element_by_accessibility_id('Content')
         el2 = self.driver.find_element_by_accessibility_id('Animation')

--- a/test/functional/android/multi_action_tests.py
+++ b/test/functional/android/multi_action_tests.py
@@ -19,10 +19,10 @@ from appium.webdriver.common.mobileby import MobileBy
 from appium.webdriver.common.multi_action import MultiAction
 from appium.webdriver.common.touch_action import TouchAction
 
-from .helper.test_helper import BaseTest, wait_for_element
+from .helper.test_helper import BaseTestCase, wait_for_element
 
 
-class MultiActionTests(BaseTest):
+class MultiActionTests(BaseTestCase):
     def test_parallel_actions(self):
         el1 = self.driver.find_element_by_accessibility_id('Content')
         el2 = self.driver.find_element_by_accessibility_id('Animation')

--- a/test/functional/android/network_connection_tests.py
+++ b/test/functional/android/network_connection_tests.py
@@ -15,25 +15,19 @@
 
 import unittest
 
-from appium import webdriver
 from appium.webdriver.connectiontype import ConnectionType
 
-from .helper import desired_capabilities
+from .helper.test_helper import BaseTest, is_ci
 
 
-class NetworkConnectionTests(unittest.TestCase):
-    def setUp(self):
-        desired_caps = desired_capabilities.get_desired_capabilities('ApiDemos-debug.apk')
-        self.driver = webdriver.Remote('http://localhost:4723/wd/hub', desired_caps)
-
-    def tearDown(self):
-        self.driver.quit()
-
+class NetworkConnectionTests(BaseTest):
     def test_get_network_connection(self):
         nc = self.driver.network_connection
         self.assertIsInstance(nc, int)
 
     def test_set_network_connection(self):
+        if is_ci():
+            self.skipTest('Need to fix flaky test during running on CI')
         nc = self.driver.set_network_connection(ConnectionType.DATA_ONLY)
         self.assertIsInstance(nc, int)
         self.assertEqual(nc, ConnectionType.DATA_ONLY)

--- a/test/functional/android/network_connection_tests.py
+++ b/test/functional/android/network_connection_tests.py
@@ -17,10 +17,10 @@ import unittest
 
 from appium.webdriver.connectiontype import ConnectionType
 
-from .helper.test_helper import BaseTest, is_ci
+from .helper.test_helper import BaseTestCase, is_ci
 
 
-class NetworkConnectionTests(BaseTest):
+class NetworkConnectionTests(BaseTestCase):
     def test_get_network_connection(self):
         nc = self.driver.network_connection
         self.assertIsInstance(nc, int)

--- a/test/functional/android/remote_fs_tests.py
+++ b/test/functional/android/remote_fs_tests.py
@@ -19,20 +19,12 @@ import unittest
 from io import BytesIO
 from zipfile import ZipFile
 
-from appium import webdriver
 from appium.common.helper import appium_bytes
 
-from .helper import desired_capabilities
+from .helper.test_helper import BaseTest
 
 
-class RemoteFsTests(unittest.TestCase):
-    def setUp(self):
-        desired_caps = desired_capabilities.get_desired_capabilities('ApiDemos-debug.apk')
-        self.driver = webdriver.Remote('http://localhost:4723/wd/hub', desired_caps)
-
-    def tearDown(self):
-        self.driver.quit()
-
+class RemoteFsTests(BaseTest):
     def test_push_pull_file(self):
         dest_path = '/data/local/tmp/test_push_file.txt'
         data = appium_bytes('This is the contents of the file to push to the device.', 'utf-8')

--- a/test/functional/android/remote_fs_tests.py
+++ b/test/functional/android/remote_fs_tests.py
@@ -21,10 +21,10 @@ from zipfile import ZipFile
 
 from appium.common.helper import appium_bytes
 
-from .helper.test_helper import BaseTest
+from .helper.test_helper import BaseTestCase
 
 
-class RemoteFsTests(BaseTest):
+class RemoteFsTests(BaseTestCase):
     def test_push_pull_file(self):
         dest_path = '/data/local/tmp/test_push_file.txt'
         data = appium_bytes('This is the contents of the file to push to the device.', 'utf-8')

--- a/test/functional/android/screen_record_tests.py
+++ b/test/functional/android/screen_record_tests.py
@@ -16,10 +16,10 @@
 import unittest
 from time import sleep
 
-from .helper.test_helper import BaseTest
+from .helper.test_helper import BaseTestCase
 
 
-class ScreenRecordTests(BaseTest):
+class ScreenRecordTests(BaseTestCase):
     def test_screen_record(self):
         self.driver.start_recording_screen(timeLimit=10, forcedRestart=True)
         sleep(10)

--- a/test/functional/android/screen_record_tests.py
+++ b/test/functional/android/screen_record_tests.py
@@ -16,19 +16,10 @@
 import unittest
 from time import sleep
 
-from appium import webdriver
-
-from .helper import desired_capabilities
+from .helper.test_helper import BaseTest
 
 
-class ScreenRecordTests(unittest.TestCase):
-    def setUp(self):
-        desired_caps = desired_capabilities.get_desired_capabilities('ApiDemos-debug.apk')
-        self.driver = webdriver.Remote('http://localhost:4723/wd/hub', desired_caps)
-
-    def tearDown(self):
-        self.driver.quit()
-
+class ScreenRecordTests(BaseTest):
     def test_screen_record(self):
         self.driver.start_recording_screen(timeLimit=10, forcedRestart=True)
         sleep(10)

--- a/test/functional/android/settings_tests.py
+++ b/test/functional/android/settings_tests.py
@@ -15,19 +15,10 @@
 
 import unittest
 
-from appium import webdriver
-
-from .helper import desired_capabilities
+from .helper.test_helper import BaseTest
 
 
-class SettingsTests(unittest.TestCase):
-    def setUp(self):
-        desired_caps = desired_capabilities.get_desired_capabilities('ApiDemos-debug.apk')
-        self.driver = webdriver.Remote('http://localhost:4723/wd/hub', desired_caps)
-
-    def tearDown(self):
-        self.driver.quit()
-
+class SettingsTests(BaseTest):
     def test_get_settings(self):
         settings = self.driver.get_settings()
         self.assertIsNotNone(settings)

--- a/test/functional/android/settings_tests.py
+++ b/test/functional/android/settings_tests.py
@@ -15,10 +15,10 @@
 
 import unittest
 
-from .helper.test_helper import BaseTest
+from .helper.test_helper import BaseTestCase
 
 
-class SettingsTests(BaseTest):
+class SettingsTests(BaseTestCase):
     def test_get_settings(self):
         settings = self.driver.get_settings()
         self.assertIsNotNone(settings)

--- a/test/functional/android/touch_action_tests.py
+++ b/test/functional/android/touch_action_tests.py
@@ -21,10 +21,10 @@ from appium.webdriver.common.mobileby import MobileBy
 from appium.webdriver.common.touch_action import TouchAction
 
 from .helper import desired_capabilities
-from .helper.test_helper import BaseTest, wait_for_element
+from .helper.test_helper import BaseTestCase, wait_for_element
 
 
-class TouchActionTests(BaseTest):
+class TouchActionTests(BaseTestCase):
     def test_tap(self):
         el = self.driver.find_element_by_accessibility_id('Animation')
         action = TouchAction(self.driver)

--- a/test/functional/android/touch_action_tests.py
+++ b/test/functional/android/touch_action_tests.py
@@ -21,17 +21,10 @@ from appium.webdriver.common.mobileby import MobileBy
 from appium.webdriver.common.touch_action import TouchAction
 
 from .helper import desired_capabilities
-from .helper.test_helper import wait_for_element
+from .helper.test_helper import BaseTest, wait_for_element
 
 
-class TouchActionTests(unittest.TestCase):
-    def setUp(self):
-        desired_caps = desired_capabilities.get_desired_capabilities('ApiDemos-debug.apk')
-        self.driver = webdriver.Remote('http://localhost:4723/wd/hub', desired_caps)
-
-    def tearDown(self):
-        self.driver.quit()
-
+class TouchActionTests(BaseTest):
     def test_tap(self):
         el = self.driver.find_element_by_accessibility_id('Animation')
         action = TouchAction(self.driver)

--- a/test/functional/android/touch_action_tests.py
+++ b/test/functional/android/touch_action_tests.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import unittest
-from time import sleep
 
 from selenium.common.exceptions import NoSuchElementException
 
@@ -110,7 +109,7 @@ class TouchActionTests(unittest.TestCase):
         action = TouchAction(self.driver)
         action.press(el1).move_to(el2).release().perform()
 
-        el = self.driver.find_element_by_accessibility_id('Views')
+        el = wait_for_element(self.driver, MobileBy.ACCESSIBILITY_ID, 'Views')
         self.assertIsNotNone(el)
 
     def test_press_and_moveto_x_y(self):
@@ -120,7 +119,7 @@ class TouchActionTests(unittest.TestCase):
         action = TouchAction(self.driver)
         action.press(el1).move_to(el2, 100, 100).release().perform()
 
-        el = self.driver.find_element_by_accessibility_id('Views')
+        el = wait_for_element(self.driver, MobileBy.ACCESSIBILITY_ID, 'Views')
         self.assertIsNotNone(el)
 
     def test_long_press(self):
@@ -130,7 +129,7 @@ class TouchActionTests(unittest.TestCase):
         action = TouchAction(self.driver)
         action.press(el1).move_to(el2).perform()
 
-        el = self.driver.find_element_by_accessibility_id('Views')
+        el = wait_for_element(self.driver, MobileBy.ACCESSIBILITY_ID, 'Views')
         action.tap(el).perform()
 
         el = wait_for_element(self.driver, MobileBy.ACCESSIBILITY_ID, 'Expandable Lists')
@@ -155,13 +154,13 @@ class TouchActionTests(unittest.TestCase):
         action = TouchAction(self.driver)
         action.press(el1).move_to(el2).perform()
 
-        el = self.driver.find_element_by_accessibility_id('Views')
+        el = wait_for_element(self.driver, MobileBy.ACCESSIBILITY_ID, 'Views')
         action.tap(el).perform()
 
-        el = self.driver.find_element_by_accessibility_id('Expandable Lists')
+        el = wait_for_element(self.driver, MobileBy.ACCESSIBILITY_ID, 'Expandable Lists')
         action.tap(el).perform()
 
-        el = self.driver.find_element_by_accessibility_id('1. Custom Adapter')
+        el = wait_for_element(self.driver, MobileBy.ACCESSIBILITY_ID, '1. Custom Adapter')
         action.tap(el).perform()
 
         # the element "People Names" is located at 430:310 (top left corner)
@@ -191,7 +190,7 @@ class TouchActionTests(unittest.TestCase):
         # dnd is stimulated by longpress-move_to-release
         action.long_press(dd3).move_to(dd2).release().perform()
 
-        el = self.driver.find_element_by_id('com.example.android.apis:id/drag_text')
+        el = wait_for_element(self.driver, MobileBy.ID, 'com.example.android.apis:id/drag_text')
         self.assertTrue('drag_dot_3' in el.text)
 
     def test_driver_drag_and_drop(self):
@@ -199,19 +198,19 @@ class TouchActionTests(unittest.TestCase):
         el2 = self.driver.find_element_by_accessibility_id('Animation')
         self.driver.scroll(el1, el2)
 
-        el = self.driver.find_element_by_accessibility_id('Views')
+        el = wait_for_element(self.driver, MobileBy.ACCESSIBILITY_ID, 'Views')
         action = TouchAction(self.driver)
         action.tap(el).perform()
 
         el = wait_for_element(self.driver, MobileBy.ACCESSIBILITY_ID, 'Drag and Drop')
         action.tap(el).perform()
 
-        dd3 = self.driver.find_element_by_id('com.example.android.apis:id/drag_dot_3')
+        dd3 = wait_for_element(self.driver, MobileBy.ID, 'com.example.android.apis:id/drag_dot_3')
         dd2 = self.driver.find_element_by_id('com.example.android.apis:id/drag_dot_2')
 
         self.driver.drag_and_drop(dd3, dd2)
 
-        el = self.driver.find_element_by_id('com.example.android.apis:id/drag_text')
+        el = wait_for_element(self.driver, MobileBy.ID, 'com.example.android.apis:id/drag_text')
         self.assertTrue('drag_dot_3' in el.text)
 
     def test_driver_swipe(self):

--- a/test/functional/android/webdriver_tests.py
+++ b/test/functional/android/webdriver_tests.py
@@ -18,20 +18,12 @@ from time import sleep
 
 from selenium.common.exceptions import NoSuchElementException
 
-from appium import webdriver
 from appium.webdriver.common.mobileby import MobileBy
 
-from .helper import desired_capabilities
-from .helper.test_helper import wait_for_element
+from .helper.test_helper import BaseTest, is_ci, wait_for_element
 
 
-class WebdriverTests(unittest.TestCase):
-    def setUp(self):
-        desired_caps = desired_capabilities.get_desired_capabilities('ApiDemos-debug.apk')
-        self.driver = webdriver.Remote('http://localhost:4723/wd/hub', desired_caps)
-
-    def tearDown(self):
-        self.driver.quit()
+class WebdriverTests(BaseTest):
 
     def test_current_package(self):
         package = self.driver.current_package
@@ -47,6 +39,9 @@ class WebdriverTests(unittest.TestCase):
         self.assertTrue(self.driver.is_app_installed('com.example.android.apis'))
 
     def test_open_notifications(self):
+        if is_ci():
+            # TODO Due to unexpected dialog, "System UI isn't responding"
+            self.skipTest('Need to fix flaky test during running on CI.')
         for word in ['App', 'Notification', 'Status Bar', ':-|']:
             wait_for_element(self.driver, MobileBy.ANDROID_UIAUTOMATOR,
                              'new UiSelector().text("{}")'.format(word)).click()
@@ -72,35 +67,6 @@ class WebdriverTests(unittest.TestCase):
         self.driver.keyevent(4)
         sleep(1)
         self.driver.find_element_by_android_uiautomator('new UiSelector().text(":-|")')
-
-    def test_set_text(self):
-        self.driver.find_element_by_android_uiautomator(
-            'new UiScrollable(new UiSelector().scrollable(true).instance(0)).scrollIntoView(new UiSelector().text("Views").instance(0));').click()
-
-        wait_for_element(self.driver, MobileBy.ACCESSIBILITY_ID, 'Controls').click()
-        wait_for_element(self.driver, MobileBy.ACCESSIBILITY_ID, '1. Light Theme').click()
-
-        el = wait_for_element(self.driver, MobileBy.CLASS_NAME, 'android.widget.EditText')
-        el.send_keys('original text')
-        el.set_text('new text')
-
-        self.assertEqual('new text', el.text)
-
-    def test_send_keys(self):
-        for text in ['App', 'Activity', 'Custom Title']:
-            wait_for_element(self.driver, MobileBy.XPATH,
-                             "//android.widget.TextView[@text='{}']".format(text)).click()
-
-        el = wait_for_element(self.driver, MobileBy.ID, 'com.example.android.apis:id/left_text_edit')
-        el.send_keys(' text')
-
-        self.assertEqual('Left is best text', el.text)
-
-    def test_element_location_in_view(self):
-        el = self.driver.find_element_by_accessibility_id('Content')
-        loc = el.location_in_view
-        self.assertIsNotNone(loc['x'])
-        self.assertIsNotNone(loc['y'])
 
 
 if __name__ == '__main__':

--- a/test/functional/android/webdriver_tests.py
+++ b/test/functional/android/webdriver_tests.py
@@ -47,11 +47,9 @@ class WebdriverTests(unittest.TestCase):
         self.assertTrue(self.driver.is_app_installed('com.example.android.apis'))
 
     def test_open_notifications(self):
-        self.driver.find_element_by_android_uiautomator('new UiSelector().text("App")').click()
-        self.driver.find_element_by_android_uiautomator('new UiSelector().text("Notification")').click()
-        self.driver.find_element_by_android_uiautomator('new UiSelector().text("Status Bar")').click()
-
-        self.driver.find_element_by_android_uiautomator('new UiSelector().text(":-|")').click()
+        for word in ['App', 'Notification', 'Status Bar', ':-|']:
+            wait_for_element(self.driver, MobileBy.ANDROID_UIAUTOMATOR,
+                             'new UiSelector().text("{}")'.format(word)).click()
 
         self.driver.open_notifications()
         sleep(1)
@@ -93,7 +91,7 @@ class WebdriverTests(unittest.TestCase):
             wait_for_element(self.driver, MobileBy.XPATH,
                              "//android.widget.TextView[@text='{}']".format(text)).click()
 
-        el = self.driver.find_element(MobileBy.ID, 'com.example.android.apis:id/left_text_edit')
+        el = wait_for_element(self.driver, MobileBy.ID, 'com.example.android.apis:id/left_text_edit')
         el.send_keys(' text')
 
         self.assertEqual('Left is best text', el.text)

--- a/test/functional/android/webdriver_tests.py
+++ b/test/functional/android/webdriver_tests.py
@@ -20,10 +20,10 @@ from selenium.common.exceptions import NoSuchElementException
 
 from appium.webdriver.common.mobileby import MobileBy
 
-from .helper.test_helper import BaseTest, is_ci, wait_for_element
+from .helper.test_helper import BaseTestCase, is_ci, wait_for_element
 
 
-class WebdriverTests(BaseTest):
+class WebdriverTests(BaseTestCase):
 
     def test_current_package(self):
         package = self.driver.current_package

--- a/test/functional/android/webelement_tests.py
+++ b/test/functional/android/webelement_tests.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from appium import webdriver
+from appium.webdriver.common.mobileby import MobileBy
+
+from .helper import desired_capabilities
+from .helper.test_helper import BaseTest, wait_for_element
+
+
+class WebelementTests(BaseTest):
+    def test_element_location_in_view(self):
+        el = self.driver.find_element_by_accessibility_id('Content')
+        loc = el.location_in_view
+        self.assertIsNotNone(loc['x'])
+        self.assertIsNotNone(loc['y'])
+
+    def test_set_text(self):
+        self.driver.find_element_by_android_uiautomator(
+            'new UiScrollable(new UiSelector().scrollable(true).instance(0)).scrollIntoView(new UiSelector().text("Views").instance(0));').click()
+
+        wait_for_element(self.driver, MobileBy.ACCESSIBILITY_ID, 'Controls').click()
+        wait_for_element(self.driver, MobileBy.ACCESSIBILITY_ID, '1. Light Theme').click()
+
+        el = wait_for_element(self.driver, MobileBy.CLASS_NAME, 'android.widget.EditText')
+        el.send_keys('original text')
+        el.set_text('new text')
+
+        self.assertEqual('new text', el.text)
+
+    def test_send_keys(self):
+        for text in ['App', 'Activity', 'Custom Title']:
+            wait_for_element(self.driver, MobileBy.XPATH,
+                             "//android.widget.TextView[@text='{}']".format(text)).click()
+
+        el = wait_for_element(self.driver, MobileBy.ID, 'com.example.android.apis:id/left_text_edit')
+        el.send_keys(' text')
+
+        self.assertEqual('Left is best text', el.text)
+
+
+if __name__ == '__main__':
+    suite = unittest.TestLoader().loadTestsFromTestCase(WebelementTests)
+    unittest.TextTestRunner(verbosity=2).run(suite)

--- a/test/functional/android/webelement_tests.py
+++ b/test/functional/android/webelement_tests.py
@@ -19,10 +19,10 @@ from appium import webdriver
 from appium.webdriver.common.mobileby import MobileBy
 
 from .helper import desired_capabilities
-from .helper.test_helper import BaseTest, wait_for_element
+from .helper.test_helper import BaseTestCase, wait_for_element
 
 
-class WebelementTests(BaseTest):
+class WebelementTests(BaseTestCase):
     def test_element_location_in_view(self):
         el = self.driver.find_element_by_accessibility_id('Content')
         loc = el.location_in_view

--- a/test/functional/ios/execute_driver_tests.py
+++ b/test/functional/ios/execute_driver_tests.py
@@ -16,7 +16,8 @@ import textwrap
 import unittest
 
 from appium import webdriver
-from helper import desired_capabilities
+
+from .helper import desired_capabilities
 
 
 class ExecuteDriverTests(unittest.TestCase):


### PR DESCRIPTION
For https://github.com/appium/python-client/issues/377

### Changes
* Basically wait for target elements located
* Extend various timeouts
* Others

### Remaining TODO in the next PR
* Run chrome, touch_action, multi_action, find_by_accessibility_id, find_by_uiautomator

### Target stability
10 times successes in a row
https://dev.azure.com/ki4070ma/python-client/_build?definitionId=2&_a=summary

#### [commit] Don't run flaky tests on CI
* (success) 10/12
   * https://dev.azure.com/ki4070ma/python-client/_build/results?buildId=414 to https://dev.azure.com/ki4070ma/python-client/_build/results?buildId=425
* Failures
   * 1. Failed to launch android emulator.
      * Launching emulator script is basically same to ruby_client's one based on azure's samples. Can't handle it.
      * https://dev.azure.com/ki4070ma/python-client/_build/results?buildId=416
   * 2. Lost communication with the server
      * `The agent: Azure Pipelines 4 lost communication with the server. Verify the machine is running and has a healthy network connection. For more information, see: https://go.microsoft.com/fwlink/?linkid=846610`
      * https://dev.azure.com/ki4070ma/python-client/_build/results?buildId=419