### PR TITLE
chore: add checking package file count comparison in release script

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -7,6 +7,8 @@ if [ -z "$PYTHON_BIN_PATH" ]; then
   PYTHON_BIN_PATH=$(which python3 || which python || true)
 fi
 
+export PYTHON_BIN_PATH
+
 CONFIGURE_DIR=$(dirname "$0")
 "$PYTHON_BIN_PATH" "${CONFIGURE_DIR}/script/release.py" "$@"
 

--- a/script/release.py
+++ b/script/release.py
@@ -126,7 +126,7 @@ def has_same_file_count_original_built() -> bool:
     built_files = _get_py_files(BUILT_APPIUM_DIR_PATH)
     if len(original_files) != len(built_files):
         print("The count of files in 'build/lib/appium' and 'appium' were different. "
-              "'appium': {},\n 'build/lib/appium': {}".format(original_files, built_files))
+              f"'appium': {original_files},\n 'build/lib/appium': {built_files}")
         return False
 
     return True

--- a/script/release.py
+++ b/script/release.py
@@ -122,7 +122,12 @@ def compare_file_count():
 
     original_files = _get_py_files(APPIUM_DIR_PATH)
     built_files = _get_py_files(BUILT_APPIUM_DIR_PATH)
-    return len(original_files) - 1 == len(built_files)
+    if len(original_files) != len(built_files):
+        print("The count of files in 'build/lib/appium' and 'appium' were different. "
+              "'appium': {},\n 'build/lib/appium': {}".format(original_files, built_files))
+        return False
+
+    return True
 
 
 def main():

--- a/script/release.py
+++ b/script/release.py
@@ -126,9 +126,6 @@ def assert_files_count_in_package() -> None:
     original_files = get_py_files_in_dir(APPIUM_DIR_PATH)
     built_files = get_py_files_in_dir(BUILT_APPIUM_DIR_PATH)
 
-    print(len(original_files))
-    print(len(built_files))
-
     if len(original_files) != len(built_files):
         print(f"The count of files in '{APPIUM_DIR_PATH}' and '{BUILT_APPIUM_DIR_PATH}' were different.")
 


### PR DESCRIPTION
It help to prevent broken package like https://github.com/appium/python-client/issues/542 without any expensive process.