### PR TITLE
Fix: CI doesn't fail even if autopep8 makes changes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
     rev: v1.4
     hooks:
     -   id: autopep8
-        args: ["--global-config", ".config-pep8", "-i"]
+        args: ["-a", "--global-config", ".config-pep8", "-i"]
 -   repo: https://github.com/pre-commit/mirrors-isort
     rev: v4.3.20
     hooks:

--- a/appium/webdriver/extensions/applications.py
+++ b/appium/webdriver/extensions/applications.py
@@ -177,9 +177,9 @@ class Applications(webdriver.Remote):
             string_file (str): the name of the string file to query
         """
         data = {}
-        if language != None:
+        if language is not None:
             data['language'] = language
-        if string_file != None:
+        if string_file is not None:
             data['stringFile'] = string_file
         return self.execute(Command.GET_APP_STRINGS, data)['value']
 

--- a/ci.sh
+++ b/ci.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 
-if ! python -m autopep8 -r --global-config .config-pep8 -i . ; then
-  echo "Please run command 'python -m autopep8 -r --global-config .config-pep8 -i .' on your local and commit the result"
+if ! python -m autopep8 --exit-code -a -r --global-config .config-pep8 -i . ; then
+  echo "Please run command 'python -m autopep8 -a -r --global-config .config-pep8 -i .' on your local and commit the result"
   exit 1
 fi
 

--- a/test/unit/webdriver/device/location_test.py
+++ b/test/unit/webdriver/device/location_test.py
@@ -75,7 +75,7 @@ class TestWebDriverLocation(object):
         d = get_httpretty_request_body(httpretty.last_request())
         assert abs(d['location']['latitude'] - 11.1) <= FLT_EPSILON
         assert abs(d['location']['longitude'] - 22.2) <= FLT_EPSILON
-        assert d['location'].get('altitude') == None
+        assert d['location'].get('altitude') is None
 
     @httpretty.activate
     def test_location(self):


### PR DESCRIPTION
## Changes
* Fix: CI doesn't fail even if autopep8 makes changes
* Add `a` option to autopep8
   * To reduce review comments for coding style
   * https://github.com/hhatto/autopep8#more-advanced-usage
   * `-a, --aggressive      enable non-whitespace changes; multiple -a result in more aggressive changes`
