### PR TITLE
fix: Tune mixin types, so linters could recognize them better

### DIFF
--- a/appium/webdriver/extensions/action_helpers.py
+++ b/appium/webdriver/extensions/action_helpers.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import TYPE_CHECKING, List, Optional, Tuple, TypeVar
+from typing import List, Optional, Tuple, TypeVar, Union
 
 from selenium import webdriver
 
@@ -20,21 +20,18 @@ from appium.webdriver.common.multi_action import MultiAction
 from appium.webdriver.common.touch_action import TouchAction
 from appium.webdriver.webelement import WebElement
 
-if TYPE_CHECKING:
-    from appium.webdriver.webdriver import WebDriver
-
-T = TypeVar('T', bound='WebDriver')
+T = TypeVar('T', bound=Union[webdriver.Remote, 'ActionHelpers'])
 
 
 class ActionHelpers(webdriver.Remote):
 
-    def scroll(self, origin_el: WebElement, destination_el: WebElement, duration: Optional[int] = None) -> T:
+    def scroll(self: T, origin_el: WebElement, destination_el: WebElement, duration: Optional[int] = None) -> T:
         """Scrolls from one element to another
 
         Args:
-            originalEl (`appium.webdriver.webelement.WebElement`): the element from which to being scrolling
-            destinationEl (`appium.webdriver.webelement.WebElement`): the element to scroll to
-            duration (int): a duration after pressing originalEl and move the element to destinationEl.
+            origin_el: the element from which to being scrolling
+            destination_el: the element to scroll to
+            duration: a duration after pressing originalEl and move the element to destinationEl.
                 Default is 600 ms for W3C spec. Zero for MJSONWP.
 
         Usage:
@@ -55,12 +52,12 @@ class ActionHelpers(webdriver.Remote):
             action.press(origin_el).wait(duration).move_to(destination_el).release().perform()
         return self
 
-    def drag_and_drop(self, origin_el: WebElement, destination_el: WebElement) -> T:
+    def drag_and_drop(self: T, origin_el: WebElement, destination_el: WebElement) -> T:
         """Drag the origin element to the destination element
 
         Args:
-            originEl (`appium.webdriver.webelement.WebElement`): the element to drag
-            destinationEl (`appium.webdriver.webelement.WebElement`): the element to drag to
+            origin_el: the element to drag
+            destination_el: the element to drag to
 
         Returns:
             `appium.webdriver.webelement.WebElement`
@@ -69,7 +66,7 @@ class ActionHelpers(webdriver.Remote):
         action.long_press(origin_el).move_to(destination_el).release().perform()
         return self
 
-    def tap(self, positions: List[Tuple[int, int]], duration: Optional[int] = None) -> T:
+    def tap(self: T, positions: List[Tuple[int, int]], duration: Optional[int] = None) -> T:
         """Taps on an particular place with up to five fingers, holding for a
         certain time
 
@@ -108,7 +105,7 @@ class ActionHelpers(webdriver.Remote):
             ma.perform()
         return self
 
-    def swipe(self, start_x: int, start_y: int, end_x: int, end_y: int, duration: int = 0) -> T:
+    def swipe(self: T, start_x: int, start_y: int, end_x: int, end_y: int, duration: int = 0) -> T:
         """Swipe from one point to another point, for an optional duration.
 
         Args:
@@ -135,7 +132,7 @@ class ActionHelpers(webdriver.Remote):
         action.perform()
         return self
 
-    def flick(self, start_x: int, start_y: int, end_x: int, end_y: int) -> T:
+    def flick(self: T, start_x: int, start_y: int, end_x: int, end_y: int) -> T:
         """Flick from one point to another point.
 
         Args:

--- a/appium/webdriver/extensions/action_helpers.py
+++ b/appium/webdriver/extensions/action_helpers.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import List, Optional, Tuple, TypeVar, Union, TYPE_CHECKING
+from typing import TYPE_CHECKING, List, Optional, Tuple, TypeVar, Union
 
 from selenium import webdriver
 

--- a/appium/webdriver/extensions/action_helpers.py
+++ b/appium/webdriver/extensions/action_helpers.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import List, Optional, Tuple, TypeVar, Union
+from typing import List, Optional, Tuple, TypeVar, Union, TYPE_CHECKING
 
 from selenium import webdriver
 
@@ -20,7 +20,11 @@ from appium.webdriver.common.multi_action import MultiAction
 from appium.webdriver.common.touch_action import TouchAction
 from appium.webdriver.webelement import WebElement
 
-T = TypeVar('T', bound=Union[webdriver.Remote, 'ActionHelpers'])
+if TYPE_CHECKING:
+    # noinspection PyUnresolvedReferences
+    from appium.webdriver.webdriver import WebDriver
+
+T = TypeVar('T', bound=Union['WebDriver', 'ActionHelpers'])
 
 
 class ActionHelpers(webdriver.Remote):

--- a/appium/webdriver/extensions/android/activities.py
+++ b/appium/webdriver/extensions/android/activities.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Union, TypeVar
+from typing import Union, TypeVar, TYPE_CHECKING
 
 from selenium import webdriver
 from selenium.common.exceptions import TimeoutException
@@ -20,7 +20,11 @@ from selenium.webdriver.support.ui import WebDriverWait
 
 from appium.webdriver.mobilecommand import MobileCommand as Command
 
-T = TypeVar('T', bound=Union[webdriver.Remote, 'Activities'])
+if TYPE_CHECKING:
+    # noinspection PyUnresolvedReferences
+    from appium.webdriver.webdriver import WebDriver
+
+T = TypeVar('T', bound=Union['WebDriver', 'Activities'])
 
 
 class Activities(webdriver.Remote):
@@ -93,7 +97,7 @@ class Activities(webdriver.Remote):
 
     # pylint: disable=protected-access
     # noinspection PyProtectedMember
-    def _addCommands(self: T) -> None:
+    def _addCommands(self) -> None:
         self.command_executor._commands[Command.GET_CURRENT_ACTIVITY] = \
             ('GET', '/session/$sessionId/appium/device/current_activity')
         self.command_executor._commands[Command.START_ACTIVITY] = \

--- a/appium/webdriver/extensions/android/activities.py
+++ b/appium/webdriver/extensions/android/activities.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Union, TypeVar, TYPE_CHECKING
+from typing import TYPE_CHECKING, TypeVar, Union
 
 from selenium import webdriver
 from selenium.common.exceptions import TimeoutException

--- a/appium/webdriver/extensions/android/activities.py
+++ b/appium/webdriver/extensions/android/activities.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import TYPE_CHECKING, TypeVar
+from typing import Union, TypeVar
 
 from selenium import webdriver
 from selenium.common.exceptions import TimeoutException
@@ -20,14 +20,11 @@ from selenium.webdriver.support.ui import WebDriverWait
 
 from appium.webdriver.mobilecommand import MobileCommand as Command
 
-if TYPE_CHECKING:
-    from appium.webdriver.webdriver import WebDriver
-
-T = TypeVar('T', bound='WebDriver')
+T = TypeVar('T', bound=Union[webdriver.Remote, 'Activities'])
 
 
 class Activities(webdriver.Remote):
-    def start_activity(self, app_package: str, app_activity: str, **opts: str) -> T:
+    def start_activity(self: T, app_package: str, app_activity: str, **opts: str) -> T:
         """Opens an arbitrary activity during a test. If the activity belongs to
         another application, that application is started and the activity is opened.
 
@@ -66,7 +63,7 @@ class Activities(webdriver.Remote):
         return self
 
     @property
-    def current_activity(self) -> str:
+    def current_activity(self: T) -> str:
         """Retrieves the current activity running on the device.
 
         Returns:
@@ -74,7 +71,7 @@ class Activities(webdriver.Remote):
         """
         return self.execute(Command.GET_CURRENT_ACTIVITY)['value']
 
-    def wait_activity(self, activity: str, timeout: int, interval: int = 1) -> bool:
+    def wait_activity(self: T, activity: str, timeout: int, interval: int = 1) -> bool:
         """Wait for an activity: block until target activity presents or time out.
 
         This is an Android-only method.
@@ -95,8 +92,8 @@ class Activities(webdriver.Remote):
             return False
 
     # pylint: disable=protected-access
-
-    def _addCommands(self) -> None:
+    # noinspection PyProtectedMember
+    def _addCommands(self: T) -> None:
         self.command_executor._commands[Command.GET_CURRENT_ACTIVITY] = \
             ('GET', '/session/$sessionId/appium/device/current_activity')
         self.command_executor._commands[Command.START_ACTIVITY] = \

--- a/appium/webdriver/extensions/android/common.py
+++ b/appium/webdriver/extensions/android/common.py
@@ -12,21 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import Union, Any, TypeVar
 
 from selenium import webdriver
 
 from appium.webdriver.mobilecommand import MobileCommand as Command
 
-if TYPE_CHECKING:
-    from appium.webdriver.webdriver import WebDriver
-
-T = TypeVar('T', bound='WebDriver')
+T = TypeVar('T', bound=Union[webdriver.Remote, 'Common'])
 
 
 class Common(webdriver.Remote):
 
-    def end_test_coverage(self, intent: str, path: str) -> Any:  # TODO Check return type
+    def end_test_coverage(self: T, intent: str, path: str) -> Any:  # TODO Check return type
         """Ends the coverage collection and pull the coverage.ec file from the device.
 
         Android only.
@@ -45,7 +42,7 @@ class Common(webdriver.Remote):
         }
         return self.execute(Command.END_TEST_COVERAGE, data)['value']
 
-    def open_notifications(self) -> T:
+    def open_notifications(self: T) -> T:
         """Open notification shade in Android (API Level 18 and above)
 
         Returns:
@@ -55,12 +52,13 @@ class Common(webdriver.Remote):
         return self
 
     @property
-    def current_package(self) -> str:
+    def current_package(self: T) -> str:
         """Retrieves the current package running on the device.
         """
         return self.execute(Command.GET_CURRENT_PACKAGE)['value']
 
-    def _addCommands(self) -> None:
+    # noinspection PyProtectedMember
+    def _addCommands(self: T) -> None:
         self.command_executor._commands[Command.GET_CURRENT_PACKAGE] = \
             ('GET', '/session/$sessionId/appium/device/current_package')
         self.command_executor._commands[Command.END_TEST_COVERAGE] = \

--- a/appium/webdriver/extensions/android/common.py
+++ b/appium/webdriver/extensions/android/common.py
@@ -12,13 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Union, Any, TypeVar
+from typing import Union, Any, TypeVar, TYPE_CHECKING
 
 from selenium import webdriver
 
 from appium.webdriver.mobilecommand import MobileCommand as Command
 
-T = TypeVar('T', bound=Union[webdriver.Remote, 'Common'])
+if TYPE_CHECKING:
+    # noinspection PyUnresolvedReferences
+    from appium.webdriver.webdriver import WebDriver
+
+T = TypeVar('T', bound=Union['WebDriver', 'Common'])
 
 
 class Common(webdriver.Remote):
@@ -58,7 +62,7 @@ class Common(webdriver.Remote):
         return self.execute(Command.GET_CURRENT_PACKAGE)['value']
 
     # noinspection PyProtectedMember
-    def _addCommands(self: T) -> None:
+    def _addCommands(self) -> None:
         self.command_executor._commands[Command.GET_CURRENT_PACKAGE] = \
             ('GET', '/session/$sessionId/appium/device/current_package')
         self.command_executor._commands[Command.END_TEST_COVERAGE] = \

--- a/appium/webdriver/extensions/android/common.py
+++ b/appium/webdriver/extensions/android/common.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Union, Any, TypeVar, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, TypeVar, Union
 
 from selenium import webdriver
 

--- a/appium/webdriver/extensions/android/display.py
+++ b/appium/webdriver/extensions/android/display.py
@@ -12,14 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import TypeVar, Union
+
 from selenium import webdriver
 
 from appium.webdriver.mobilecommand import MobileCommand as Command
 
+T = TypeVar('T', bound=Union[webdriver.Remote, 'Display'])
+
 
 class Display(webdriver.Remote):
 
-    def get_display_density(self) -> int:
+    def get_display_density(self: T) -> int:
         """Get the display density, Android only
 
         Returns:
@@ -31,7 +35,7 @@ class Display(webdriver.Remote):
         return self.execute(Command.GET_DISPLAY_DENSITY)['value']
 
     # pylint: disable=protected-access
-
-    def _addCommands(self) -> None:
+    # noinspection PyProtectedMember
+    def _addCommands(self: T) -> None:
         self.command_executor._commands[Command.GET_DISPLAY_DENSITY] = \
             ('GET', '/session/$sessionId/appium/device/display_density')

--- a/appium/webdriver/extensions/android/display.py
+++ b/appium/webdriver/extensions/android/display.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import TypeVar, Union, TYPE_CHECKING
+from typing import TYPE_CHECKING, TypeVar, Union
 
 from selenium import webdriver
 

--- a/appium/webdriver/extensions/android/display.py
+++ b/appium/webdriver/extensions/android/display.py
@@ -12,13 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import TypeVar, Union
+from typing import TypeVar, Union, TYPE_CHECKING
 
 from selenium import webdriver
 
 from appium.webdriver.mobilecommand import MobileCommand as Command
 
-T = TypeVar('T', bound=Union[webdriver.Remote, 'Display'])
+if TYPE_CHECKING:
+    # noinspection PyUnresolvedReferences
+    from appium.webdriver.webdriver import WebDriver
+
+T = TypeVar('T', bound=Union['WebDriver', 'Display'])
 
 
 class Display(webdriver.Remote):
@@ -36,6 +40,6 @@ class Display(webdriver.Remote):
 
     # pylint: disable=protected-access
     # noinspection PyProtectedMember
-    def _addCommands(self: T) -> None:
+    def _addCommands(self) -> None:
         self.command_executor._commands[Command.GET_DISPLAY_DENSITY] = \
             ('GET', '/session/$sessionId/appium/device/display_density')

--- a/appium/webdriver/extensions/android/gsm.py
+++ b/appium/webdriver/extensions/android/gsm.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Union, TypeVar, TYPE_CHECKING
+from typing import TYPE_CHECKING, TypeVar, Union
 
 from selenium import webdriver
 

