### PR TITLE
fix: Handling of dictionary-values in WebElement.get_attribute()

### DIFF
--- a/appium/webdriver/webelement.py
+++ b/appium/webdriver/webelement.py
@@ -59,8 +59,14 @@ class WebElement(AppiumWebElementSearchContext):
         if attributeValue is None:
             return None
 
+        if isinstance(attributeValue, dict):
+            return attributeValue
+
         if not isinstance(attributeValue, str):
-            attributeValue = unicode(attributeValue)
+            try:
+                attributeValue = unicode(attributeValue)
+            except NameError:
+                attributeValue = str(attributeValue)
 
         if name != 'value' and attributeValue.lower() in ('true', 'false'):
             return attributeValue.lower()

--- a/test/unit/webdriver/webelement_test.py
+++ b/test/unit/webdriver/webelement_test.py
@@ -75,3 +75,26 @@ class TestWebElement(object):
 
         d = get_httpretty_request_body(httpretty.last_request())
         assert d['text'] == ''.join(d['value'])
+
+    @httpretty.activate
+    def test_get_attribute_with_dict(self):
+        driver = android_w3c_driver()
+        rect_dict = {
+            'y': 200,
+            'x': 100,
+            'width': 300,
+            'height': 56
+        }
+        httpretty.register_uri(
+            httpretty.GET,
+            appium_command('/session/1234567890/element/element_id/attribute/rect'),
+            body=json.dumps({"value": rect_dict})
+        )
+
+        element = MobileWebElement(driver, 'element_id', w3c=True)
+        ef = element.get_attribute('rect')
+
+        d = httpretty.last_request()
+
+        assert isinstance(ef, dict)
+        assert ef == rect_dict


### PR DESCRIPTION
## Changes
- Add additional type check to ```get_attribute()``` to avoid mishandling of dictionaries received from an Appium server.

## Problem
get_attribute() in WebElement currently cannot receive dictionary values.


E.g. when calling ```get_attribute('rect')``` on an element the Appium iOS Server returns a dictionary of coordinates and size which the Python client cannot handle:

```
>>> buttons[2].get_attribute('rect')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python3.7/site-packages/appium/webdriver/webelement.py", line 66, in get_attribute
    attributeValue = unicode(attributeValue)
NameError: name 'unicode' is not defined
```

*(Note that the NameError results from me using Python 3 in which ```unicode()``` is not available. I am not sure whether this should be considered an issue as well or not. The core issue is that this code path shouldn't be reached in this case anyways.)*

When the client receives a return value from the Appium server but it isn't of type ```str``` it tries to convert it to one using ```unicode()```; as far as I can tell this is because of the different string types available in Python 2. However this leads to an issues if the value received isn't a ```str``` but a ```dict``` in which case the client still tries to convert it even though it isn't supposed to be handled as a string at all (calling ```unicode()``` on a ```dict``` in Python 2 would also lead to undesired behaviour because the value would effectively be converted to a string as well).

## Proposed Fix
The proposed fix adds a check and immediately returns the value if it is a dictionary. This avoids undesired behaviour (the NameError seen above when using Python 3, or the value being converted to a string when using Python 2) but leaves the existing conversion in place in case the value is neither a dictionary nor a ```str```.

I have further added a test case to the WebElement unit test that checks whether ```get_attribute()``` correctly receives and passes on received dictionaries.

I have run both ```$ tox``` and ```$ pytest test/unit``` and did not see any testing regressions due to the proposed change.