### PR TITLE
Fix CI fails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ python:
   - "3.5"
   - "3.6"
   - "3.7"
-  - "3.8-dev"
+#  - "3.8-dev"  # TODO Remove comment-out when pylint and astroid upgraded to the latest and py2 support dropped
 
 install:
   - pip install tox-travis

--- a/test/functional/android/helper/test_helper.py
+++ b/test/functional/android/helper/test_helper.py
@@ -64,6 +64,8 @@ class BaseTestCase(unittest.TestCase):
         self.driver = webdriver.Remote('http://localhost:4723/wd/hub', desired_caps)
 
     def tearDown(self):
-        img_path = os.path.join(os.getcwd(), self._testMethodName + '.png')
-        self.driver.get_screenshot_as_file(img_path)
+        if is_ci():
+            # Take the screenshot to investigate when tests failed only on CI
+            img_path = os.path.join(os.getcwd(), self._testMethodName + '.png')
+            self.driver.get_screenshot_as_file(img_path)
         self.driver.quit()

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ envlist =
     py35,
     py36,
     py37,
-    py38
+#    py38  # TODO Remove comment-out when pylint and astroid upgraded to the latest and py2 support dropped
 
 [testenv]
 deps =


### PR DESCRIPTION
### Failed CI build
* https://travis-ci.org/appium/python-client/jobs/583237973

### Reasons
1. Already failing by https://github.com/appium/python-client/pull/433, but travis CI missed fails
2. https://github.com/appium/python-client/pull/431 outputs correct results
3. As a result that above 2 PRs merged, travis CI is failing

### Root cause
The combination with py3.8 and current pylint and astroid versions in `Pipfile` doesn't work