--- a/appium/webdriver/extensions/android/gsm.py
+++ b/appium/webdriver/extensions/android/gsm.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Union, TypeVar
+from typing import Union, TypeVar, TYPE_CHECKING
 
 from selenium import webdriver
 
@@ -20,7 +20,11 @@ from appium.common.helper import extract_const_attributes
 from appium.common.logger import logger
 from appium.webdriver.mobilecommand import MobileCommand as Command
 
-T = TypeVar('T', bound=Union[webdriver.Remote, 'Gsm'])
+if TYPE_CHECKING:
+    # noinspection PyUnresolvedReferences
+    from appium.webdriver.webdriver import WebDriver
+
+T = TypeVar('T', bound=Union['WebDriver', 'Gsm'])
 
 
 class GsmCallActions:
@@ -113,7 +117,7 @@ class Gsm(webdriver.Remote):
 
     # pylint: disable=protected-access
     # noinspection PyProtectedMember
-    def _addCommands(self: T) -> None:
+    def _addCommands(self) -> None:
         self.command_executor._commands[Command.MAKE_GSM_CALL] = \
             ('POST', '/session/$sessionId/appium/device/gsm_call')
         self.command_executor._commands[Command.SET_GSM_SIGNAL] = \

--- a/appium/webdriver/extensions/android/gsm.py
+++ b/appium/webdriver/extensions/android/gsm.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import TYPE_CHECKING, TypeVar
+from typing import Union, TypeVar
 
 from selenium import webdriver
 
@@ -20,8 +20,7 @@ from appium.common.helper import extract_const_attributes
 from appium.common.logger import logger
 from appium.webdriver.mobilecommand import MobileCommand as Command
 
-if TYPE_CHECKING:
-    from appium.webdriver.webdriver import WebDriver
+T = TypeVar('T', bound=Union[webdriver.Remote, 'Gsm'])
 
 
 class GsmCallActions:
@@ -49,12 +48,9 @@ class GsmVoiceState:
     ON = 'on'
 
 
-T = TypeVar('T', bound='WebDriver')
-
-
 class Gsm(webdriver.Remote):
 
-    def make_gsm_call(self, phone_number: str, action: str) -> T:
+    def make_gsm_call(self: T, phone_number: str, action: str) -> T:
         """Make GSM call (Emulator only)
 
         Android only.
@@ -70,11 +66,12 @@ class Gsm(webdriver.Remote):
         constants = extract_const_attributes(GsmCallActions)
         if action not in constants.values():
             logger.warning(
-                f'{action} is unknown. Consider using one of {list(constants.keys())} constants. (e.g. {GsmCallActions.__name__}.CALL)')
+                f'{action} is unknown. Consider using one of {list(constants.keys())} constants. '
+                f'(e.g. {GsmCallActions.__name__}.CALL)')
         self.execute(Command.MAKE_GSM_CALL, {'phoneNumber': phone_number, 'action': action})
         return self
 
-    def set_gsm_signal(self, strength: int) -> T:
+    def set_gsm_signal(self: T, strength: int) -> T:
         """Set GSM signal strength (Emulator only)
 
         Android only.
@@ -89,11 +86,12 @@ class Gsm(webdriver.Remote):
         constants = extract_const_attributes(GsmSignalStrength)
         if strength not in constants.values():
             logger.warning(
-                f'{strength} is out of range. Consider using one of {list(constants.keys())} constants. (e.g. {GsmSignalStrength.__name__}.GOOD)')
+                f'{strength} is out of range. Consider using one of {list(constants.keys())} constants. '
+                f'(e.g. {GsmSignalStrength.__name__}.GOOD)')
         self.execute(Command.SET_GSM_SIGNAL, {'signalStrength': strength, 'signalStrengh': strength})
         return self
 
-    def set_gsm_voice(self, state: str) -> T:
+    def set_gsm_voice(self: T, state: str) -> T:
         """Set GSM voice state (Emulator only)
 
         Android only.
@@ -108,13 +106,14 @@ class Gsm(webdriver.Remote):
         constants = extract_const_attributes(GsmVoiceState)
         if state not in constants.values():
             logger.warning(
-                f'{state} is unknown. Consider using one of {list(constants.keys())} constants. (e.g. {GsmVoiceState.__name__}.HOME)')
+                f'{state} is unknown. Consider using one of {list(constants.keys())} constants. '
+                f'(e.g. {GsmVoiceState.__name__}.HOME)')
         self.execute(Command.SET_GSM_VOICE, {'state': state})
         return self
 
     # pylint: disable=protected-access
-
-    def _addCommands(self) -> None:
+    # noinspection PyProtectedMember
+    def _addCommands(self: T) -> None:
         self.command_executor._commands[Command.MAKE_GSM_CALL] = \
             ('POST', '/session/$sessionId/appium/device/gsm_call')
         self.command_executor._commands[Command.SET_GSM_SIGNAL] = \

--- a/appium/webdriver/extensions/android/network.py
+++ b/appium/webdriver/extensions/android/network.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Union, TypeVar, TYPE_CHECKING
+from typing import TYPE_CHECKING, TypeVar, Union
 
 from selenium import webdriver
 

--- a/appium/webdriver/extensions/android/network.py
+++ b/appium/webdriver/extensions/android/network.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import TYPE_CHECKING, TypeVar
+from typing import Union, TypeVar
 
 from selenium import webdriver
 
@@ -20,10 +20,7 @@ from appium.common.helper import extract_const_attributes
 from appium.common.logger import logger
 from appium.webdriver.mobilecommand import MobileCommand as Command
 
-if TYPE_CHECKING:
-    from appium.webdriver.webdriver import WebDriver
-
-T = TypeVar('T', bound='WebDriver')
+T = TypeVar('T', bound=Union[webdriver.Remote, 'NetSpeed'])
 
 
 class NetSpeed:
@@ -41,7 +38,7 @@ class NetSpeed:
 class Network(webdriver.Remote):
 
     @property
-    def network_connection(self) -> int:
+    def network_connection(self: T) -> int:
         """Returns an integer bitmask specifying the network connection type.
 
         Android only.
@@ -49,7 +46,7 @@ class Network(webdriver.Remote):
         """
         return self.execute(Command.GET_NETWORK_CONNECTION, {})['value']
 
-    def set_network_connection(self, connection_type: int) -> int:
+    def set_network_connection(self: T, connection_type: int) -> int:
         """Sets the network connection type. Android only.
 
         Possible values:
@@ -83,7 +80,7 @@ class Network(webdriver.Remote):
         }
         return self.execute(Command.SET_NETWORK_CONNECTION, data)['value']
 
-    def toggle_wifi(self) -> T:
+    def toggle_wifi(self: T) -> T:
         """Toggle the wifi on the device, Android only.
 
         Returns:
@@ -92,7 +89,7 @@ class Network(webdriver.Remote):
         self.execute(Command.TOGGLE_WIFI, {})
         return self
 
-    def set_network_speed(self, speed_type: str) -> T:
+    def set_network_speed(self: T, speed_type: str) -> T:
         """Set the network speed emulation.
 
         Android Emulator only.
@@ -110,14 +107,15 @@ class Network(webdriver.Remote):
         constants = extract_const_attributes(NetSpeed)
         if speed_type not in constants.values():
             logger.warning(
-                f'{speed_type} is unknown. Consider using one of {list(constants.keys())} constants. (e.g. {NetSpeed.__name__}.LTE)')
+                f'{speed_type} is unknown. Consider using one of {list(constants.keys())} constants. '
+                f'(e.g. {NetSpeed.__name__}.LTE)')
 
         self.execute(Command.SET_NETWORK_SPEED, {'netspeed': speed_type})
         return self
 
     # pylint: disable=protected-access
-
-    def _addCommands(self) -> None:
+    # noinspection PyProtectedMember
+    def _addCommands(self: T) -> None:
         self.command_executor._commands[Command.TOGGLE_WIFI] = \
             ('POST', '/session/$sessionId/appium/device/toggle_wifi')
         self.command_executor._commands[Command.GET_NETWORK_CONNECTION] = \

--- a/appium/webdriver/extensions/android/network.py
+++ b/appium/webdriver/extensions/android/network.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Union, TypeVar
+from typing import Union, TypeVar, TYPE_CHECKING
 
 from selenium import webdriver
 
@@ -20,7 +20,11 @@ from appium.common.helper import extract_const_attributes
 from appium.common.logger import logger
 from appium.webdriver.mobilecommand import MobileCommand as Command
 
-T = TypeVar('T', bound=Union[webdriver.Remote, 'NetSpeed'])
+if TYPE_CHECKING:
+    # noinspection PyUnresolvedReferences
+    from appium.webdriver.webdriver import WebDriver
+
+T = TypeVar('T', bound=Union['WebDriver', 'NetSpeed'])
 
 
 class NetSpeed:
@@ -115,7 +119,7 @@ class Network(webdriver.Remote):
 
     # pylint: disable=protected-access
     # noinspection PyProtectedMember
-    def _addCommands(self: T) -> None:
+    def _addCommands(self) -> None:
         self.command_executor._commands[Command.TOGGLE_WIFI] = \
             ('POST', '/session/$sessionId/appium/device/toggle_wifi')
         self.command_executor._commands[Command.GET_NETWORK_CONNECTION] = \

--- a/appium/webdriver/extensions/android/performance.py
+++ b/appium/webdriver/extensions/android/performance.py
@@ -12,16 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Dict, List, Union
+from typing import Dict, List, Union, TypeVar
 
 from selenium import webdriver
 
 from appium.webdriver.mobilecommand import MobileCommand as Command
 
+T = TypeVar('T', bound=Union[webdriver.Remote, 'Performance'])
+
 
 class Performance(webdriver.Remote):
 
-    def get_performance_data(self, package_name: str, data_type: str, data_read_timeout: int = None) -> List[List[str]]:
+    def get_performance_data(self: T, package_name: str, data_type: str,
+                             data_read_timeout: int = None) -> List[List[str]]:
         """Returns the information of the system state
         which is supported to read as like cpu, memory, network traffic, and battery.
 
@@ -45,7 +48,7 @@ class Performance(webdriver.Remote):
             data['dataReadTimeout'] = data_read_timeout
         return self.execute(Command.GET_PERFORMANCE_DATA, data)['value']
 
-    def get_performance_data_types(self) -> List:
+    def get_performance_data_types(self: T) -> List:
         """Returns the information types of the system state
         which is supported to read as like cpu, memory, network traffic, and battery.
         Android only.
@@ -60,7 +63,8 @@ class Performance(webdriver.Remote):
 
     # pylint: disable=protected-access
 
-    def _addCommands(self) -> None:
+    # noinspection PyProtectedMember
+    def _addCommands(self: T) -> None:
         self.command_executor._commands[Command.GET_PERFORMANCE_DATA] = \
             ('POST', '/session/$sessionId/appium/getPerformanceData')
         self.command_executor._commands[Command.GET_PERFORMANCE_DATA_TYPES] = \

--- a/appium/webdriver/extensions/android/performance.py
+++ b/appium/webdriver/extensions/android/performance.py
@@ -12,13 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Dict, List, Union, TypeVar
+from typing import Dict, List, Union, TypeVar, TYPE_CHECKING
 
 from selenium import webdriver
 
 from appium.webdriver.mobilecommand import MobileCommand as Command
 
-T = TypeVar('T', bound=Union[webdriver.Remote, 'Performance'])
+if TYPE_CHECKING:
+    # noinspection PyUnresolvedReferences
+    from appium.webdriver.webdriver import WebDriver
+
+T = TypeVar('T', bound=Union['WebDriver', 'Performance'])
 
 
 class Performance(webdriver.Remote):
@@ -64,7 +68,7 @@ class Performance(webdriver.Remote):
     # pylint: disable=protected-access
 
     # noinspection PyProtectedMember
-    def _addCommands(self: T) -> None:
+    def _addCommands(self) -> None:
         self.command_executor._commands[Command.GET_PERFORMANCE_DATA] = \
             ('POST', '/session/$sessionId/appium/getPerformanceData')
         self.command_executor._commands[Command.GET_PERFORMANCE_DATA_TYPES] = \

--- a/appium/webdriver/extensions/android/performance.py
+++ b/appium/webdriver/extensions/android/performance.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Dict, List, Union, TypeVar, TYPE_CHECKING
+from typing import TYPE_CHECKING, Dict, List, TypeVar, Union
 
 from selenium import webdriver
 

--- a/appium/webdriver/extensions/android/power.py
+++ b/appium/webdriver/extensions/android/power.py
@@ -12,23 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import TYPE_CHECKING, TypeVar
+from typing import Union, TypeVar
 
 from selenium import webdriver
 
 from appium.webdriver.mobilecommand import MobileCommand as Command
 
-if TYPE_CHECKING:
-    from appium.webdriver.webdriver import WebDriver
 
-T = TypeVar('T', bound='WebDriver')
+T = TypeVar('T', bound=Union[webdriver.Remote, 'Power'])
 
 
 class Power(webdriver.Remote):
 
     AC_OFF, AC_ON = 'off', 'on'
 
-    def set_power_capacity(self, percent: int) -> T:
+    def set_power_capacity(self: T, percent: int) -> T:
         """Emulate power capacity change on the connected emulator.
 
         Android only.
@@ -45,7 +43,7 @@ class Power(webdriver.Remote):
         self.execute(Command.SET_POWER_CAPACITY, {'percent': percent})
         return self
 
-    def set_power_ac(self, ac_state: str) -> T:
+    def set_power_ac(self: T, ac_state: str) -> T:
         """Emulate power state change on the connected emulator.
 
         Android only.
@@ -65,8 +63,8 @@ class Power(webdriver.Remote):
         return self
 
     # pylint: disable=protected-access
-
-    def _addCommands(self) -> None:
+    # noinspection PyProtectedMember
+    def _addCommands(self: T) -> None:
         self.command_executor._commands[Command.SET_POWER_CAPACITY] = \
             ('POST', '/session/$sessionId/appium/device/power_capacity')
         self.command_executor._commands[Command.SET_POWER_AC] = \

--- a/appium/webdriver/extensions/android/power.py
+++ b/appium/webdriver/extensions/android/power.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Union, TypeVar, TYPE_CHECKING
+from typing import TYPE_CHECKING, TypeVar, Union
 
 from selenium import webdriver
 

