### PR TITLE
chore: address selenium-4 branch in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ framework [Appium](https://appium.io).
 
 Since **v1.0.0**, only Python 3 is supported
 
+### developing version
+[selenium-4](https://github.com/appium/python-client/tree/selenium-4) branch is a developing branch to switch base selenium client version from v3 to v4. The branch is available as pre-release versioning like `2.0.0.a0` via pypi.
+
+Main differences since current v1 is the v2 can connect to invalid SSL environment like self-certificated server. Please take a look at the branch's README for more details.
+
 ## Getting the Appium Python client
 
 There are three ways to install and use the Appium Python client.


### PR DESCRIPTION
I've created a selenium-4 based branch to inherits selenium 4.0.0.a7 (for now) instead of current v3.
It allows us to relax SSL verification so that it can connect to self-certificated SSL server.
I'd like to push the branch as pre-release like `2.0.0.a0` to pipy like selenium 4.0.0.a7.

For now, Python 3 and selenium v3 cannot connect to the environment because of an exception.

Our main working branch is still v1 (current master) though.

---

Btw, Python binding v4 still has JSONWP as well, while selenium 4 is basically going to support only W3C