### PR TITLE
chore: Fix int - str comparison error in ios desired capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,18 +92,18 @@ $ pytest -n 2 test/unit
 ### Functional
 
 ```
-$ pytest test/functional/ios/find_by_ios_class_chain_tests.py
+$ pytest test/functional/ios/search_context/find_by_ios_class_chain_tests.py
 ```
 
 ### In parallel for iOS
-1. Create simulators named 'iPhone 6s - 8100' and 'iPhone 6s - 8101'
+1. Create simulators named 'iPhone 8 - 8100' and 'iPhone 8 - 8101'
 2. Install test libraries via pip
     ```
     $ pip install pytest pytest-xdist
     ```
 3. Run tests
     ```
-    $ pytest -n 2 test/functional/ios/find_by_ios_class_chain_tests.py
+    $ pytest -n 2 test/functional/ios/search_context/find_by_ios_class_chain_tests.py
     ```
 
 # Release

--- a/test/functional/ios/helper/desired_capabilities.py
+++ b/test/functional/ios/helper/desired_capabilities.py
@@ -50,7 +50,7 @@ class PytestXdistWorker(object):
         if PytestXdistWorker.COUNT is None:
             return '0'
 
-        if number >= PytestXdistWorker.COUNT:
+        if number >= int(PytestXdistWorker.COUNT):
             return 'gw0'
 
         return 'gw{}'.format(number)
@@ -65,7 +65,7 @@ def wda_port():
     return 8100
 
 
-# Before running tests, you must have iOS simulators named 'iPhone 6s - 8100' and 'iPhone 6s - 8101'
+# Before running tests, you must have iOS simulators named 'iPhone 8 - 8100' and 'iPhone 8 - 8101'
 
 
 def iphone_device_name(port=None):


### PR DESCRIPTION
For #373 
### **Changes**
1. Fix for below error in ios desired_capabilities, which occurred when trying to run ios functional tests in parallel

```
if number >= PytestXdistWorker.COUNT:
TypeError: '>=' not supported between instances of 'int' and 'str'
```

2. Updated test case folder path and iPhone model in Readme file