--- a/appium/webdriver/extensions/android/power.py
+++ b/appium/webdriver/extensions/android/power.py
@@ -12,14 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Union, TypeVar
+from typing import Union, TypeVar, TYPE_CHECKING
 
 from selenium import webdriver
 
 from appium.webdriver.mobilecommand import MobileCommand as Command
 
+if TYPE_CHECKING:
+    # noinspection PyUnresolvedReferences
+    from appium.webdriver.webdriver import WebDriver
 
-T = TypeVar('T', bound=Union[webdriver.Remote, 'Power'])
+T = TypeVar('T', bound=Union['WebDriver', 'Power'])
 
 
 class Power(webdriver.Remote):
@@ -64,7 +67,7 @@ class Power(webdriver.Remote):
 
     # pylint: disable=protected-access
     # noinspection PyProtectedMember
-    def _addCommands(self: T) -> None:
+    def _addCommands(self) -> None:
         self.command_executor._commands[Command.SET_POWER_CAPACITY] = \
             ('POST', '/session/$sessionId/appium/device/power_capacity')
         self.command_executor._commands[Command.SET_POWER_AC] = \

--- a/appium/webdriver/extensions/android/sms.py
+++ b/appium/webdriver/extensions/android/sms.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Union, TypeVar, TYPE_CHECKING
+from typing import TYPE_CHECKING, TypeVar, Union
 
 from selenium import webdriver
 

--- a/appium/webdriver/extensions/android/sms.py
+++ b/appium/webdriver/extensions/android/sms.py
@@ -12,13 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Union, TypeVar
+from typing import Union, TypeVar, TYPE_CHECKING
 
 from selenium import webdriver
 
 from appium.webdriver.mobilecommand import MobileCommand as Command
 
-T = TypeVar('T', bound=Union[webdriver.Remote, 'Sms'])
+if TYPE_CHECKING:
+    # noinspection PyUnresolvedReferences
+    from appium.webdriver.webdriver import WebDriver
+
+T = TypeVar('T', bound=Union['WebDriver', 'Sms'])
 
 
 class Sms(webdriver.Remote):
@@ -43,6 +47,6 @@ class Sms(webdriver.Remote):
 
     # pylint: disable=protected-access
     # noinspection PyProtectedMember
-    def _addCommands(self: T) -> None:
+    def _addCommands(self) -> None:
         self.command_executor._commands[Command.SEND_SMS] = \
             ('POST', '/session/$sessionId/appium/device/send_sms')

--- a/appium/webdriver/extensions/android/sms.py
+++ b/appium/webdriver/extensions/android/sms.py
@@ -12,21 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import TYPE_CHECKING, TypeVar
+from typing import Union, TypeVar
 
 from selenium import webdriver
 
 from appium.webdriver.mobilecommand import MobileCommand as Command
 
-if TYPE_CHECKING:
-    from appium.webdriver.webdriver import WebDriver
-
-T = TypeVar('T', bound='WebDriver')
+T = TypeVar('T', bound=Union[webdriver.Remote, 'Sms'])
 
 
 class Sms(webdriver.Remote):
 
-    def send_sms(self, phone_number: str, message: str) -> T:
+    def send_sms(self: T, phone_number: str, message: str) -> T:
         """Emulate send SMS event on the connected emulator.
 
         Android only.
@@ -45,7 +42,7 @@ class Sms(webdriver.Remote):
         return self
 
     # pylint: disable=protected-access
-
-    def _addCommands(self) -> None:
+    # noinspection PyProtectedMember
+    def _addCommands(self: T) -> None:
         self.command_executor._commands[Command.SEND_SMS] = \
             ('POST', '/session/$sessionId/appium/device/send_sms')

--- a/appium/webdriver/extensions/android/system_bars.py
+++ b/appium/webdriver/extensions/android/system_bars.py
@@ -12,16 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Dict, Union
+from typing import Dict, Union, TypeVar
 
 from selenium import webdriver
 
 from appium.webdriver.mobilecommand import MobileCommand as Command
 
+T = TypeVar('T', bound=Union[webdriver.Remote, 'SystemBars'])
+
 
 class SystemBars(webdriver.Remote):
 
-    def get_system_bars(self) -> Dict[str, Dict[str, Union[int, bool]]]:
+    def get_system_bars(self: T) -> Dict[str, Dict[str, Union[int, bool]]]:
         """Retrieve visibility and bounds information of the status and navigation bars.
 
         Android only.
@@ -44,7 +46,7 @@ class SystemBars(webdriver.Remote):
         return self.execute(Command.GET_SYSTEM_BARS)['value']
 
     # pylint: disable=protected-access
-
-    def _addCommands(self) -> None:
+    # noinspection PyProtectedMember
+    def _addCommands(self: T) -> None:
         self.command_executor._commands[Command.GET_SYSTEM_BARS] = \
             ('GET', '/session/$sessionId/appium/device/system_bars')

--- a/appium/webdriver/extensions/android/system_bars.py
+++ b/appium/webdriver/extensions/android/system_bars.py
@@ -12,13 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Dict, Union, TypeVar
+from typing import Dict, Union, TypeVar, TYPE_CHECKING
 
 from selenium import webdriver
 
 from appium.webdriver.mobilecommand import MobileCommand as Command
 
-T = TypeVar('T', bound=Union[webdriver.Remote, 'SystemBars'])
+if TYPE_CHECKING:
+    # noinspection PyUnresolvedReferences
+    from appium.webdriver.webdriver import WebDriver
+
+T = TypeVar('T', bound=Union['WebDriver', 'SystemBars'])
 
 
 class SystemBars(webdriver.Remote):
@@ -47,6 +51,6 @@ class SystemBars(webdriver.Remote):
 
     # pylint: disable=protected-access
     # noinspection PyProtectedMember
-    def _addCommands(self: T) -> None:
+    def _addCommands(self) -> None:
         self.command_executor._commands[Command.GET_SYSTEM_BARS] = \
             ('GET', '/session/$sessionId/appium/device/system_bars')

--- a/appium/webdriver/extensions/android/system_bars.py
+++ b/appium/webdriver/extensions/android/system_bars.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Dict, Union, TypeVar, TYPE_CHECKING
+from typing import TYPE_CHECKING, Dict, TypeVar, Union
 
 from selenium import webdriver
 

--- a/appium/webdriver/extensions/applications.py
+++ b/appium/webdriver/extensions/applications.py
@@ -12,13 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Union, Any, Dict, TypeVar
+from typing import Union, Any, Dict, TypeVar, TYPE_CHECKING
 
 from selenium import webdriver
 
 from ..mobilecommand import MobileCommand as Command
 
-T = TypeVar('T', bound=Union[webdriver.Remote, 'Applications'])
+if TYPE_CHECKING:
+    # noinspection PyUnresolvedReferences
+    from appium.webdriver.webdriver import WebDriver
+
+T = TypeVar('T', bound=Union['WebDriver', 'Applications'])
 
 
 class Applications(webdriver.Remote):
@@ -198,7 +202,7 @@ class Applications(webdriver.Remote):
 
     # pylint: disable=protected-access
     # noinspection PyProtectedMember
-    def _addCommands(self: T) -> None:
+    def _addCommands(self) -> None:
         self.command_executor._commands[Command.BACKGROUND] = \
             ('POST', '/session/$sessionId/appium/app/background')
         self.command_executor._commands[Command.IS_APP_INSTALLED] = \

--- a/appium/webdriver/extensions/applications.py
+++ b/appium/webdriver/extensions/applications.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Union, Any, Dict, TypeVar, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Dict, TypeVar, Union
 
 from selenium import webdriver
 

--- a/appium/webdriver/extensions/applications.py
+++ b/appium/webdriver/extensions/applications.py
@@ -12,20 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import TYPE_CHECKING, Any, Dict, TypeVar
+from typing import Union, Any, Dict, TypeVar
 
 from selenium import webdriver
 
 from ..mobilecommand import MobileCommand as Command
 
-if TYPE_CHECKING:
-    from appium.webdriver.webdriver import WebDriver
-
-T = TypeVar('T', bound='WebDriver')
+T = TypeVar('T', bound=Union[webdriver.Remote, 'Applications'])
 
 
 class Applications(webdriver.Remote):
-    def background_app(self, seconds: int) -> T:
+    def background_app(self: T, seconds: int) -> T:
         """Puts the application in the background on the device for a certain duration.
 
         Args:
@@ -40,7 +37,7 @@ class Applications(webdriver.Remote):
         self.execute(Command.BACKGROUND, data)
         return self
 
-    def is_app_installed(self, bundle_id: str) -> bool:
+    def is_app_installed(self: T, bundle_id: str) -> bool:
         """Checks whether the application specified by `bundle_id` is installed on the device.
 
         Args:
@@ -54,7 +51,7 @@ class Applications(webdriver.Remote):
         }
         return self.execute(Command.IS_APP_INSTALLED, data)['value']
 
-    def install_app(self, app_path: str, **options: Any) -> T:
+    def install_app(self: T, app_path: str, **options: Any) -> T:
         """Install the application found at `app_path` on the device.
 
         Args:
@@ -82,7 +79,7 @@ class Applications(webdriver.Remote):
         self.execute(Command.INSTALL_APP, data)
         return self
 
-    def remove_app(self, app_id: str, **options: Any) -> T:
+    def remove_app(self: T, app_id: str, **options: Any) -> T:
         """Remove the specified application from the device.
 
         Args:
@@ -105,7 +102,7 @@ class Applications(webdriver.Remote):
         self.execute(Command.REMOVE_APP, data)
         return self
 
-    def launch_app(self) -> T:
+    def launch_app(self: T) -> T:
         """Start on the device the application specified in the desired capabilities.
 
         Returns:
@@ -114,7 +111,7 @@ class Applications(webdriver.Remote):
         self.execute(Command.LAUNCH_APP)
         return self
 
-    def close_app(self) -> T:
+    def close_app(self: T) -> T:
         """Stop the running application, specified in the desired capabilities, on
         the device.
 
@@ -124,7 +121,7 @@ class Applications(webdriver.Remote):
         self.execute(Command.CLOSE_APP)
         return self
 
-    def terminate_app(self, app_id: str, **options: Any) -> bool:
+    def terminate_app(self: T, app_id: str, **options: Any) -> bool:
         """Terminates the application if it is running.
 
         Args:
@@ -144,7 +141,7 @@ class Applications(webdriver.Remote):
             data.update({'options': options})
         return self.execute(Command.TERMINATE_APP, data)['value']
 
-    def activate_app(self, app_id: str) -> T:
+    def activate_app(self: T, app_id: str) -> T:
         """Activates the application if it is not running
         or is running in the background.
 
@@ -160,7 +157,7 @@ class Applications(webdriver.Remote):
         self.execute(Command.ACTIVATE_APP, data)
         return self
 
-    def query_app_state(self, app_id: str) -> int:
+    def query_app_state(self: T, app_id: str) -> int:
         """Queries the state of the application.
 
         Args:
@@ -175,7 +172,7 @@ class Applications(webdriver.Remote):
         }
         return self.execute(Command.QUERY_APP_STATE, data)['value']
 
-    def app_strings(self, language: str = None, string_file: str = None) -> Dict[str, str]:
+    def app_strings(self: T, language: str = None, string_file: str = None) -> Dict[str, str]:
         """Returns the application strings from the device for the specified
         language.
 
@@ -193,15 +190,15 @@ class Applications(webdriver.Remote):
             data['stringFile'] = string_file
         return self.execute(Command.GET_APP_STRINGS, data)['value']
 
-    def reset(self) -> T:
+    def reset(self: T) -> T:
         """Resets the current application on the device.
         """
         self.execute(Command.RESET)
         return self
 
     # pylint: disable=protected-access
-
-    def _addCommands(self) -> None:
+    # noinspection PyProtectedMember
+    def _addCommands(self: T) -> None:
         self.command_executor._commands[Command.BACKGROUND] = \
             ('POST', '/session/$sessionId/appium/app/background')
         self.command_executor._commands[Command.IS_APP_INSTALLED] = \

--- a/appium/webdriver/extensions/clipboard.py
+++ b/appium/webdriver/extensions/clipboard.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import base64
-from typing import Optional, TypeVar, Union, TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional, TypeVar, Union
 
 from selenium import webdriver
 

--- a/appium/webdriver/extensions/clipboard.py
+++ b/appium/webdriver/extensions/clipboard.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import base64
-from typing import Optional, TypeVar, Union
+from typing import Optional, TypeVar, Union, TYPE_CHECKING
 
 from selenium import webdriver
 
@@ -21,8 +21,11 @@ from appium.webdriver.clipboard_content_type import ClipboardContentType
 
 from ..mobilecommand import MobileCommand as Command
 
+if TYPE_CHECKING:
+    # noinspection PyUnresolvedReferences
+    from appium.webdriver.webdriver import WebDriver
 
-T = TypeVar('T', bound=Union['Clipboard', webdriver.Remote])
+T = TypeVar('T', bound=Union['WebDriver', 'Clipboard'])
 
 
 class Clipboard(webdriver.Remote):

--- a/appium/webdriver/extensions/clipboard.py
+++ b/appium/webdriver/extensions/clipboard.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import base64
-from typing import TYPE_CHECKING, Optional, TypeVar
+from typing import Optional, TypeVar, Union
 
 from selenium import webdriver
 
@@ -21,15 +21,13 @@ from appium.webdriver.clipboard_content_type import ClipboardContentType
 
 from ..mobilecommand import MobileCommand as Command
 
-if TYPE_CHECKING:
-    from appium.webdriver.webdriver import WebDriver
 
-T = TypeVar('T', bound='WebDriver')
+T = TypeVar('T', bound=Union['Clipboard', webdriver.Remote])
 
 
 class Clipboard(webdriver.Remote):
 
