### PR TITLE
chore: add py.typed in package, add maintainers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,8 +33,10 @@ setup(
     ],
     author='Isaac Murchie',
     author_email='isaac@saucelabs.com',
+    maintainer='Kazuaki Matsuo, Mykola Mokhnach, Mori Atsushi',
     url='http://appium.io/',
-    packages=find_packages(include=['appium*']),
+    package_data={'appium': ['webdriver/py.typed']},
+    packages=find_packages(include=['appium']),
     license='Apache 2.0',
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
`py.typed` is missing in package.

![image](https://user-images.githubusercontent.com/5511591/81461965-54d76b00-91ea-11ea-9c2b-1ad659a2f001.png)

Current master hasn't pushed yet.
I noticed the missing item when I crated a package on my local
https://github.com/appium/python-client/issues/537

I also added maintainer part