### PR TITLE
fix: broken package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,8 +35,7 @@ setup(
     author_email='isaac@saucelabs.com',
     maintainer='Kazuaki Matsuo, Mykola Mokhnach, Mori Atsushi',
     url='http://appium.io/',
-    package_data={'appium': ['webdriver/py.typed']},
-    packages=find_packages(include=['appium']),
+    packages=find_packages(include=['appium*', 'appium/webdriver/py.typed']),
     license='Apache 2.0',
     classifiers=[
         'Development Status :: 5 - Production/Stable',

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,8 @@ setup(
     author_email='isaac@saucelabs.com',
     maintainer='Kazuaki Matsuo, Mykola Mokhnach, Mori Atsushi',
     url='http://appium.io/',
-    packages=find_packages(include=['appium*', 'appium/webdriver/py.typed']),
+    package_data={'appium': ['webdriver/py.typed']},
+    packages=find_packages(include=['appium*']),
     license='Apache 2.0',
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
Manually installed by `python setup.py install` on local package, then all files were in `build/lib/appium/**`

![image](https://user-images.githubusercontent.com/5511591/82214913-7acedf00-9951-11ea-9af1-fc4ef1afc045.png)

We can check the package with:

1. `python setup.py sdist`
2. Go to `dist/<package>`
3. `python setup.py install`
4. Check the number of files in ``build/lib/appium/**`

Let me add the package check in release script.