-    def set_clipboard(self, content: bytes, content_type: str = ClipboardContentType.PLAINTEXT,
+    def set_clipboard(self: T, content: bytes, content_type: str = ClipboardContentType.PLAINTEXT,
                       label: Optional[str] = None) -> T:
         """Set the content of the system clipboard
 
@@ -51,7 +49,7 @@ class Clipboard(webdriver.Remote):
         self.execute(Command.SET_CLIPBOARD, options)
         return self
 
-    def set_clipboard_text(self, text: str, label: Optional[str] = None) -> T:
+    def set_clipboard_text(self: T, text: str, label: Optional[str] = None) -> T:
         """Copies the given text to the system clipboard
 
         Args:
@@ -65,7 +63,7 @@ class Clipboard(webdriver.Remote):
         self.set_clipboard(bytes(str(text), 'UTF-8'), ClipboardContentType.PLAINTEXT, label)
         return self
 
-    def get_clipboard(self, content_type: str = ClipboardContentType.PLAINTEXT) -> bytes:
+    def get_clipboard(self: T, content_type: str = ClipboardContentType.PLAINTEXT) -> bytes:
         """Receives the content of the system clipboard
 
         Args:
@@ -80,7 +78,7 @@ class Clipboard(webdriver.Remote):
         })['value']
         return base64.b64decode(base64_str)
 
-    def get_clipboard_text(self) -> str:
+    def get_clipboard_text(self: T) -> str:
         """Receives the text of the system clipboard
 
         Return:
@@ -89,7 +87,7 @@ class Clipboard(webdriver.Remote):
         return self.get_clipboard(ClipboardContentType.PLAINTEXT).decode('UTF-8')
 
     # pylint: disable=protected-access
-
+    # noinspection PyProtectedMember
     def _addCommands(self) -> None:
         self.command_executor._commands[Command.SET_CLIPBOARD] = \
             ('POST', '/session/$sessionId/appium/device/set_clipboard')

--- a/appium/webdriver/extensions/context.py
+++ b/appium/webdriver/extensions/context.py
@@ -12,16 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import List
+from typing import List, Union, TypeVar
 
 from selenium import webdriver
 
 from ..mobilecommand import MobileCommand as Command
 
+T = TypeVar('T', bound=Union['Context', webdriver.Remote])
+
 
 class Context(webdriver.Remote):
     @property
-    def contexts(self) -> List[str]:
+    def contexts(self: T) -> List[str]:
         """Returns the contexts within the current session.
 
         Usage:
@@ -34,7 +36,7 @@ class Context(webdriver.Remote):
         return self.execute(Command.CONTEXTS)['value']
 
     @property
-    def current_context(self) -> str:
+    def current_context(self: T) -> str:
         """Returns the current context of the current session.
 
         Usage:
@@ -46,7 +48,7 @@ class Context(webdriver.Remote):
         return self.execute(Command.GET_CURRENT_CONTEXT)['value']
 
     @property
-    def context(self) -> str:
+    def context(self: T) -> str:
         """Returns the current context of the current session.
 
         Usage:
@@ -58,8 +60,8 @@ class Context(webdriver.Remote):
         return self.current_context
 
     # pylint: disable=protected-access
-
-    def _addCommands(self) -> None:
+    # noinspection PyProtectedMember
+    def _addCommands(self: T) -> None:
         self.command_executor._commands[Command.CONTEXTS] = \
             ('GET', '/session/$sessionId/contexts')
         self.command_executor._commands[Command.GET_CURRENT_CONTEXT] = \

--- a/appium/webdriver/extensions/context.py
+++ b/appium/webdriver/extensions/context.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import List, Union, TypeVar, TYPE_CHECKING
+from typing import TYPE_CHECKING, List, TypeVar, Union
 
 from selenium import webdriver
 

--- a/appium/webdriver/extensions/context.py
+++ b/appium/webdriver/extensions/context.py
@@ -12,13 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import List, Union, TypeVar
+from typing import List, Union, TypeVar, TYPE_CHECKING
 
 from selenium import webdriver
 
 from ..mobilecommand import MobileCommand as Command
 
-T = TypeVar('T', bound=Union['Context', webdriver.Remote])
+if TYPE_CHECKING:
+    # noinspection PyUnresolvedReferences
+    from appium.webdriver.webdriver import WebDriver
+
+T = TypeVar('T', bound=Union['WebDriver', 'Context'])
 
 
 class Context(webdriver.Remote):
@@ -61,7 +65,7 @@ class Context(webdriver.Remote):
 
     # pylint: disable=protected-access
     # noinspection PyProtectedMember
-    def _addCommands(self: T) -> None:
+    def _addCommands(self) -> None:
         self.command_executor._commands[Command.CONTEXTS] = \
             ('GET', '/session/$sessionId/contexts')
         self.command_executor._commands[Command.GET_CURRENT_CONTEXT] = \

--- a/appium/webdriver/extensions/device_time.py
+++ b/appium/webdriver/extensions/device_time.py
@@ -12,13 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional, TypeVar, Union
+from typing import Optional, TypeVar, Union, TYPE_CHECKING
 
 from selenium import webdriver
 
 from ..mobilecommand import MobileCommand as Command
 
-T = TypeVar('T', bound=Union['DeviceTime', webdriver.Remote])
+if TYPE_CHECKING:
+    # noinspection PyUnresolvedReferences
+    from appium.webdriver.webdriver import WebDriver
+
+T = TypeVar('T', bound=Union['WebDriver', 'DeviceTime'])
 
 
 class DeviceTime(webdriver.Remote):
@@ -55,7 +59,7 @@ class DeviceTime(webdriver.Remote):
 
     # pylint: disable=protected-access
     # noinspection PyProtectedMember
-    def _addCommands(self: T) -> None:
+    def _addCommands(self) -> None:
         self.command_executor._commands[Command.GET_DEVICE_TIME_GET] = \
             ('GET', '/session/$sessionId/appium/device/system_time')
         self.command_executor._commands[Command.GET_DEVICE_TIME_POST] = \

--- a/appium/webdriver/extensions/device_time.py
+++ b/appium/webdriver/extensions/device_time.py
@@ -12,17 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional
+from typing import Optional, TypeVar, Union
 
 from selenium import webdriver
 
 from ..mobilecommand import MobileCommand as Command
 
+T = TypeVar('T', bound=Union['DeviceTime', webdriver.Remote])
+
 
 class DeviceTime(webdriver.Remote):
 
     @property
-    def device_time(self) -> str:
+    def device_time(self: T) -> str:
         """Returns the date and time from the device.
 
         Return:
@@ -30,7 +32,7 @@ class DeviceTime(webdriver.Remote):
         """
         return self.execute(Command.GET_DEVICE_TIME_GET, {})['value']
 
-    def get_device_time(self, format: Optional[str] = None) -> str:
+    def get_device_time(self: T, format: Optional[str] = None) -> str:
         """Returns the date and time from the device.
 
         Args:
@@ -52,8 +54,8 @@ class DeviceTime(webdriver.Remote):
         return self.execute(Command.GET_DEVICE_TIME_POST, {'format': format})['value']
 
     # pylint: disable=protected-access
-
-    def _addCommands(self) -> None:
+    # noinspection PyProtectedMember
+    def _addCommands(self: T) -> None:
         self.command_executor._commands[Command.GET_DEVICE_TIME_GET] = \
             ('GET', '/session/$sessionId/appium/device/system_time')
         self.command_executor._commands[Command.GET_DEVICE_TIME_POST] = \

--- a/appium/webdriver/extensions/device_time.py
+++ b/appium/webdriver/extensions/device_time.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional, TypeVar, Union, TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional, TypeVar, Union
 
 from selenium import webdriver
 

--- a/appium/webdriver/extensions/execute_driver.py
+++ b/appium/webdriver/extensions/execute_driver.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Dict, Optional, Union, TypeVar, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Dict, Optional, TypeVar, Union
 
 from selenium import webdriver
 

--- a/appium/webdriver/extensions/execute_driver.py
+++ b/appium/webdriver/extensions/execute_driver.py
@@ -12,17 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, Optional, Union, TypeVar
 
 from selenium import webdriver
 
 from ..mobilecommand import MobileCommand as Command
 
+T = TypeVar('T', bound=Union['ExecuteDriver', webdriver.Remote])
+
 
 class ExecuteDriver(webdriver.Remote):
 
     # TODO Inner class case
-    def execute_driver(self, script: str, script_type: str = 'webdriverio', timeout_ms: Optional[int] = None) -> Any:
+    def execute_driver(self: T, script: str, script_type: str = 'webdriverio', timeout_ms: Optional[int] = None) -> Any:
         """Run a set of script against the current session, allowing execution of many commands in one Appium request.
         Please read http://appium.io/docs/en/commands/session/execute-driver for more details about the acceptable
         scripts and the output format.
@@ -30,7 +32,8 @@ class ExecuteDriver(webdriver.Remote):
         Args:
             script (str): The string consisting of the script itself
             script_type (str): The name of the script type. Defaults to 'webdriverio'.
-            timeout_ms (:obj:`int`, optional): The number of `ms` Appium should wait for the script to finish before killing it due to timeout_ms.
+            timeout_ms (:obj:`int`, optional): The number of `ms` Appium should wait for the script to finish before
+             killing it due to timeout_ms.
 
         Usage:
             self.driver.execute_driver(script='return [];')
@@ -48,9 +51,9 @@ class ExecuteDriver(webdriver.Remote):
 
         class Result:
 
-            def __init__(self, response: Dict):
-                self.result = response['result']
-                self.logs = response['logs']
+            def __init__(self, res: Dict):
+                self.result = res['result']
+                self.logs = res['logs']
 
         option: Dict[str, Union[str, int]] = {'script': script, 'type': script_type}
         if timeout_ms is not None:
@@ -60,7 +63,7 @@ class ExecuteDriver(webdriver.Remote):
         return Result(response)
 
     # pylint: disable=protected-access
-
-    def _addCommands(self) -> None:
+    # noinspection PyProtectedMember
+    def _addCommands(self: T) -> None:
         self.command_executor._commands[Command.EXECUTE_DRIVER] = \
             ('POST', '/session/$sessionId/appium/execute_driver')

--- a/appium/webdriver/extensions/execute_driver.py
+++ b/appium/webdriver/extensions/execute_driver.py
@@ -12,13 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Dict, Optional, Union, TypeVar
+from typing import Any, Dict, Optional, Union, TypeVar, TYPE_CHECKING
 
 from selenium import webdriver
 
 from ..mobilecommand import MobileCommand as Command
 
-T = TypeVar('T', bound=Union['ExecuteDriver', webdriver.Remote])
+if TYPE_CHECKING:
+    # noinspection PyUnresolvedReferences
+    from appium.webdriver.webdriver import WebDriver
+
+T = TypeVar('T', bound=Union['WebDriver', 'ExecuteDriver'])
 
 
 class ExecuteDriver(webdriver.Remote):
@@ -64,6 +68,6 @@ class ExecuteDriver(webdriver.Remote):
 
     # pylint: disable=protected-access
     # noinspection PyProtectedMember
-    def _addCommands(self: T) -> None:
+    def _addCommands(self) -> None:
         self.command_executor._commands[Command.EXECUTE_DRIVER] = \
             ('POST', '/session/$sessionId/appium/execute_driver')

--- a/appium/webdriver/extensions/execute_mobile_command.py
+++ b/appium/webdriver/extensions/execute_mobile_command.py
@@ -12,19 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import TYPE_CHECKING, Any, Dict, TypeVar
+from typing import Union, Any, Dict, TypeVar
 
 from selenium import webdriver
 
-if TYPE_CHECKING:
-    from appium.webdriver.webdriver import WebDriver
-
-T = TypeVar('T', bound='WebDriver')
+T = TypeVar('T', bound=Union[webdriver.Remote, 'ExecuteMobileCommand'])
 
 
 class ExecuteMobileCommand(webdriver.Remote):
 
-    def press_button(self, button_name: str) -> T:
+    def press_button(self: T, button_name: str) -> T:
         """Sends a physical button name to the device to simulate the user pressing.
 
         iOS only.
@@ -45,7 +42,7 @@ class ExecuteMobileCommand(webdriver.Remote):
         return self
 
     @property
-    def battery_info(self) -> Dict[str, Any]:
+    def battery_info(self: T) -> Dict[str, Any]:
         """Retrieves battery information for the device under test.
 
         Returns:

--- a/appium/webdriver/extensions/execute_mobile_command.py
+++ b/appium/webdriver/extensions/execute_mobile_command.py
@@ -12,11 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Union, Any, Dict, TypeVar
+from typing import Union, Any, Dict, TypeVar, TYPE_CHECKING
 
 from selenium import webdriver
 
-T = TypeVar('T', bound=Union[webdriver.Remote, 'ExecuteMobileCommand'])
+if TYPE_CHECKING:
+    # noinspection PyUnresolvedReferences
+    from appium.webdriver.webdriver import WebDriver
+
+T = TypeVar('T', bound=Union['WebDriver', 'ExecuteMobileCommand'])
 
 
 class ExecuteMobileCommand(webdriver.Remote):

--- a/appium/webdriver/extensions/execute_mobile_command.py
+++ b/appium/webdriver/extensions/execute_mobile_command.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Union, Any, Dict, TypeVar, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Dict, TypeVar, Union
 
 from selenium import webdriver
 

--- a/appium/webdriver/extensions/hw_actions.py
+++ b/appium/webdriver/extensions/hw_actions.py
@@ -12,21 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import TYPE_CHECKING, Any, Optional, TypeVar
+from typing import Union, Any, Optional, TypeVar
 
 from selenium import webdriver
 
 from ..mobilecommand import MobileCommand as Command
 
-if TYPE_CHECKING:
-    from appium.webdriver.webdriver import WebDriver
-
-T = TypeVar('T', bound='WebDriver')
+T = TypeVar('T', bound=Union[webdriver.Remote, 'HardwareActions'])
 
 
 class HardwareActions(webdriver.Remote):
 
-    def lock(self, seconds: Optional[int] = None) -> T:
+    def lock(self: T, seconds: Optional[int] = None) -> T:
         """Lock the device. No changes are made if the device is already unlocked.
 
         Args:
@@ -45,7 +42,7 @@ class HardwareActions(webdriver.Remote):
 
         return self
 
-    def unlock(self) -> T:
+    def unlock(self: T) -> T:
         """Unlock the device. No changes are made if the device is already locked.
 
         Returns:
@@ -54,7 +51,7 @@ class HardwareActions(webdriver.Remote):
         self.execute(Command.UNLOCK)
         return self
 
-    def is_locked(self) -> bool:
+    def is_locked(self: T) -> bool:
         """Checks whether the device is locked.
 
         Returns:
@@ -62,7 +59,7 @@ class HardwareActions(webdriver.Remote):
         """
         return self.execute(Command.IS_LOCKED)['value']
 
-    def shake(self) -> T:
+    def shake(self: T) -> T:
         """Shake the device.
 
         Returns:
@@ -71,7 +68,7 @@ class HardwareActions(webdriver.Remote):
         self.execute(Command.SHAKE)
         return self
 
-    def touch_id(self, match: bool) -> T:
+    def touch_id(self: T, match: bool) -> T:
         """Simulate touchId on iOS Simulator
 
         Args:
@@ -86,7 +83,7 @@ class HardwareActions(webdriver.Remote):
         self.execute(Command.TOUCH_ID, data)
         return self
 
-    def toggle_touch_id_enrollment(self) -> T:
+    def toggle_touch_id_enrollment(self: T) -> T:
         """Toggle enroll touchId on iOS Simulator
 
         Returns:
@@ -95,7 +92,7 @@ class HardwareActions(webdriver.Remote):
         self.execute(Command.TOGGLE_TOUCH_ID_ENROLLMENT)
         return self
 
-    def finger_print(self, finger_id: int) -> Any:
+    def finger_print(self: T, finger_id: int) -> Any:
         """Authenticate users by using their finger print scans on supported Android emulators.
 
         Args:
@@ -107,8 +104,8 @@ class HardwareActions(webdriver.Remote):
         return self.execute(Command.FINGER_PRINT, {'fingerprintId': finger_id})['value']
 
     # pylint: disable=protected-access
-
-    def _addCommands(self) -> None:
+    # noinspection PyProtectedMember
+    def _addCommands(self: T) -> None:
         self.command_executor._commands[Command.LOCK] = \
             ('POST', '/session/$sessionId/appium/device/lock')
         self.command_executor._commands[Command.UNLOCK] = \

--- a/appium/webdriver/extensions/hw_actions.py
+++ b/appium/webdriver/extensions/hw_actions.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Union, Any, Optional, TypeVar, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Optional, TypeVar, Union
 
 from selenium import webdriver
 

--- a/appium/webdriver/extensions/hw_actions.py
+++ b/appium/webdriver/extensions/hw_actions.py
@@ -12,13 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Union, Any, Optional, TypeVar
+from typing import Union, Any, Optional, TypeVar, TYPE_CHECKING
 
 from selenium import webdriver
 
 from ..mobilecommand import MobileCommand as Command
 
-T = TypeVar('T', bound=Union[webdriver.Remote, 'HardwareActions'])
+if TYPE_CHECKING:
+    # noinspection PyUnresolvedReferences
+    from appium.webdriver.webdriver import WebDriver
+
+T = TypeVar('T', bound=Union['WebDriver', 'HardwareActions'])
 
 
 class HardwareActions(webdriver.Remote):
@@ -105,7 +109,7 @@ class HardwareActions(webdriver.Remote):
 
     # pylint: disable=protected-access
     # noinspection PyProtectedMember
-    def _addCommands(self: T) -> None:
+    def _addCommands(self) -> None:
         self.command_executor._commands[Command.LOCK] = \
             ('POST', '/session/$sessionId/appium/device/lock')
         self.command_executor._commands[Command.UNLOCK] = \

--- a/appium/webdriver/extensions/images_comparison.py
+++ b/appium/webdriver/extensions/images_comparison.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Dict, Union, TypeVar, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Dict, TypeVar, Union
 
 from selenium import webdriver
 

--- a/appium/webdriver/extensions/images_comparison.py
+++ b/appium/webdriver/extensions/images_comparison.py
@@ -12,16 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Dict, Union
+from typing import Any, Dict, Union, TypeVar
 
 from selenium import webdriver
 
 from ..mobilecommand import MobileCommand as Command
 
+T = TypeVar('T', bound=Union['ImagesComparison', webdriver.Remote])
+
 
 class ImagesComparison(webdriver.Remote):
 
-    def match_images_features(self, base64_image1: bytes, base64_image2: bytes, **opts: Any) -> Dict[str, Any]:
+    def match_images_features(self: T, base64_image1: bytes, base64_image2: bytes, **opts: Any) -> Dict[str, Any]:
         """Performs images matching by features.
 
         Read
@@ -75,7 +77,7 @@ class ImagesComparison(webdriver.Remote):
         }
         return self.execute(Command.COMPARE_IMAGES, options)['value']
 
