### PR TITLE
Change altitude optional as arg for set_location

### DIFF
--- a/appium/webdriver/extensions/location.py
+++ b/appium/webdriver/extensions/location.py
@@ -35,7 +35,7 @@ class Location(webdriver.Remote):
         Args:
             latitude (float): String or numeric value between -90.0 and 90.00
             longitude (float): String or numeric value between -180.0 and 180.0
-            altitude (float, optional): String or numeric value
+            altitude (float, optional): String or numeric value (Android real device only)
 
         Returns:
             `appium.webdriver.webdriver.WebDriver`

--- a/appium/webdriver/extensions/location.py
+++ b/appium/webdriver/extensions/location.py
@@ -33,21 +33,21 @@ class Location(webdriver.Remote):
         """Set the location of the device
 
         Args:
-            latitude (float): String or numeric value between -90.0 and 90.00
-            longitude (float): String or numeric value between -180.0 and 180.0
-            altitude (float, optional): String or numeric value (Android real device only)
+            latitude (Union[float, str]): String or numeric value between -90.0 and 90.00
+            longitude (Union[float, str]): String or numeric value between -180.0 and 180.0
+            altitude (Union[float, str], optional): String or numeric value (Android real device only)
 
         Returns:
             `appium.webdriver.webdriver.WebDriver`
         """
         data = {
             "location": {
-                "latitude": float(latitude),
-                "longitude": float(longitude),
+                "latitude": latitude,
+                "longitude": longitude,
             }
         }
-        if altitude:
-            data['location']['altitude'] = float(altitude)
+        if altitude is not None:
+            data['location']['altitude'] = altitude
         self.execute(Command.SET_LOCATION, data)
         return self
 

--- a/appium/webdriver/extensions/location.py
+++ b/appium/webdriver/extensions/location.py
@@ -29,13 +29,13 @@ class Location(webdriver.Remote):
         self.execute(Command.TOGGLE_LOCATION_SERVICES, {})
         return self
 
-    def set_location(self, latitude, longitude, altitude):
+    def set_location(self, latitude, longitude, altitude=None):
         """Set the location of the device
 
         Args:
             latitude (float): String or numeric value between -90.0 and 90.00
             longitude (float): String or numeric value between -180.0 and 180.0
-            altitude (float): String or numeric value
+            altitude (float, optional): String or numeric value
 
         Returns:
             `appium.webdriver.webdriver.WebDriver`
@@ -44,9 +44,10 @@ class Location(webdriver.Remote):
             "location": {
                 "latitude": float(latitude),
                 "longitude": float(longitude),
-                "altitude": float(altitude)
             }
         }
+        if altitude:
+            data['location']['altitude'] = float(altitude)
         self.execute(Command.SET_LOCATION, data)
         return self
 

--- a/test/unit/webdriver/device/location_test.py
+++ b/test/unit/webdriver/device/location_test.py
@@ -50,6 +50,20 @@ class TestWebDriverLocation(object):
         assert abs(d['location']['altitude'] - 33.3) <= FLT_EPSILON
 
     @httpretty.activate
+    def test_set_location_without_altitude(self):
+        driver = android_w3c_driver()
+        httpretty.register_uri(
+            httpretty.POST,
+            appium_command('/session/1234567890/location')
+        )
+        assert isinstance(driver.set_location(11.1, 22.2), WebDriver)
+
+        d = get_httpretty_request_body(httpretty.last_request())
+        assert abs(d['location']['latitude'] - 11.1) <= FLT_EPSILON
+        assert abs(d['location']['longitude'] - 22.2) <= FLT_EPSILON
+        assert d['location'].get('altitude') == None
+
+    @httpretty.activate
     def test_location(self):
         driver = android_w3c_driver()
         httpretty.register_uri(

--- a/test/unit/webdriver/device/location_test.py
+++ b/test/unit/webdriver/device/location_test.py
@@ -36,7 +36,7 @@ class TestWebDriverLocation(object):
         assert isinstance(driver.toggle_location_services(), WebDriver)
 
     @httpretty.activate
-    def test_set_location(self):
+    def test_set_location_float(self):
         driver = android_w3c_driver()
         httpretty.register_uri(
             httpretty.POST,
@@ -48,6 +48,20 @@ class TestWebDriverLocation(object):
         assert abs(d['location']['latitude'] - 11.1) <= FLT_EPSILON
         assert abs(d['location']['longitude'] - 22.2) <= FLT_EPSILON
         assert abs(d['location']['altitude'] - 33.3) <= FLT_EPSILON
+
+    @httpretty.activate
+    def test_set_location_str(self):
+        driver = android_w3c_driver()
+        httpretty.register_uri(
+            httpretty.POST,
+            appium_command('/session/1234567890/location')
+        )
+        assert isinstance(driver.set_location('11.1', '22.2', '33.3'), WebDriver)
+
+        d = get_httpretty_request_body(httpretty.last_request())
+        assert d['location']['latitude'] == '11.1'
+        assert d['location']['longitude'] == '22.2'
+        assert d['location']['altitude'] == '33.3'
 
     @httpretty.activate
     def test_set_location_without_altitude(self):


### PR DESCRIPTION
## Changes
* Change altitude optional as arg for set_location

## Reasons
1. `altitude` is optional for appium server
   - http://appium.io/docs/en/commands/session/geolocation/set-geolocation/
      - JSON Parameters - altitude
2. It's enough that users set `altitude` when users want.

## Verified
Checked below No.1-3 cases work.

```
    self.driver.set_location(121.21, 11.56, 20)  # No.1
    # self.driver.set_location(121.21, 11.56)  # No.2
    # self.driver.set_location('121.22', '11.56', '21') # No.3
    import time
    time.sleep(10)
    print(self.driver.location)
```

Link to https://github.com/appium/python-client/issues/414