### PR TITLE
feat: Override send_keys without file upload function

### DIFF
--- a/appium/webdriver/webelement.py
+++ b/appium/webdriver/webelement.py
@@ -206,15 +206,17 @@ class WebElement(AppiumWebElementSearchContext):
         self._execute(Command.SET_IMMEDIATE_VALUE, data)
         return self
 
-    def send_keys_direct(self, *value):
+    # Override
+    def send_keys(self, *value):
         """Simulates typing into the element.
 
-        Please consider to use this method if WebElement#send_keys did not work.
-        WebElement#send_keys works uploading a local file, but this method simply
-        sends given string without such uploading.
+        Args:
+            value (str): A string for typing.
 
-        Argument is the same as WebElement#send_keys
+        Returns:
+            `appium.webdriver.webelement.WebElement`
         """
         self._execute(RemoteCommand.SEND_KEYS_TO_ELEMENT,
                       {'text': "".join(keys_to_typing(value)),
                        'value': keys_to_typing(value)})
+        return self

--- a/appium/webdriver/webelement.py
+++ b/appium/webdriver/webelement.py
@@ -216,7 +216,7 @@ class WebElement(AppiumWebElementSearchContext):
         Returns:
             `appium.webdriver.webelement.WebElement`
         """
-        _value = keys_to_typing(value)
+        keys = keys_to_typing(value)
         self._execute(RemoteCommand.SEND_KEYS_TO_ELEMENT,
-                      {'text': "".join(_value), 'value': _value})
+                      {'text': ''.join(keys), 'value': keys})
         return self

--- a/appium/webdriver/webelement.py
+++ b/appium/webdriver/webelement.py
@@ -216,7 +216,7 @@ class WebElement(AppiumWebElementSearchContext):
         Returns:
             `appium.webdriver.webelement.WebElement`
         """
+        _value = keys_to_typing(value)
         self._execute(RemoteCommand.SEND_KEYS_TO_ELEMENT,
-                      {'text': "".join(keys_to_typing(value)),
-                       'value': keys_to_typing(value)})
+                      {'text': "".join(_value), 'value': _value})
         return self

--- a/appium/webdriver/webelement.py
+++ b/appium/webdriver/webelement.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from selenium.webdriver.common.by import By
+from selenium.webdriver.common.utils import keys_to_typing
 from selenium.webdriver.remote.command import Command as RemoteCommand
 
 from .extensions.search_context import AppiumWebElementSearchContext
@@ -204,3 +205,16 @@ class WebElement(AppiumWebElementSearchContext):
         }
         self._execute(Command.SET_IMMEDIATE_VALUE, data)
         return self
+
+    def send_keys_direct(self, *value):
+        """Simulates typing into the element.
+
+        Please consider to use this method if WebElement#send_keys did not work.
+        WebElement#send_keys works uploading a local file, but this method simply
+        sends given string without such uploading.
+
+        Argument is the same as WebElement#send_keys
+        """
+        self._execute(RemoteCommand.SEND_KEYS_TO_ELEMENT,
+                      {'text': "".join(keys_to_typing(value)),
+                       'value': keys_to_typing(value)})

--- a/test/functional/ios/keyboard_tests.py
+++ b/test/functional/ios/keyboard_tests.py
@@ -52,7 +52,7 @@ class KeyboardTests(BaseTestCase):
 
         el = self.driver.find_elements_by_class_name('XCUIElementTypeTextField')[0]
         el.click()
-        el.set_value('Testing')
+        el.send_keys('Testing')
 
         el = self.driver.find_element_by_class_name('UIAKeyboard')
         self.assertTrue(el.is_displayed())
@@ -68,7 +68,7 @@ class KeyboardTests(BaseTestCase):
 
         el = self.driver.find_elements_by_class_name('XCUIElementTypeTextField')[0]
         el.click()
-        el.set_value('Testing')
+        el.send_keys('Testing')
         self.assertTrue(self.driver.is_keyboard_shown())
 
     def _move_to_textbox(self):

--- a/test/functional/ios/keyboard_tests.py
+++ b/test/functional/ios/keyboard_tests.py
@@ -52,7 +52,7 @@ class KeyboardTests(BaseTestCase):
 
         el = self.driver.find_elements_by_class_name('XCUIElementTypeTextField')[0]
         el.click()
-        el.send_keys('Testing')
+        el.set_value('Testing')
 
         el = self.driver.find_element_by_class_name('UIAKeyboard')
         self.assertTrue(el.is_displayed())
@@ -68,7 +68,7 @@ class KeyboardTests(BaseTestCase):
 
         el = self.driver.find_elements_by_class_name('XCUIElementTypeTextField')[0]
         el.click()
-        el.send_keys('Testing')
+        el.set_value('Testing')
         self.assertTrue(self.driver.is_keyboard_shown())
 
     def _move_to_textbox(self):

--- a/test/unit/webdriver/webelement_test.py
+++ b/test/unit/webdriver/webelement_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import json
+import os
 import tempfile
 
 import httpretty

--- a/test/unit/webdriver/webelement_test.py
+++ b/test/unit/webdriver/webelement_test.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import tempfile
+
+import httpretty
+
+from appium.webdriver.webelement import WebElement as MobileWebElement
+from test.unit.helper.test_helper import (
+    android_w3c_driver,
+    appium_command,
+    get_httpretty_request_body
+)
+
+
+class TestWebElement(object):
+
+    @httpretty.activate
+    def test_send_key(self):
+        driver = android_w3c_driver()
+        httpretty.register_uri(
+            httpretty.POST,
+            appium_command('/session/1234567890/element/element_id/value')
+        )
+
+        element = MobileWebElement(driver, 'element_id', w3c=True)
+        element.send_keys('happy testing')
+
+        d = get_httpretty_request_body(httpretty.last_request())
+        assert d['text'] == ''.join(d['value'])
+
+    @httpretty.activate
+    def test_send_key_with_file(self):
+        driver = android_w3c_driver()
+        # Should not send this file
+        tmp_f = tempfile.NamedTemporaryFile()
+        httpretty.register_uri(
+            httpretty.POST,
+            appium_command('/session/1234567890/element/element_id/value')
+        )
+
+        try:
+            element = MobileWebElement(driver, 'element_id', w3c=True)
+            element.send_keys(tmp_f.name)
+        finally:
+            tmp_f.close()
+
+        d = get_httpretty_request_body(httpretty.last_request())
+        assert d['text'] == ''.join(d['value'])


### PR DESCRIPTION
Will update the naming, but let me create a PR as a draft

background: https://github.com/appium/appium-desktop/issues/1335
`send_keys` by some selenium bindings send a local file binary if the given string is a file.
But https://github.com/appium/appium-desktop/issues/1335 has a use case won't send a local file even if the given string is a local path.