-    def find_image_occurrence(self, base64_full_image: bytes, base64_partial_image: bytes,
+    def find_image_occurrence(self: T, base64_full_image: bytes, base64_partial_image: bytes,
                               **opts: Any) -> Dict[str, Union[bytes, Dict]]:
         """Performs images matching by template to find possible occurrence of the partial image
         in the full image.
@@ -108,7 +110,7 @@ class ImagesComparison(webdriver.Remote):
         }
         return self.execute(Command.COMPARE_IMAGES, options)['value']
 
-    def get_images_similarity(self, base64_image1: bytes, base64_image2: bytes,
+    def get_images_similarity(self: T, base64_image1: bytes, base64_image2: bytes,
                               **opts: Any) -> Dict[str, Union[bytes, Dict]]:
         """Performs images matching to calculate the similarity score between them.
 
@@ -140,7 +142,7 @@ class ImagesComparison(webdriver.Remote):
         return self.execute(Command.COMPARE_IMAGES, options)['value']
 
     # pylint: disable=protected-access
-
-    def _addCommands(self) -> None:
+    # noinspection PyProtectedMember
+    def _addCommands(self: T) -> None:
         self.command_executor._commands[Command.COMPARE_IMAGES] = \
             ('POST', '/session/$sessionId/appium/compare_images')

--- a/appium/webdriver/extensions/images_comparison.py
+++ b/appium/webdriver/extensions/images_comparison.py
@@ -12,13 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Dict, Union, TypeVar
+from typing import Any, Dict, Union, TypeVar, TYPE_CHECKING
 
 from selenium import webdriver
 
 from ..mobilecommand import MobileCommand as Command
 
-T = TypeVar('T', bound=Union['ImagesComparison', webdriver.Remote])
+if TYPE_CHECKING:
+    # noinspection PyUnresolvedReferences
+    from appium.webdriver.webdriver import WebDriver
+
+T = TypeVar('T', bound=Union['WebDriver', 'ImagesComparison'])
 
 
 class ImagesComparison(webdriver.Remote):
@@ -143,6 +147,6 @@ class ImagesComparison(webdriver.Remote):
 
     # pylint: disable=protected-access
     # noinspection PyProtectedMember
-    def _addCommands(self: T) -> None:
+    def _addCommands(self) -> None:
         self.command_executor._commands[Command.COMPARE_IMAGES] = \
             ('POST', '/session/$sessionId/appium/compare_images')

--- a/appium/webdriver/extensions/ime.py
+++ b/appium/webdriver/extensions/ime.py
@@ -12,22 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import TYPE_CHECKING, List, TypeVar
+from typing import Union, List, TypeVar
 
 from selenium import webdriver
 
 from ..mobilecommand import MobileCommand as Command
 
-if TYPE_CHECKING:
-    from appium.webdriver.webdriver import WebDriver
-
-T = TypeVar('T', bound='WebDriver')
+T = TypeVar('T', bound=Union[webdriver.Remote, 'IME'])
 
 
 class IME(webdriver.Remote):
 
     @property
-    def available_ime_engines(self) -> List[str]:
+    def available_ime_engines(self: T) -> List[str]:
         """Get the available input methods for an Android device.
 
         Package and activity are returned (e.g., ['com.android.inputmethod.latin/.LatinIME'])
@@ -38,7 +35,7 @@ class IME(webdriver.Remote):
         """
         return self.execute(Command.GET_AVAILABLE_IME_ENGINES, {})['value']
 
-    def is_ime_active(self) -> bool:
+    def is_ime_active(self: T) -> bool:
         """Checks whether the device has IME service active.
         Android only.
 
@@ -47,7 +44,7 @@ class IME(webdriver.Remote):
         """
         return self.execute(Command.IS_IME_ACTIVE, {})['value']
 
-    def activate_ime_engine(self, engine: str) -> T:
+    def activate_ime_engine(self: T, engine: str) -> T:
         """Activates the given IME engine on the device.
 
         Android only.
@@ -65,7 +62,7 @@ class IME(webdriver.Remote):
         self.execute(Command.ACTIVATE_IME_ENGINE, data)
         return self
 
-    def deactivate_ime_engine(self) -> T:
+    def deactivate_ime_engine(self: T) -> T:
         """Deactivates the currently active IME engine on the device.
 
         Android only.
@@ -77,8 +74,9 @@ class IME(webdriver.Remote):
         return self
 
     @property
-    def active_ime_engine(self) -> str:
-        """Returns the activity and package of the currently active IME engine(e.g., 'com.android.inputmethod.latin/.LatinIME').
+    def active_ime_engine(self: T) -> str:
+        """Returns the activity and package of the currently active IME engine
+        (e.g., 'com.android.inputmethod.latin/.LatinIME').
 
         Android only.
 
@@ -88,8 +86,8 @@ class IME(webdriver.Remote):
         return self.execute(Command.GET_ACTIVE_IME_ENGINE, {})['value']
 
     # pylint: disable=protected-access
-
-    def _addCommands(self) -> None:
+    # noinspection PyProtectedMember
+    def _addCommands(self: T) -> None:
         self.command_executor._commands[Command.GET_AVAILABLE_IME_ENGINES] = \
             ('GET', '/session/$sessionId/ime/available_engines')
         self.command_executor._commands[Command.IS_IME_ACTIVE] = \

--- a/appium/webdriver/extensions/ime.py
+++ b/appium/webdriver/extensions/ime.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Union, List, TypeVar, TYPE_CHECKING
+from typing import TYPE_CHECKING, List, TypeVar, Union
 
 from selenium import webdriver
 

--- a/appium/webdriver/extensions/ime.py
+++ b/appium/webdriver/extensions/ime.py
@@ -12,13 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Union, List, TypeVar
+from typing import Union, List, TypeVar, TYPE_CHECKING
 
 from selenium import webdriver
 
 from ..mobilecommand import MobileCommand as Command
 
-T = TypeVar('T', bound=Union[webdriver.Remote, 'IME'])
+if TYPE_CHECKING:
+    # noinspection PyUnresolvedReferences
+    from appium.webdriver.webdriver import WebDriver
+
+T = TypeVar('T', bound=Union['WebDriver', 'IME'])
 
 
 class IME(webdriver.Remote):
@@ -87,7 +91,7 @@ class IME(webdriver.Remote):
 
     # pylint: disable=protected-access
     # noinspection PyProtectedMember
-    def _addCommands(self: T) -> None:
+    def _addCommands(self) -> None:
         self.command_executor._commands[Command.GET_AVAILABLE_IME_ENGINES] = \
             ('GET', '/session/$sessionId/ime/available_engines')
         self.command_executor._commands[Command.IS_IME_ACTIVE] = \

--- a/appium/webdriver/extensions/keyboard.py
+++ b/appium/webdriver/extensions/keyboard.py
@@ -12,21 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import TYPE_CHECKING, Dict, Optional, TypeVar
+from typing import Union, Dict, Optional, TypeVar
 
 from selenium import webdriver
 
 from ..mobilecommand import MobileCommand as Command
 
-if TYPE_CHECKING:
-    from appium.webdriver.webdriver import WebDriver
-
-T = TypeVar('T', bound='WebDriver')
+T = TypeVar('T', bound=Union[webdriver.Remote, 'Keyboard'])
 
 
 class Keyboard(webdriver.Remote):
 
-    def hide_keyboard(self, key_name: Optional[str] = None, key: Optional[str]
+    def hide_keyboard(self: T, key_name: Optional[str] = None, key: Optional[str]
                       = None, strategy: Optional[str] = None) -> T:
         """Hides the software keyboard on the device.
 
@@ -49,7 +46,7 @@ class Keyboard(webdriver.Remote):
         self.execute(Command.HIDE_KEYBOARD, data)
         return self
 
-    def is_keyboard_shown(self) -> bool:
+    def is_keyboard_shown(self: T) -> bool:
         """Attempts to detect whether a software keyboard is present
 
         Returns:
@@ -57,7 +54,7 @@ class Keyboard(webdriver.Remote):
         """
         return self.execute(Command.IS_KEYBOARD_SHOWN)['value']
 
-    def keyevent(self, keycode: int, metastate: Optional[int] = None) -> T:
+    def keyevent(self: T, keycode: int, metastate: Optional[int] = None) -> T:
         """Sends a keycode to the device.
 
         Android only.
@@ -78,10 +75,11 @@ class Keyboard(webdriver.Remote):
         self.execute(Command.KEY_EVENT, data)
         return self
 
-    def press_keycode(self, keycode: int, metastate: Optional[int] = None, flags: Optional[int] = None) -> T:
+    def press_keycode(self: T, keycode: int, metastate: Optional[int] = None, flags: Optional[int] = None) -> T:
         """Sends a keycode to the device.
 
-        Android only. Possible keycodes can be found in http://developer.android.com/reference/android/view/KeyEvent.html.
+        Android only. Possible keycodes can be found
+        in http://developer.android.com/reference/android/view/KeyEvent.html.
 
         Args:
             keycode (int): the keycode to be sent to the device
@@ -101,10 +99,11 @@ class Keyboard(webdriver.Remote):
         self.execute(Command.PRESS_KEYCODE, data)
         return self
 
-    def long_press_keycode(self, keycode: int, metastate: Optional[int] = None, flags: Optional[int] = None) -> T:
+    def long_press_keycode(self: T, keycode: int, metastate: Optional[int] = None, flags: Optional[int] = None) -> T:
         """Sends a long press of keycode to the device.
 
-        Android only. Possible keycodes can be found in http://developer.android.com/reference/android/view/KeyEvent.html.
+        Android only. Possible keycodes can be found in
+        http://developer.android.com/reference/android/view/KeyEvent.html.
 
         Args:
             keycode (int): the keycode to be sent to the device
@@ -125,8 +124,8 @@ class Keyboard(webdriver.Remote):
         return self
 
     # pylint: disable=protected-access
-
-    def _addCommands(self) -> None:
+    # noinspection PyProtectedMember
+    def _addCommands(self: T) -> None:
         self.command_executor._commands[Command.HIDE_KEYBOARD] = \
             ('POST', '/session/$sessionId/appium/device/hide_keyboard')
         self.command_executor._commands[Command.IS_KEYBOARD_SHOWN] = \

--- a/appium/webdriver/extensions/keyboard.py
+++ b/appium/webdriver/extensions/keyboard.py
@@ -12,13 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Union, Dict, Optional, TypeVar
+from typing import Union, Dict, Optional, TypeVar, TYPE_CHECKING
 
 from selenium import webdriver
 
 from ..mobilecommand import MobileCommand as Command
 
-T = TypeVar('T', bound=Union[webdriver.Remote, 'Keyboard'])
+
+if TYPE_CHECKING:
+    # noinspection PyUnresolvedReferences
+    from appium.webdriver.webdriver import WebDriver
+
+T = TypeVar('T', bound=Union['WebDriver', 'Keyboard'])
 
 
 class Keyboard(webdriver.Remote):
@@ -125,7 +130,7 @@ class Keyboard(webdriver.Remote):
 
     # pylint: disable=protected-access
     # noinspection PyProtectedMember
-    def _addCommands(self: T) -> None:
+    def _addCommands(self) -> None:
         self.command_executor._commands[Command.HIDE_KEYBOARD] = \
             ('POST', '/session/$sessionId/appium/device/hide_keyboard')
         self.command_executor._commands[Command.IS_KEYBOARD_SHOWN] = \

--- a/appium/webdriver/extensions/keyboard.py
+++ b/appium/webdriver/extensions/keyboard.py
@@ -12,12 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Union, Dict, Optional, TypeVar, TYPE_CHECKING
+from typing import TYPE_CHECKING, Dict, Optional, TypeVar, Union
 
 from selenium import webdriver
 
 from ..mobilecommand import MobileCommand as Command
-
 
 if TYPE_CHECKING:
     # noinspection PyUnresolvedReferences

--- a/appium/webdriver/extensions/location.py
+++ b/appium/webdriver/extensions/location.py
@@ -12,20 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import TYPE_CHECKING, Dict, TypeVar, Union
+from typing import Dict, TypeVar, Union
 
 from selenium import webdriver
 
 from ..mobilecommand import MobileCommand as Command
 
-if TYPE_CHECKING:
-    from appium.webdriver.webdriver import WebDriver
-
-T = TypeVar('T', bound='WebDriver')
+T = TypeVar('T', bound=Union[webdriver.Remote, 'Location'])
 
 
 class Location(webdriver.Remote):
-    def toggle_location_services(self) -> T:
+    def toggle_location_services(self: T) -> T:
         """Toggle the location services on the device.
 
         Android only.
@@ -36,7 +33,7 @@ class Location(webdriver.Remote):
         self.execute(Command.TOGGLE_LOCATION_SERVICES, {})
         return self
 
-    def set_location(self,
+    def set_location(self: T,
                      latitude: Union[float, str],
                      longitude: Union[float, str],
                      altitude: Union[float, str] = None) -> T:
@@ -62,7 +59,7 @@ class Location(webdriver.Remote):
         return self
 
     @property
-    def location(self) -> Dict[str, float]:
+    def location(self: T) -> Dict[str, float]:
         """Retrieves the current location
 
         Returns:
@@ -74,7 +71,7 @@ class Location(webdriver.Remote):
         return self.execute(Command.GET_LOCATION)['value']
 
     # pylint: disable=protected-access
-
+    # noinspection PyProtectedMember
     def _addCommands(self) -> None:
         self.command_executor._commands[Command.TOGGLE_LOCATION_SERVICES] = \
             ('POST', '/session/$sessionId/appium/device/toggle_location_services')

--- a/appium/webdriver/extensions/location.py
+++ b/appium/webdriver/extensions/location.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Dict, TypeVar, Union, TYPE_CHECKING
+from typing import TYPE_CHECKING, Dict, TypeVar, Union
 
 from selenium import webdriver
 

--- a/appium/webdriver/extensions/location.py
+++ b/appium/webdriver/extensions/location.py
@@ -12,13 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Dict, TypeVar, Union
+from typing import Dict, TypeVar, Union, TYPE_CHECKING
 
 from selenium import webdriver
 
 from ..mobilecommand import MobileCommand as Command
 
-T = TypeVar('T', bound=Union[webdriver.Remote, 'Location'])
+if TYPE_CHECKING:
+    # noinspection PyUnresolvedReferences
+    from appium.webdriver.webdriver import WebDriver
+
+T = TypeVar('T', bound=Union['WebDriver', 'Location'])
 
 
 class Location(webdriver.Remote):

--- a/appium/webdriver/extensions/log_event.py
+++ b/appium/webdriver/extensions/log_event.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Dict, List, TypeVar, Union, TYPE_CHECKING
+from typing import TYPE_CHECKING, Dict, List, TypeVar, Union
 
 from selenium import webdriver
 

--- a/appium/webdriver/extensions/log_event.py
+++ b/appium/webdriver/extensions/log_event.py
@@ -12,13 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Dict, List, TypeVar, Union
+from typing import Dict, List, TypeVar, Union, TYPE_CHECKING
 
 from selenium import webdriver
 
 from ..mobilecommand import MobileCommand as Command
 
-T = TypeVar('T', bound=Union[webdriver.Remote, 'LogEvent'])
+if TYPE_CHECKING:
+    # noinspection PyUnresolvedReferences
+    from appium.webdriver.webdriver import WebDriver
+
+T = TypeVar('T', bound=Union['WebDriver', 'LogEvent'])
 
 
 class LogEvent(webdriver.Remote):
@@ -70,7 +74,7 @@ class LogEvent(webdriver.Remote):
 
     # pylint: disable=protected-access
     # noinspection PyProtectedMember
-    def _addCommands(self: T) -> None:
+    def _addCommands(self) -> None:
         self.command_executor._commands[Command.GET_EVENTS] = \
             ('POST', '/session/$sessionId/appium/events')
         self.command_executor._commands[Command.LOG_EVENT] = \

--- a/appium/webdriver/extensions/log_event.py
+++ b/appium/webdriver/extensions/log_event.py
@@ -12,21 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import TYPE_CHECKING, Dict, List, TypeVar, Union
+from typing import Dict, List, TypeVar, Union
 
 from selenium import webdriver
 
 from ..mobilecommand import MobileCommand as Command
 
-if TYPE_CHECKING:
-    from appium.webdriver.webdriver import WebDriver
-
-T = TypeVar('T', bound='WebDriver')
+T = TypeVar('T', bound=Union[webdriver.Remote, 'LogEvent'])
 
 
 class LogEvent(webdriver.Remote):
 
-    def get_events(self, type: List[str] = None) -> Dict[str, Union[str, int]]:
+    def get_events(self: T, type: List[str] = None) -> Dict[str, Union[str, int]]:
         """ Retrieves events information from the current session
         (Since Appium 1.16.0)
 
@@ -50,7 +47,7 @@ class LogEvent(webdriver.Remote):
             data['type'] = type
         return self.execute(Command.GET_EVENTS, data)['value']
 
-    def log_event(self, vendor: str, event: str) -> T:
+    def log_event(self: T, vendor: str, event: str) -> T:
         """Log a custom event on the Appium server.
         (Since Appium 1.16.0)
 
@@ -72,8 +69,8 @@ class LogEvent(webdriver.Remote):
         return self
 
     # pylint: disable=protected-access
-
-    def _addCommands(self) -> None:
+    # noinspection PyProtectedMember
+    def _addCommands(self: T) -> None:
         self.command_executor._commands[Command.GET_EVENTS] = \
             ('POST', '/session/$sessionId/appium/events')
         self.command_executor._commands[Command.LOG_EVENT] = \

--- a/appium/webdriver/extensions/remote_fs.py
+++ b/appium/webdriver/extensions/remote_fs.py
@@ -13,14 +13,18 @@
 # limitations under the License.
 
 import base64
-from typing import Union, Optional, TypeVar
+from typing import Union, Optional, TypeVar, TYPE_CHECKING
 
 from selenium import webdriver
 from selenium.common.exceptions import InvalidArgumentException
 
 from ..mobilecommand import MobileCommand as Command
 
-T = TypeVar('T', bound=Union[webdriver.remote, 'RemoteFS'])
+if TYPE_CHECKING:
+    # noinspection PyUnresolvedReferences
+    from appium.webdriver.webdriver import WebDriver
+
+T = TypeVar('T', bound=Union['WebDriver', 'RemoteFS'])
 
 
 class RemoteFS(webdriver.Remote):
@@ -88,7 +92,7 @@ class RemoteFS(webdriver.Remote):
 
     # pylint: disable=protected-access
     # noinspection PyProtectedMember
-    def _addCommands(self: T) -> None:
+    def _addCommands(self) -> None:
         self.command_executor._commands[Command.PULL_FILE] = \
             ('POST', '/session/$sessionId/appium/device/pull_file')
         self.command_executor._commands[Command.PULL_FOLDER] = \

--- a/appium/webdriver/extensions/remote_fs.py
+++ b/appium/webdriver/extensions/remote_fs.py
@@ -13,21 +13,18 @@
 # limitations under the License.
 
 import base64
-from typing import TYPE_CHECKING, Optional, TypeVar
+from typing import Union, Optional, TypeVar
 
 from selenium import webdriver
 from selenium.common.exceptions import InvalidArgumentException
 
 from ..mobilecommand import MobileCommand as Command
 
-if TYPE_CHECKING:
-    from appium.webdriver.webdriver import WebDriver
-
-T = TypeVar('T', bound='WebDriver')
+T = TypeVar('T', bound=Union[webdriver.remote, 'RemoteFS'])
 
 
 class RemoteFS(webdriver.Remote):
-    def pull_file(self, path: str) -> str:
+    def pull_file(self: T, path: str) -> str:
         """Retrieves the file at `path`.
 
         Args:
@@ -41,7 +38,7 @@ class RemoteFS(webdriver.Remote):
         }
         return self.execute(Command.PULL_FILE, data)['value']
 
-    def pull_folder(self, path: str) -> str:
+    def pull_folder(self: T, path: str) -> str:
         """Retrieves a folder at `path`.
 
         Args:
@@ -55,7 +52,7 @@ class RemoteFS(webdriver.Remote):
         }
         return self.execute(Command.PULL_FOLDER, data)['value']
 
-    def push_file(self, destination_path: str,
+    def push_file(self: T, destination_path: str,
                   base64data: Optional[str] = None, source_path: Optional[str] = None) -> T:
         """Puts the data from the file at `source_path`, encoded as Base64, in the file specified as `path`.
 
@@ -63,7 +60,8 @@ class RemoteFS(webdriver.Remote):
 
         Args:
             destination_path (str): the location on the device/simulator where the local file contents should be saved
-            base64data (:obj:`str`, optional): file contents, encoded as Base64, to be written to the file on the device/simulator
+            base64data (:obj:`str`, optional): file contents, encoded as Base64, to be written
+            to the file on the device/simulator
             source_path (:obj:`str`, optional): local file path for the file to be loaded on device
 
         Returns:
@@ -89,8 +87,8 @@ class RemoteFS(webdriver.Remote):
         return self
 
     # pylint: disable=protected-access
-
-    def _addCommands(self) -> None:
+    # noinspection PyProtectedMember
+    def _addCommands(self: T) -> None:
         self.command_executor._commands[Command.PULL_FILE] = \
             ('POST', '/session/$sessionId/appium/device/pull_file')
         self.command_executor._commands[Command.PULL_FOLDER] = \

--- a/appium/webdriver/extensions/remote_fs.py
+++ b/appium/webdriver/extensions/remote_fs.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import base64
-from typing import Union, Optional, TypeVar, TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional, TypeVar, Union
 
 from selenium import webdriver
 from selenium.common.exceptions import InvalidArgumentException

--- a/appium/webdriver/extensions/screen_record.py
+++ b/appium/webdriver/extensions/screen_record.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Union, TypeVar, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, TypeVar, Union
 
 from selenium import webdriver
 

--- a/appium/webdriver/extensions/screen_record.py
+++ b/appium/webdriver/extensions/screen_record.py
@@ -12,16 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Union
+from typing import Any, Union, TypeVar
 
 from selenium import webdriver
 
 from ..mobilecommand import MobileCommand as Command
 
+T = TypeVar('T', bound=Union[webdriver.remote, 'ScreenRecord'])
+
 
 class ScreenRecord(webdriver.Remote):
 
-    def start_recording_screen(self, **options: Any) -> Union[bytes, str]:
+    def start_recording_screen(self: T, **options: Any) -> Union[bytes, str]:
         """Start asynchronous screen recording process.
 
         Keyword Args:
@@ -45,24 +47,25 @@ class ScreenRecord(webdriver.Remote):
                 The maximum value for Android is 3 minutes.
                 The maximum value for iOS is 10 minutes.
             forcedRestart (bool): Whether to ignore the result of previous capture and start a new recording
-                immediately (`True` value). By default  (`False`) the endpoint will try to catch and return the result of
-                the previous capture if it's still available.
+                immediately (`True` value). By default  (`False`) the endpoint will try to catch and
+                return the result of the previous capture if it's still available.
             bugReport (str): Makes the recorder to display an additional information on the video overlay,
                 such as a timestamp, that is helpful in videos captured to illustrate bugs.
                 This option is only supported since API level 27 (Android P).
 
-            videoQuality (str): [iOS only] The video encoding quality: 'low', 'medium', 'high', 'photo'. Defaults to 'medium'.
+            videoQuality (str): [iOS only] The video encoding quality: 'low', 'medium', 'high', 'photo'. Defaults
+                to 'medium'.
             videoType (str): [iOS only] The format of the screen capture to be recorded.
                 Available formats: Execute `ffmpeg -codecs` in the terminal to see the list of supported video codecs.
                 'mjpeg' by default. (Since Appium 1.10.0)
-            videoFps (int): [iOS only] The Frames Per Second rate of the recorded video. Change this value if the resulting video
-                is too slow or too fast. Defaults to 10. This can decrease the resulting file size.
+            videoFps (int): [iOS only] The Frames Per Second rate of the recorded video. Change this value if the
+                resulting video is too slow or too fast. Defaults to 10. This can decrease the resulting file size.
             videoFilters (str): [iOS only] The FFMPEG video filters to apply. These filters allow to scale,
-                flip, rotate and do many other useful transformations on the source video stream. The format of the property
-                must comply with https://ffmpeg.org/ffmpeg-filters.html. (Since Appium 1.15)
-            videoScale (str): [iOS only] The scaling value to apply. Read https://trac.ffmpeg.org/wiki/Scaling for possible values.
-                No scale is applied by default. If videoFilters are set then the scale setting is effectively ignored.
-                (Since Appium 1.10.0)
+                flip, rotate and do many other useful transformations on the source video stream. The format of the
+                property must comply with https://ffmpeg.org/ffmpeg-filters.html. (Since Appium 1.15)
+            videoScale (str): [iOS only] The scaling value to apply. Read https://trac.ffmpeg.org/wiki/Scaling for
+                possible values. No scale is applied by default. If videoFilters are set then the scale setting is
+                effectively ignored. (Since Appium 1.10.0)
             pixelFormat (str): [iOS only] Output pixel format. Run `ffmpeg -pix_fmts` to list possible values.
                 For Quicktime compatibility, set to "yuv420p" along with videoType: "libx264". (Since Appium 1.12.0)
 
@@ -84,7 +87,7 @@ class ScreenRecord(webdriver.Remote):
             del options['password']
         return self.execute(Command.START_RECORDING_SCREEN, {'options': options})['value']
 
-    def stop_recording_screen(self, **options: Any) -> bytes:
+    def stop_recording_screen(self: T, **options: Any) -> bytes:
         """Gather the output from the previously started screen recording to a media file.
 
         Keyword Args:
@@ -113,8 +116,8 @@ class ScreenRecord(webdriver.Remote):
         return self.execute(Command.STOP_RECORDING_SCREEN, {'options': options})['value']
 
     # pylint: disable=protected-access
-
-    def _addCommands(self) -> None:
+    # noinspection PyProtectedMember
+    def _addCommands(self: T) -> None:
         self.command_executor._commands[Command.START_RECORDING_SCREEN] = \
             ('POST', '/session/$sessionId/appium/start_recording_screen')
         self.command_executor._commands[Command.STOP_RECORDING_SCREEN] = \

--- a/appium/webdriver/extensions/screen_record.py
+++ b/appium/webdriver/extensions/screen_record.py
@@ -12,13 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Union, TypeVar
+from typing import Any, Union, TypeVar, TYPE_CHECKING
 
 from selenium import webdriver
 
 from ..mobilecommand import MobileCommand as Command
 
-T = TypeVar('T', bound=Union[webdriver.remote, 'ScreenRecord'])
+if TYPE_CHECKING:
+    # noinspection PyUnresolvedReferences
+    from appium.webdriver.webdriver import WebDriver
+
+T = TypeVar('T', bound=Union['WebDriver', 'ScreenRecord'])
 
 
 class ScreenRecord(webdriver.Remote):
@@ -117,7 +121,7 @@ class ScreenRecord(webdriver.Remote):
 
     # pylint: disable=protected-access
     # noinspection PyProtectedMember
-    def _addCommands(self: T) -> None:
+    def _addCommands(self) -> None:
         self.command_executor._commands[Command.START_RECORDING_SCREEN] = \
             ('POST', '/session/$sessionId/appium/start_recording_screen')
         self.command_executor._commands[Command.STOP_RECORDING_SCREEN] = \

--- a/appium/webdriver/extensions/search_context/android.py
+++ b/appium/webdriver/extensions/search_context/android.py
@@ -15,7 +15,7 @@
 # pylint: disable=abstract-method
 
 import json
-from typing import TYPE_CHECKING, Any, List, Optional, Union, TypeVar
+from typing import TYPE_CHECKING, Any, List, Optional, TypeVar, Union
 
 from appium.webdriver.common.mobileby import MobileBy
 

--- a/appium/webdriver/extensions/search_context/android.py
+++ b/appium/webdriver/extensions/search_context/android.py
@@ -15,7 +15,7 @@
 # pylint: disable=abstract-method
 
 import json
-from typing import TYPE_CHECKING, Any, List, Optional
+from typing import TYPE_CHECKING, Any, List, Optional, Union, TypeVar
 
 from appium.webdriver.common.mobileby import MobileBy
 
@@ -24,12 +24,14 @@ from .base_search_context import BaseSearchContext
 if TYPE_CHECKING:
     from appium.webdriver.webelement import WebElement
 
+T = TypeVar('T', bound=Union[BaseSearchContext, 'AndroidSearchContext'])
+
 
 class AndroidSearchContext(BaseSearchContext):
     """Define search context for Android"""
 
-    def find_element_by_android_view_matcher(
-            self, name: Optional[str] = None, args: Optional[Any] = None, className: Optional[str] = None) -> 'WebElement':
+    def find_element_by_android_view_matcher(self: T, name: Optional[str] = None, args: Optional[Any] = None,
+                                             className: Optional[str] = None) -> 'WebElement':
         """Finds element by [onView](https://developer.android.com/training/testing/espresso/basics) in Android
 
         It works with [Espresso Driver](https://github.com/appium/appium-espresso-driver).
@@ -39,7 +41,8 @@ class AndroidSearchContext(BaseSearchContext):
                 The method must return a Hamcrest
                 [Matcher](http://hamcrest.org/JavaHamcrest/javadoc/1.3/org/hamcrest/Matcher.html)
             args (:obj:`Any`, optional): The args provided to the method
-            className (:obj:`str`, optional): The class name that the method is part of (defaults to `org.hamcrest.Matchers`).
+            className (:obj:`str`, optional): The class name that the method is part of
+                (defaults to `org.hamcrest.Matchers`).
                 Can be fully qualified by having the androidx.test.espresso.matcher. prefix.
                 If the prefix is not provided then it is going to be added implicitly.
                 (e.g.: `class=CursorMatchers` fully qualified is `class=androidx.test.espresso.matcher.CursorMatchers`
@@ -51,7 +54,8 @@ class AndroidSearchContext(BaseSearchContext):
             TypeError - Raises a TypeError if the arguments are not validated for JSON format
 
         Usage:
-            driver.find_element_by_android_view_matcher(name='withText', args=['Accessibility'], className='ViewMatchers')
+            driver.find_element_by_android_view_matcher(name='withText', args=['Accessibility'],
+            className='ViewMatchers')
 
         # To enable auto completion in PyCharm(IDE)
         :rtype: `appium.webdriver.webelement.WebElement`
@@ -62,9 +66,10 @@ class AndroidSearchContext(BaseSearchContext):
             value=self._build_data_matcher(name=name, args=args, className=className)
         )
 
-    def find_element_by_android_data_matcher(
-            self, name: Optional[str] = None, args: Optional[Any] = None, className: Optional[str] = None) -> 'WebElement':
-        """Finds element by [onData](https://medium.com/androiddevelopers/adapterviews-and-espresso-f4172aa853cf) in Android
+    def find_element_by_android_data_matcher(self: T, name: Optional[str] = None, args: Optional[Any] = None,
+                                             className: Optional[str] = None) -> 'WebElement':
+        """Finds element by
+        [onData](https://medium.com/androiddevelopers/adapterviews-and-espresso-f4172aa853cf) in Android
 
         It works with [Espresso Driver](https://github.com/appium/appium-espresso-driver).
 
@@ -73,7 +78,8 @@ class AndroidSearchContext(BaseSearchContext):
                 The method must return a Hamcrest
                 [Matcher](http://hamcrest.org/JavaHamcrest/javadoc/1.3/org/hamcrest/Matcher.html)
             args (:obj:`Any`, optional): The args provided to the method
-            className (:obj:`str`, optional): The class name that the method is part of (defaults to `org.hamcrest.Matchers`).
+            className (:obj:`str`, optional): The class name that the method is part of
+                (defaults to `org.hamcrest.Matchers`).
                 Can be fully qualified, or simple, and simple defaults to `androidx.test.espresso.matcher` package
                 (e.g.: `class=CursorMatchers` fully qualified is `class=androidx.test.espresso.matcher.CursorMatchers`
 
@@ -95,9 +101,10 @@ class AndroidSearchContext(BaseSearchContext):
             value=self._build_data_matcher(name=name, args=args, className=className)
         )
 
-    def find_elements_by_android_data_matcher(
-            self, name: Optional[str] = None, args: Optional[Any] = None, className: Optional[str] = None) -> List['WebElement']:
-        """Finds elements by [onData](https://medium.com/androiddevelopers/adapterviews-and-espresso-f4172aa853cf) in Android
+    def find_elements_by_android_data_matcher(self: T, name: Optional[str] = None, args: Optional[Any] = None,
+                                              className: Optional[str] = None) -> List['WebElement']:
+        """Finds elements by
+        [onData](https://medium.com/androiddevelopers/adapterviews-and-espresso-f4172aa853cf) in Android
         It works with [Espresso Driver](https://github.com/appium/appium-espresso-driver).
 
         Args:
@@ -105,7 +112,8 @@ class AndroidSearchContext(BaseSearchContext):
                 The method must return a Hamcrest
                 [Matcher](http://hamcrest.org/JavaHamcrest/javadoc/1.3/org/hamcrest/Matcher.html)
             args (:obj:`Any`, optional): The args provided to the method
-            className (:obj:`str`, optional): The class name that the method is part of (defaults to `org.hamcrest.Matchers`).
+            className (:obj:`str`, optional): The class name that the method is part of
+                (defaults to `org.hamcrest.Matchers`).
                 Can be fully qualified, or simple, and simple defaults to `androidx.test.espresso.matcher` package
                 (e.g.: `class=CursorMatchers` fully qualified is `class=androidx.test.espresso.matcher.CursorMatchers`
 
@@ -123,8 +131,8 @@ class AndroidSearchContext(BaseSearchContext):
             value=self._build_data_matcher(name=name, args=args, className=className)
         )
 
-    def _build_data_matcher(self, name: Optional[str] = None, args: Optional[Any]
-                            = None, className: Optional[str] = None) -> str:
+    def _build_data_matcher(self: T, name: Optional[str] = None, args: Optional[Any] = None,
+                            className: Optional[str] = None) -> str:
         result = {}
 
         for key, value in {'name': name, 'args': args, 'class': className}.items():
@@ -133,7 +141,7 @@ class AndroidSearchContext(BaseSearchContext):
 
         return json.dumps(result)
 
-    def find_element_by_android_uiautomator(self, uia_string: str) -> 'WebElement':
+    def find_element_by_android_uiautomator(self: T, uia_string: str) -> 'WebElement':
         """Finds element by uiautomator in Android.
 
         Args:
@@ -149,7 +157,7 @@ class AndroidSearchContext(BaseSearchContext):
         """
         return self.find_element(by=MobileBy.ANDROID_UIAUTOMATOR, value=uia_string)
 
-    def find_elements_by_android_uiautomator(self, uia_string: str) -> List['WebElement']:
+    def find_elements_by_android_uiautomator(self: T, uia_string: str) -> List['WebElement']:
         """Finds elements by uiautomator in Android.
 
         Args:
@@ -165,7 +173,7 @@ class AndroidSearchContext(BaseSearchContext):
         """
         return self.find_elements(by=MobileBy.ANDROID_UIAUTOMATOR, value=uia_string)
 
-    def find_element_by_android_viewtag(self, tag: str) -> 'WebElement':
+    def find_element_by_android_viewtag(self: T, tag: str) -> 'WebElement':
         """Finds element by [View#tags](https://developer.android.com/reference/android/view/View#tags) in Android.
 
         It works with [Espresso Driver](https://github.com/appium/appium-espresso-driver).
@@ -183,7 +191,7 @@ class AndroidSearchContext(BaseSearchContext):
         """
         return self.find_element(by=MobileBy.ANDROID_VIEWTAG, value=tag)
 
-    def find_elements_by_android_viewtag(self, tag: str) -> List['WebElement']:
+    def find_elements_by_android_viewtag(self: T, tag: str) -> List['WebElement']:
         """Finds element by [View#tags](https://developer.android.com/reference/android/view/View#tags) in Android.
 
         It works with [Espresso Driver](https://github.com/appium/appium-espresso-driver).

--- a/appium/webdriver/extensions/search_context/custom.py
+++ b/appium/webdriver/extensions/search_context/custom.py
@@ -14,7 +14,7 @@
 
 # pylint: disable=abstract-method
 
-from typing import TYPE_CHECKING, List
+from typing import TYPE_CHECKING, List, Union, TypeVar
 
 from appium.webdriver.common.mobileby import MobileBy
 
@@ -23,11 +23,13 @@ from .base_search_context import BaseSearchContext
 if TYPE_CHECKING:
     from appium.webdriver.webelement import WebElement
 
+T = TypeVar('T', bound=Union[BaseSearchContext, 'CustomSearchContext'])
+
 
 class CustomSearchContext(BaseSearchContext):
     """Define search context for custom plugin"""
 
-    def find_element_by_custom(self, selector: str) -> 'WebElement':
+    def find_element_by_custom(self: T, selector: str) -> 'WebElement':
         """Finds an element in conjunction with a custom element finding plugin
 
         Args:
@@ -47,7 +49,7 @@ class CustomSearchContext(BaseSearchContext):
         """
         return self.find_element(by=MobileBy.CUSTOM, value=selector)
 
-    def find_elements_by_custom(self, selector: str) -> List['WebElement']:
+    def find_elements_by_custom(self: T, selector: str) -> List['WebElement']:
         """Finds elements in conjunction with a custom element finding plugin
 
         Args:

--- a/appium/webdriver/extensions/search_context/custom.py
+++ b/appium/webdriver/extensions/search_context/custom.py
@@ -14,7 +14,7 @@
 
 # pylint: disable=abstract-method
 
-from typing import TYPE_CHECKING, List, Union, TypeVar
+from typing import TYPE_CHECKING, List, TypeVar, Union
 
 from appium.webdriver.common.mobileby import MobileBy
 

--- a/appium/webdriver/extensions/search_context/ios.py
+++ b/appium/webdriver/extensions/search_context/ios.py
@@ -14,7 +14,7 @@
 
 # pylint: disable=abstract-method
 
-from typing import TYPE_CHECKING, List
+from typing import TYPE_CHECKING, List, TypeVar, Union
 
 from appium.webdriver.common.mobileby import MobileBy
 
@@ -23,11 +23,13 @@ from .base_search_context import BaseSearchContext
 if TYPE_CHECKING:
     from appium.webdriver.webelement import WebElement
 
+T = TypeVar('T', bound=Union[BaseSearchContext, 'iOSSearchContext'])
+
 
 class iOSSearchContext(BaseSearchContext):
     """Define search context for iOS"""
 
-    def find_element_by_ios_uiautomation(self, uia_string: str) -> 'WebElement':
+    def find_element_by_ios_uiautomation(self: T, uia_string: str) -> 'WebElement':
         """Finds an element by uiautomation in iOS.
 
         Args:
@@ -44,7 +46,7 @@ class iOSSearchContext(BaseSearchContext):
         """
         return self.find_element(by=MobileBy.IOS_UIAUTOMATION, value=uia_string)
 
-    def find_elements_by_ios_uiautomation(self, uia_string: str) -> List['WebElement']:
+    def find_elements_by_ios_uiautomation(self: T, uia_string: str) -> List['WebElement']:
         """Finds elements by uiautomation in iOS.
 
         Args:
@@ -60,7 +62,7 @@ class iOSSearchContext(BaseSearchContext):
         """
         return self.find_elements(by=MobileBy.IOS_UIAUTOMATION, value=uia_string)
 
-    def find_element_by_ios_predicate(self, predicate_string: str) -> 'WebElement':
+    def find_element_by_ios_predicate(self: T, predicate_string: str) -> 'WebElement':
         """Find an element by ios predicate string.
 
         Args:
@@ -76,7 +78,7 @@ class iOSSearchContext(BaseSearchContext):
         """
         return self.find_element(by=MobileBy.IOS_PREDICATE, value=predicate_string)
 
-    def find_elements_by_ios_predicate(self, predicate_string: str) -> List['WebElement']:
+    def find_elements_by_ios_predicate(self: T, predicate_string: str) -> List['WebElement']:
         """Finds elements by ios predicate string.
 
         Args:
@@ -92,7 +94,7 @@ class iOSSearchContext(BaseSearchContext):
         """
         return self.find_elements(by=MobileBy.IOS_PREDICATE, value=predicate_string)
 
-    def find_element_by_ios_class_chain(self, class_chain_string: str) -> 'WebElement':
+    def find_element_by_ios_class_chain(self: T, class_chain_string: str) -> 'WebElement':
         """Find an element by ios class chain string.
 
         Args:
@@ -108,7 +110,7 @@ class iOSSearchContext(BaseSearchContext):
         """
         return self.find_element(by=MobileBy.IOS_CLASS_CHAIN, value=class_chain_string)
 
-    def find_elements_by_ios_class_chain(self, class_chain_string: str) -> List['WebElement']:
+    def find_elements_by_ios_class_chain(self: T, class_chain_string: str) -> List['WebElement']:
         """Finds elements by ios class chain string.
 
         Args:

--- a/appium/webdriver/extensions/search_context/mobile.py
+++ b/appium/webdriver/extensions/search_context/mobile.py
@@ -15,7 +15,7 @@
 # pylint: disable=abstract-method
 
 import base64
-from typing import TYPE_CHECKING, List, Union, TypeVar
+from typing import TYPE_CHECKING, List, TypeVar, Union
 
 from appium.webdriver.common.mobileby import MobileBy
 

--- a/appium/webdriver/extensions/search_context/mobile.py
+++ b/appium/webdriver/extensions/search_context/mobile.py
@@ -15,7 +15,7 @@
 # pylint: disable=abstract-method
 
 import base64
-from typing import TYPE_CHECKING, List
+from typing import TYPE_CHECKING, List, Union, TypeVar
 
 from appium.webdriver.common.mobileby import MobileBy
 
@@ -24,11 +24,13 @@ from .base_search_context import BaseSearchContext
 if TYPE_CHECKING:
     from appium.webdriver.webelement import WebElement
 
+T = TypeVar('T', bound=Union[BaseSearchContext, 'MobileSearchContext'])
+
 
 class MobileSearchContext(BaseSearchContext):
     """Define search context for Mobile(Android, iOS)"""
 
-    def find_element_by_accessibility_id(self, accessibility_id: str) -> 'WebElement':
+    def find_element_by_accessibility_id(self: T, accessibility_id: str) -> 'WebElement':
         """Finds an element by accessibility id.
 
         Args:
@@ -46,7 +48,7 @@ class MobileSearchContext(BaseSearchContext):
         """
         return self.find_element(by=MobileBy.ACCESSIBILITY_ID, value=accessibility_id)
 
-    def find_elements_by_accessibility_id(self, accessibility_id: str) -> List['WebElement']:
+    def find_elements_by_accessibility_id(self: T, accessibility_id: str) -> List['WebElement']:
         """Finds elements by accessibility id.
 
         Args:
@@ -63,7 +65,7 @@ class MobileSearchContext(BaseSearchContext):
         """
         return self.find_elements(by=MobileBy.ACCESSIBILITY_ID, value=accessibility_id)
 
-    def find_element_by_image(self, img_path: str) -> 'WebElement':
+    def find_element_by_image(self: T, img_path: str) -> 'WebElement':
         """Finds a portion of a screenshot by an image.
 
         Uses driver.find_image_occurrence under the hood.
@@ -81,7 +83,7 @@ class MobileSearchContext(BaseSearchContext):
 
         return self.find_element(by=MobileBy.IMAGE, value=b64_data)
 
-    def find_elements_by_image(self, img_path: str) -> List['WebElement']:
+    def find_elements_by_image(self: T, img_path: str) -> List['WebElement']:
         """Finds a portion of a screenshot by an image.
 
         Uses driver.find_image_occurrence under the hood. Note that this will

--- a/appium/webdriver/extensions/search_context/windows.py
+++ b/appium/webdriver/extensions/search_context/windows.py
@@ -14,7 +14,7 @@
 
 # pylint: disable=abstract-method
 
-from typing import TYPE_CHECKING, List, Union, TypeVar
+from typing import TYPE_CHECKING, List, TypeVar, Union
 
 from appium.webdriver.common.mobileby import MobileBy
 

--- a/appium/webdriver/extensions/search_context/windows.py
+++ b/appium/webdriver/extensions/search_context/windows.py
@@ -14,7 +14,7 @@
 
 # pylint: disable=abstract-method
 
-from typing import TYPE_CHECKING, List
+from typing import TYPE_CHECKING, List, Union, TypeVar
 
 from appium.webdriver.common.mobileby import MobileBy
 
@@ -23,11 +23,13 @@ from .base_search_context import BaseSearchContext
 if TYPE_CHECKING:
     from appium.webdriver.webelement import WebElement
 
+T = TypeVar('T', bound=Union[BaseSearchContext, 'WindowsSearchContext'])
+
 
 class WindowsSearchContext(BaseSearchContext):
     """Define search context for Windows"""
 
-    def find_element_by_windows_uiautomation(self, win_uiautomation: str) -> 'WebElement':
+    def find_element_by_windows_uiautomation(self: T, win_uiautomation: str) -> 'WebElement':
         """Finds an element by windows uiautomation
 
         Args:
@@ -44,7 +46,7 @@ class WindowsSearchContext(BaseSearchContext):
         """
         return self.find_element(by=MobileBy.WINDOWS_UI_AUTOMATION, value=win_uiautomation)
 
-    def find_elements_by_windows_uiautomation(self, win_uiautomation: str) -> List['WebElement']:
+    def find_elements_by_windows_uiautomation(self: T, win_uiautomation: str) -> List['WebElement']:
         """Finds elements by windows uiautomation
 
         Args:

--- a/appium/webdriver/extensions/session.py
+++ b/appium/webdriver/extensions/session.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Dict, List, TypeVar, Union
+from typing import Any, Dict, List, TypeVar, Union, TYPE_CHECKING
 
 from selenium import webdriver
 
@@ -20,7 +20,11 @@ from appium.common.logger import logger
 
 from ..mobilecommand import MobileCommand as Command
 
-T = TypeVar('T', bound=Union[webdriver.remote, 'Session'])
+if TYPE_CHECKING:
+    # noinspection PyUnresolvedReferences
+    from appium.webdriver.webdriver import WebDriver
+
+T = TypeVar('T', bound=Union['WebDriver', 'Session'])
 
 
 class Session(webdriver.Remote):
@@ -67,7 +71,7 @@ class Session(webdriver.Remote):
 
     # pylint: disable=protected-access
     # noinspection PyProtectedMember
-    def _addCommands(self: T) -> None:
+    def _addCommands(self) -> None:
         self.command_executor._commands[Command.GET_SESSION] = \
             ('GET', '/session/$sessionId')
         self.command_executor._commands[Command.GET_ALL_SESSIONS] = \

--- a/appium/webdriver/extensions/session.py
+++ b/appium/webdriver/extensions/session.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Dict, List, TypeVar, Union, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Dict, List, TypeVar, Union
 
 from selenium import webdriver
 

--- a/appium/webdriver/extensions/session.py
+++ b/appium/webdriver/extensions/session.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Dict, List
+from typing import Any, Dict, List, TypeVar, Union
 
 from selenium import webdriver
 
@@ -20,10 +20,12 @@ from appium.common.logger import logger
 
 from ..mobilecommand import MobileCommand as Command
 
+T = TypeVar('T', bound=Union[webdriver.remote, 'Session'])
+
 
 class Session(webdriver.Remote):
     @property
-    def session(self) -> Dict[str, Any]:
+    def session(self: T) -> Dict[str, Any]:
         """ Retrieves session information from the current session
 
         Usage:
@@ -35,7 +37,7 @@ class Session(webdriver.Remote):
         return self.execute(Command.GET_SESSION)['value']
 
     @property
-    def all_sessions(self) -> List[Dict[str, Any]]:
+    def all_sessions(self: T) -> List[Dict[str, Any]]:
         """ Retrieves all sessions that are open
 
         Usage:
@@ -47,7 +49,7 @@ class Session(webdriver.Remote):
         return self.execute(Command.GET_ALL_SESSIONS)['value']
 
     @property
-    def events(self) -> Dict:
+    def events(self: T) -> Dict:
         """ Retrieves events information from the current session
 
         Usage:
@@ -64,8 +66,8 @@ class Session(webdriver.Remote):
             return {}
 
     # pylint: disable=protected-access
-
-    def _addCommands(self) -> None:
+    # noinspection PyProtectedMember
+    def _addCommands(self: T) -> None:
         self.command_executor._commands[Command.GET_SESSION] = \
             ('GET', '/session/$sessionId')
         self.command_executor._commands[Command.GET_ALL_SESSIONS] = \

--- a/appium/webdriver/extensions/settings.py
+++ b/appium/webdriver/extensions/settings.py
@@ -12,20 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import TYPE_CHECKING, Any, Dict, TypeVar
+from typing import Union, Any, Dict, TypeVar
 
 from selenium import webdriver
 
 from ..mobilecommand import MobileCommand as Command
 
-if TYPE_CHECKING:
-    from appium.webdriver.webdriver import WebDriver
-
-T = TypeVar('T', bound='WebDriver')
+T = TypeVar('T', bound=Union[webdriver.Remote, 'Settings'])
 
 
 class Settings(webdriver.Remote):
-    def get_settings(self) -> Dict[str, Any]:
+    def get_settings(self: T) -> Dict[str, Any]:
         """Returns the appium server Settings for the current session.
 
         Do not get Settings confused with Desired Capabilities, they are
@@ -36,7 +33,7 @@ class Settings(webdriver.Remote):
         """
         return self.execute(Command.GET_SETTINGS, {})['value']
 
-    def update_settings(self, settings: Dict[str, Any]) -> T:
+    def update_settings(self: T, settings: Dict[str, Any]) -> T:
         """Set settings for the current session.
 
         For more on settings, see: https://github.com/appium/appium/blob/master/docs/en/advanced-concepts/settings.md
@@ -50,8 +47,8 @@ class Settings(webdriver.Remote):
         return self
 
     # pylint: disable=protected-access
-
-    def _addCommands(self) -> None:
+    # noinspection PyProtectedMember
+    def _addCommands(self: T) -> None:
         self.command_executor._commands[Command.GET_SETTINGS] = \
             ('GET', '/session/$sessionId/appium/settings')
         self.command_executor._commands[Command.UPDATE_SETTINGS] = \

--- a/appium/webdriver/extensions/settings.py
+++ b/appium/webdriver/extensions/settings.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Union, Any, Dict, TypeVar, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Dict, TypeVar, Union
 
 from selenium import webdriver
 

--- a/appium/webdriver/extensions/settings.py
+++ b/appium/webdriver/extensions/settings.py
@@ -12,13 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Union, Any, Dict, TypeVar
+from typing import Union, Any, Dict, TypeVar, TYPE_CHECKING
 
 from selenium import webdriver
 
 from ..mobilecommand import MobileCommand as Command
 
-T = TypeVar('T', bound=Union[webdriver.Remote, 'Settings'])
+if TYPE_CHECKING:
+    # noinspection PyUnresolvedReferences
+    from appium.webdriver.webdriver import WebDriver
+
+T = TypeVar('T', bound=Union['WebDriver', 'Settings'])
 
 
 class Settings(webdriver.Remote):
@@ -48,7 +52,7 @@ class Settings(webdriver.Remote):
 
     # pylint: disable=protected-access
     # noinspection PyProtectedMember
-    def _addCommands(self: T) -> None:
+    def _addCommands(self) -> None:
         self.command_executor._commands[Command.GET_SETTINGS] = \
             ('GET', '/session/$sessionId/appium/settings')
         self.command_executor._commands[Command.UPDATE_SETTINGS] = \


### PR DESCRIPTION
This should improve auto-complete suggestions in the IDE and address type warnings in PyCharm.

It would be necessary to use [protocols](https://www.python.org/dev/peps/pep-0544/) if we want to give mypy a hint about access to other mixin classes. For example:

```
class CanValidateCoordinates(Protocol):
    def validate(x, y): ...

......

Here we have some other mixin class, which implements the `CanValidateCoordinates` protocol
......
T = TypeVar('T', bound=Union['MixinClass', CanValidateCoordinates])
....
def mixin_method(self: T):
   self.validate(x, y)  # <--- mypy appreciates

```