### **Results**
```
(appium-dev) akvenk:search_context akvenk$ pytest -n 2 find_by_ios_class_chain_tests.py 
bringing up nodes...
..                                                                                                                                                                                                                              [100%]Coverage.py warning: Module appium was never imported. (module-not-imported)
Coverage.py warning: No data was collected. (no-data-collected)


---------- coverage: platform darwin, python 3.7.3-final-0 -----------
Name                                                                                                                        Stmts   Miss  Cover
-----------------------------------------------------------------------------------------------------------------------------------------------
/Users/akvenk/Documents/github/appium-dev/python-client/appium/__init__.py                                                      6      1    83%
/Users/akvenk/Documents/github/appium-dev/python-client/appium/common/__init__.py                                               1      0   100%
/Users/akvenk/Documents/github/appium-dev/python-client/appium/common/exceptions.py                                             3      0   100%
/Users/akvenk/Documents/github/appium-dev/python-client/appium/common/helper.py                                                11      5    55%
/Users/akvenk/Documents/github/appium-dev/python-client/appium/common/logger.py                                                 9      0   100%
/Users/akvenk/Documents/github/appium-dev/python-client/appium/saucetestcase.py                                                30     25    17%
/Users/akvenk/Documents/github/appium-dev/python-client/appium/version.py                                                       1      0   100%
/Users/akvenk/Documents/github/appium-dev/python-client/appium/webdriver/__init__.py                                            3      0   100%
/Users/akvenk/Documents/github/appium-dev/python-client/appium/webdriver/appium_connection.py                                  11      0   100%
/Users/akvenk/Documents/github/appium-dev/python-client/appium/webdriver/appium_service.py                                    131    131     0%
/Users/akvenk/Documents/github/appium-dev/python-client/appium/webdriver/applicationstate.py                                    6      6     0%
/Users/akvenk/Documents/github/appium-dev/python-client/appium/webdriver/clipboard_content_type.py                              4      0   100%
/Users/akvenk/Documents/github/appium-dev/python-client/appium/webdriver/common/__init__.py                                     1      0   100%
/Users/akvenk/Documents/github/appium-dev/python-client/appium/webdriver/common/mobileby.py                                    13      0   100%
/Users/akvenk/Documents/github/appium-dev/python-client/appium/webdriver/common/multi_action.py                                23     16    30%
/Users/akvenk/Documents/github/appium-dev/python-client/appium/webdriver/common/touch_action.py                                54     40    26%
/Users/akvenk/Documents/github/appium-dev/python-client/appium/webdriver/connectiontype.py                                      7      7     0%
/Users/akvenk/Documents/github/appium-dev/python-client/appium/webdriver/errorhandler.py                                       11      4    64%
/Users/akvenk/Documents/github/appium-dev/python-client/appium/webdriver/extensions/__init__.py                                 0      0   100%
/Users/akvenk/Documents/github/appium-dev/python-client/appium/webdriver/extensions/action_helpers.py                          46     37    20%
/Users/akvenk/Documents/github/appium-dev/python-client/appium/webdriver/extensions/android/__init__.py                         0      0   100%
/Users/akvenk/Documents/github/appium-dev/python-client/appium/webdriver/extensions/android/activities.py                      24     13    46%
/Users/akvenk/Documents/github/appium-dev/python-client/appium/webdriver/extensions/android/common.py                          15      5    67%
/Users/akvenk/Documents/github/appium-dev/python-client/appium/webdriver/extensions/android/display.py                          7      1    86%
/Users/akvenk/Documents/github/appium-dev/python-client/appium/webdriver/extensions/android/gsm.py                             46     15    67%
/Users/akvenk/Documents/github/appium-dev/python-client/appium/webdriver/extensions/android/nativekey.py                      295    295     0%
/Users/akvenk/Documents/github/appium-dev/python-client/appium/webdriver/extensions/android/network.py                         34     10    71%
/Users/akvenk/Documents/github/appium-dev/python-client/appium/webdriver/extensions/android/performance.py                     13      5    62%
/Users/akvenk/Documents/github/appium-dev/python-client/appium/webdriver/extensions/android/power.py                           13      4    69%
/Users/akvenk/Documents/github/appium-dev/python-client/appium/webdriver/extensions/android/sms.py                              8      2    75%
/Users/akvenk/Documents/github/appium-dev/python-client/appium/webdriver/extensions/android/system_bars.py                      7      1    86%
/Users/akvenk/Documents/github/appium-dev/python-client/appium/webdriver/extensions/applications.py                            62     36    42%
/Users/akvenk/Documents/github/appium-dev/python-client/appium/webdriver/extensions/clipboard.py                               21      8    62%
/Users/akvenk/Documents/github/appium-dev/python-client/appium/webdriver/extensions/context.py                                 13      3    77%
/Users/akvenk/Documents/github/appium-dev/python-client/appium/webdriver/extensions/device_time.py                             12      4    67%
/Users/akvenk/Documents/github/appium-dev/python-client/appium/webdriver/extensions/execute_driver.py                          15      9    40%
/Users/akvenk/Documents/github/appium-dev/python-client/appium/webdriver/extensions/execute_mobile_command.py                   8      4    50%
/Users/akvenk/Documents/github/appium-dev/python-client/appium/webdriver/extensions/hw_actions.py                              33     15    55%
/Users/akvenk/Documents/github/appium-dev/python-client/appium/webdriver/extensions/images_comparison.py                       14      6    57%
/Users/akvenk/Documents/github/appium-dev/python-client/appium/webdriver/extensions/ime.py                                     22      8    64%
/Users/akvenk/Documents/github/appium-dev/python-client/appium/webdriver/extensions/keyboard.py                                44     30    32%
/Users/akvenk/Documents/github/appium-dev/python-client/appium/webdriver/extensions/location.py                                18      8    56%
/Users/akvenk/Documents/github/appium-dev/python-client/appium/webdriver/extensions/log_event.py                               15      7    53%
/Users/akvenk/Documents/github/appium-dev/python-client/appium/webdriver/extensions/remote_fs.py                               29     17    41%
/Users/akvenk/Documents/github/appium-dev/python-client/appium/webdriver/extensions/screen_record.py                           16      8    50%
/Users/akvenk/Documents/github/appium-dev/python-client/appium/webdriver/extensions/search_context/__init__.py                  9      0   100%
/Users/akvenk/Documents/github/appium-dev/python-client/appium/webdriver/extensions/search_context/android.py                  24     12    50%
/Users/akvenk/Documents/github/appium-dev/python-client/appium/webdriver/extensions/search_context/base_search_context.py       5      2    60%
/Users/akvenk/Documents/github/appium-dev/python-client/appium/webdriver/extensions/search_context/custom.py                    7      2    71%
/Users/akvenk/Documents/github/appium-dev/python-client/appium/webdriver/extensions/search_context/ios.py                      15      5    67%
/Users/akvenk/Documents/github/appium-dev/python-client/appium/webdriver/extensions/search_context/mobile.py                   16      8    50%
/Users/akvenk/Documents/github/appium-dev/python-client/appium/webdriver/extensions/search_context/windows.py                   7      2    71%
/Users/akvenk/Documents/github/appium-dev/python-client/appium/webdriver/extensions/session.py                                 18      8    56%
/Users/akvenk/Documents/github/appium-dev/python-client/appium/webdriver/extensions/settings.py                                12      4    67%
/Users/akvenk/Documents/github/appium-dev/python-client/appium/webdriver/mobilecommand.py                                      77      0   100%
/Users/akvenk/Documents/github/appium-dev/python-client/appium/webdriver/switch_to.py                                           5      1    80%
/Users/akvenk/Documents/github/appium-dev/python-client/appium/webdriver/webdriver.py                                         146     38    74%
/Users/akvenk/Documents/github/appium-dev/python-client/appium/webdriver/webelement.py                                         44     18    59%
-----------------------------------------------------------------------------------------------------------------------------------------------
TOTAL                                                                                                                        1540    886    42%

2 passed in 20.36 seconds
```