### PR TITLE
chore: add try/catch in release script

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -8,6 +8,6 @@ if [ -z "$PYTHON_BIN_PATH" ]; then
 fi
 
 CONFIGURE_DIR=$(dirname "$0")
-"$PYTHON_BIN_PATH" "${CONFIGURE_DIR}/script/release.py" "$@"
+"$PYTHON_BIN_PATH" -m "${CONFIGURE_DIR}/script/release.py" "$@"
 
 echo "Finish release process"

--- a/release.sh
+++ b/release.sh
@@ -8,6 +8,6 @@ if [ -z "$PYTHON_BIN_PATH" ]; then
 fi
 
 CONFIGURE_DIR=$(dirname "$0")
-"$PYTHON_BIN_PATH" -m "${CONFIGURE_DIR}/script/release.py" "$@"
+"$PYTHON_BIN_PATH" "${CONFIGURE_DIR}/script/release.py" "$@"
 
 echo "Finish release process"

--- a/script/release.py
+++ b/script/release.py
@@ -65,7 +65,13 @@ def tag_and_generate_changelog(new_version_num):
 
 
 def upload_sdist(new_version_num):
-    call_bash_script('twine upload "dist/Appium-Python-Client-{}.tar.gz"'.format(new_version_num))
+    push_file = 'dist/Appium-Python-Client-{}.tar.gz'.format(new_version_num)
+    try:
+        call_bash_script('twine upload "{}"'.format(push_file))
+    except Exception as e:
+        print('Failed to upload {} to pypi. '
+              'Please make sure your environment and push it later. Original error: {}'.format(
+                  push_file, e))
 
 
 def push_changes_to_master(new_version_num):
@@ -81,7 +87,7 @@ def ensure_publication(new_version_num):
     for line in sys.stdin:
         if line.rstrip().lower() == 'y':
             return
-        exit('Canceled release pricess.')
+        exit('Canceled release process.')
 
 
 def build_sdist():

--- a/script/release.py
+++ b/script/release.py
@@ -70,7 +70,7 @@ def upload_sdist(new_version_num):
         call_bash_script('twine upload "{}"'.format(push_file))
     except Exception as e:
         print('Failed to upload {} to pypi. '
-              'Please make sure your environment and push it later. Original error: {}'.format(
+              'Please fix the original error and push it again later. Original error: {}'.format(
                   push_file, e))
 
 


### PR DESCRIPTION
If the python environment has no `twine`, an exception will occur. The command only pushes the dist module to pypi. (Building the  module is in another  method)
It can run after other tasks, so let me show a message to push later when the command fails.