### PR TITLE
Fix CI fails (Updated iOS ver)

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,4 +1,4 @@
 [settings]
 multi_line_output = 3
-known_third_party = dateutil,httpretty,pytest,selenium,setuptools,urllib3,mock
+known_third_party = dateutil,httpretty,pytest,selenium,setuptools,urllib3,mock,sauceclient
 known_first_party = test

--- a/appium/saucetestcase.py
+++ b/appium/saucetestcase.py
@@ -20,8 +20,9 @@ import os
 import sys
 import unittest
 
-from appium import webdriver
 from sauceclient import SauceClient
+
+from appium import webdriver
 
 SAUCE_USERNAME = os.environ.get('SAUCE_USERNAME')
 SAUCE_ACCESS_KEY = os.environ.get('SAUCE_ACCESS_KEY')

--- a/test/functional/ios/helper/desired_capabilities.py
+++ b/test/functional/ios/helper/desired_capabilities.py
@@ -24,16 +24,18 @@ def PATH(p): return os.path.abspath(
 BUNDLE_ID = 'com.example.apple-samplecode.UICatalog'
 
 
-def get_desired_capabilities(app):
+def get_desired_capabilities(app=None):
     desired_caps = {
         'deviceName': iphone_device_name(),
         'platformName': 'iOS',
         'platformVersion': '12.4',
-        'app': PATH('../../../apps/{}'.format(app)),
         'automationName': 'XCUITest',
         'allowTouchIdEnroll': True,
         'wdaLocalPort': wda_port(),
     }
+
+    if app is not None:
+        desired_caps['app'] = PATH('../../../apps/{}'.format(app))
 
     return desired_caps
 

--- a/test/functional/ios/helper/desired_capabilities.py
+++ b/test/functional/ios/helper/desired_capabilities.py
@@ -28,7 +28,7 @@ def get_desired_capabilities(app):
     desired_caps = {
         'deviceName': iphone_device_name(),
         'platformName': 'iOS',
-        'platformVersion': '12.2',
+        'platformVersion': '12.4',
         'app': PATH('../../../apps/{}'.format(app)),
         'automationName': 'XCUITest',
         'allowTouchIdEnroll': True,

--- a/test/functional/ios/safari_tests.py
+++ b/test/functional/ios/safari_tests.py
@@ -15,19 +15,17 @@
 import unittest
 
 from appium import webdriver
-
+from .helper.desired_capabilities import get_desired_capabilities
 
 class SafariTests(unittest.TestCase):
     def setUp(self):
-        desired_caps = {
+        desired_caps = get_desired_capabilities()
+        desired_caps.update({
             'browserName': 'safari',
-            'platformName': 'iOS',
-            'platformVersion': '12.2',
-            'deviceName': 'iPhone Simulator',
             'nativeWebTap': True,
-            'safariIgnoreFraudWarning': True,
-            'automationName': 'XCUITest'
-        }
+            'safariIgnoreFraudWarning': True
+        })
+
         self.driver = webdriver.Remote('http://localhost:4723/wd/hub', desired_caps)
 
     def tearDown(self):

--- a/test/functional/ios/safari_tests.py
+++ b/test/functional/ios/safari_tests.py
@@ -15,7 +15,9 @@
 import unittest
 
 from appium import webdriver
+
 from .helper.desired_capabilities import get_desired_capabilities
+
 
 class SafariTests(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
## Problem

CI failed due to below error log

```
E       selenium.common.exceptions.WebDriverException:
Message: An unknown server-side error occurred while processing the command.
Original error: Could not create simulator with name 'appiumTest-A651F479-95B0-47C8-9278-F71B25A780B6-iPhone 8',
device type id 'iPhone 8' and runtime id 'com.apple.CoreSimulator.SimRuntime.iOS-12-2'.
Reason: 'simctl error running 'create': Invalid runtime: com.apple.CoreSimulator.SimRuntime.iOS-12-2'
```

## How to fix
Upgraded iOS ver for simulator from 12.2 to 12.4