### PR TITLE
Fix isort behavior for mock

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,4 +1,4 @@
 [settings]
 multi_line_output = 3
-known_third_party = dateutil,httpretty,pytest,selenium,setuptools,urllib3
+known_third_party = dateutil,httpretty,pytest,selenium,setuptools,urllib3,mock
 known_first_party = test

--- a/README.md
+++ b/README.md
@@ -51,7 +51,9 @@ download and unarchive the source tarball (Appium-Python-Client-X.X.tar.gz).
         ```
         $ python -m isort -rc .
         ```
-        - When you use newly 3rd party modules, add it to [.isort.cfg](.isort.cfg)
+        - When you use newly 3rd party modules, add it to [.isort.cfg](.isort.cfg) to keep import order correct
+- Docstring style: Google Style
+    - Refer [link](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html)
 - You can customise `CHANGELOG.rst` with commit messages following [.gitchangelog.rc](.gitchangelog.rc)
     - It generates readable changelog
 - Setup

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ download and unarchive the source tarball (Appium-Python-Client-X.X.tar.gz).
         ```
         $ python -m isort -rc .
         ```
+        - When you use newly 3rd party modules, add it to [.isort.cfg](.isort.cfg)
 - You can customise `CHANGELOG.rst` with commit messages following [.gitchangelog.rc](.gitchangelog.rc)
     - It generates readable changelog
 - Setup

--- a/test/functional/android/activities_tests.py
+++ b/test/functional/android/activities_tests.py
@@ -15,20 +15,10 @@
 
 import unittest
 
-from appium import webdriver
-
-from .helper import desired_capabilities
 from .helper.test_helper import BaseTestCase
 
 
 class ActivitiesTests(BaseTestCase):
-    def setUp(self):
-        desired_caps = desired_capabilities.get_desired_capabilities('ApiDemos-debug.apk')
-        self.driver = webdriver.Remote('http://localhost:4723/wd/hub', desired_caps)
-
-    def tearDown(self):
-        self.driver.quit()
-
     def test_current_activity(self):
         activity = self.driver.current_activity
         self.assertEqual('.ApiDemos', activity)


### PR DESCRIPTION
I reproduced https://github.com/appium/python-client/pull/429#issuecomment-523845293 in my local. ( `mock` was handled as 1st party module.)
So this commit fixes isort behavior for `mock` as 3rd party module.