### PR TITLE
feat: add warning to drop forceMjsonwp for W3C

### DIFF
--- a/appium/webdriver/webdriver.py
+++ b/appium/webdriver/webdriver.py
@@ -241,7 +241,8 @@ class WebDriver(
         """Manage capabilities whether W3C format or MJSONWP format
         """
         if _FORCE_MJSONWP in capabilities:
-            logger.warning("[Deprecated] 'forceMjsonwp' capability will be dropped")
+            logger.warning("[Deprecated] 'forceMjsonwp' capability will be dropped after switching base selenium client from v3 to v4 "\
+                          "to follow W3C spec capabilities. Appium 2.0 will also support only W3C session creation capabilities.")
             force_mjsonwp = capabilities[_FORCE_MJSONWP]
             del capabilities[_FORCE_MJSONWP]
 

--- a/appium/webdriver/webdriver.py
+++ b/appium/webdriver/webdriver.py
@@ -241,8 +241,12 @@ class WebDriver(
         """Manage capabilities whether W3C format or MJSONWP format
         """
         if _FORCE_MJSONWP in capabilities:
-            logger.warning("'forceMjsonwp' capability no longer works. Sending both W3C and MJSONWP capabilities")
+            logger.warning("[Deprecated] 'forceMjsonwp' capability will be dropped")
+            force_mjsonwp = capabilities[_FORCE_MJSONWP]
             del capabilities[_FORCE_MJSONWP]
+
+            if force_mjsonwp != False:
+                return {'desiredCapabilities': capabilities}
 
         w3c_caps = _make_w3c_caps(capabilities)
         return {'capabilities': w3c_caps, 'desiredCapabilities': capabilities}

--- a/appium/webdriver/webdriver.py
+++ b/appium/webdriver/webdriver.py
@@ -241,11 +241,8 @@ class WebDriver(
         """Manage capabilities whether W3C format or MJSONWP format
         """
         if _FORCE_MJSONWP in capabilities:
-            force_mjsonwp = capabilities[_FORCE_MJSONWP]
+            logger.warning("'forceMjsonwp' capability no longer works. Sending both W3C and MJSONWP capabilities")
             del capabilities[_FORCE_MJSONWP]
-
-            if force_mjsonwp != False:
-                return {'desiredCapabilities': capabilities}
 
         w3c_caps = _make_w3c_caps(capabilities)
         return {'capabilities': w3c_caps, 'desiredCapabilities': capabilities}

--- a/appium/webdriver/webdriver.py
+++ b/appium/webdriver/webdriver.py
@@ -241,8 +241,8 @@ class WebDriver(
         """Manage capabilities whether W3C format or MJSONWP format
         """
         if _FORCE_MJSONWP in capabilities:
-            logger.warning("[Deprecated] 'forceMjsonwp' capability will be dropped after switching base selenium client from v3 to v4 "\
-                          "to follow W3C spec capabilities. Appium 2.0 will also support only W3C session creation capabilities.")
+            logger.warning("[Deprecated] 'forceMjsonwp' capability will be dropped after switching base selenium client from v3 to v4 "
+                           "to follow W3C spec capabilities. Appium 2.0 will also support only W3C session creation capabilities.")
             force_mjsonwp = capabilities[_FORCE_MJSONWP]
             del capabilities[_FORCE_MJSONWP]
 

--- a/test/unit/webdriver/webdriver_test.py
+++ b/test/unit/webdriver/webdriver_test.py
@@ -89,12 +89,12 @@ class TestWebDriverWebDriver(object):
         assert 'appium/python {} (selenium'.format(appium_version.version) in request.headers['user-agent']
 
         request_json = json.loads(httpretty.HTTPretty.latest_requests[0].body.decode('utf-8'))
-        assert request_json.get('capabilities') is None
+        assert request_json.get('capabilities') is not None
         assert request_json.get('desiredCapabilities') is not None
 
         assert driver.session_id == 'session-id'
-        assert driver.w3c is False
-        assert driver.command_executor.w3c is False
+        assert driver.w3c is True
+        assert driver.command_executor.w3c is True
 
     @httpretty.activate
     def test_create_session_change_session_id(self):

--- a/test/unit/webdriver/webdriver_test.py
+++ b/test/unit/webdriver/webdriver_test.py
@@ -89,12 +89,12 @@ class TestWebDriverWebDriver(object):
         assert 'appium/python {} (selenium'.format(appium_version.version) in request.headers['user-agent']
 
         request_json = json.loads(httpretty.HTTPretty.latest_requests[0].body.decode('utf-8'))
-        assert request_json.get('capabilities') is not None
+        assert request_json.get('capabilities') is None
         assert request_json.get('desiredCapabilities') is not None
 
         assert driver.session_id == 'session-id'
-        assert driver.w3c is not True
-        assert driver.command_executor.w3c is True
+        assert driver.w3c is False
+        assert driver.command_executor.w3c is False
 
     @httpretty.activate
     def test_create_session_change_session_id(self):

--- a/test/unit/webdriver/webdriver_test.py
+++ b/test/unit/webdriver/webdriver_test.py
@@ -67,7 +67,7 @@ class TestWebDriverWebDriver(object):
         httpretty.register_uri(
             httpretty.POST,
             'http://localhost:4723/wd/hub/session',
-            body='{ "value": { "sessionId": "session-id", "capabilities": {"deviceName": "Android Emulator"}}}'
+            body='{ "capabilities": {"deviceName": "Android Emulator"}, "status": 0, "sessionId": "session-id"}'
         )
 
         desired_caps = {
@@ -93,7 +93,7 @@ class TestWebDriverWebDriver(object):
         assert request_json.get('desiredCapabilities') is not None
 
         assert driver.session_id == 'session-id'
-        assert driver.w3c is True
+        assert driver.w3c is not True
         assert driver.command_executor.w3c is True
 
     @httpretty.activate

--- a/test/unit/webdriver/webdriver_test.py
+++ b/test/unit/webdriver/webdriver_test.py
@@ -67,7 +67,7 @@ class TestWebDriverWebDriver(object):
         httpretty.register_uri(
             httpretty.POST,
             'http://localhost:4723/wd/hub/session',
-            body='{ "capabilities": {"deviceName": "Android Emulator"}, "status": 0, "sessionId": "session-id"}'
+            body='{ "value": { "sessionId": "session-id", "capabilities": {"deviceName": "Android Emulator"}}}'
         )
 
         desired_caps = {


### PR DESCRIPTION
`forceMjsonwp` only sends MJSONWP formatted capabilities, but selenium 4 and Appium is already going to focus on W3C.

The initial motivation to allow forceMjsonwp was to help users so that they were able to move to W3C from MJSONWP in their timeline. chrome driver also already defaults to W3C spec, so it's a good time to drop it.