### PR TITLE
chore: Fix functional keyboard tests with appium v1.21.0-beta.0

### DIFF
--- a/ci-jobs/functional_test.yml
+++ b/ci-jobs/functional_test.yml
@@ -2,7 +2,7 @@ parameters:
   vmImage: 'macOS-10.15'
   pytestOpt: '--doctest-modules --junitxml=junit/test-results.xml --cov=com --cov-report=xml --cov-report=html'
   androidSdkVer: 27
-  xcodeForIOS: 11.6
+  xcodeForIOS: 12.3
   CI: true
 
 jobs:

--- a/test/functional/ios/helper/desired_capabilities.py
+++ b/test/functional/ios/helper/desired_capabilities.py
@@ -28,7 +28,7 @@ def get_desired_capabilities(app: Optional[str] = None) -> Dict[str, Any]:
     desired_caps: Dict[str, Any] = {
         'deviceName': iphone_device_name(),
         'platformName': 'iOS',
-        'platformVersion': '13.6',
+        'platformVersion': '14.3',
         'automationName': 'XCUITest',
         'allowTouchIdEnroll': True,
         'wdaLocalPort': wda_port(),

--- a/test/functional/ios/keyboard_tests.py
+++ b/test/functional/ios/keyboard_tests.py
@@ -76,7 +76,7 @@ class TestKeyboard(BaseTestCase):
         assert self.driver.is_keyboard_shown()
 
     def _get_keyboard_el(self) -> 'WebElement':
-        return self.driver.find_element_by_class_name('UIAKeyboard')
+        return self.driver.find_element_by_class_name('XCUIElementTypeKeyboard')
 
     def _move_to_textbox(self) -> None:
         el1 = self.driver.find_element_by_accessibility_id('Sliders')

--- a/test/functional/ios/keyboard_tests.py
+++ b/test/functional/ios/keyboard_tests.py
@@ -13,8 +13,15 @@
 # limitations under the License.
 
 from time import sleep
+from typing import TYPE_CHECKING
+
+import pytest
+from selenium.common.exceptions import NoSuchElementException
 
 from test.functional.ios.helper.test_helper import BaseTestCase
+
+if TYPE_CHECKING:
+    from appium.webdriver.webelement import WebElement
 
 
 class TestKeyboard(BaseTestCase):
@@ -25,12 +32,12 @@ class TestKeyboard(BaseTestCase):
         el.click()
         el.set_value('Testing')
 
-        el = self.driver.find_element_by_class_name('UIAKeyboard')
-        assert el.is_displayed()
+        assert self._get_keyboard_el().is_displayed()
 
         self.driver.hide_keyboard(key_name='Done')
 
-        assert not el.is_displayed()
+        with pytest.raises(NoSuchElementException):
+            self._get_keyboard_el()
 
     def test_hide_keyboard_presskey_strategy(self) -> None:
         self._move_to_textbox()
@@ -39,12 +46,12 @@ class TestKeyboard(BaseTestCase):
         el.click()
         el.set_value('Testing')
 
-        el = self.driver.find_element_by_class_name('UIAKeyboard')
-        assert el.is_displayed()
+        assert self._get_keyboard_el().is_displayed()
 
         self.driver.hide_keyboard(strategy='pressKey', key='Done')
 
-        assert not el.is_displayed()
+        with pytest.raises(NoSuchElementException):
+            self._get_keyboard_el()
 
     def test_hide_keyboard_no_key_name(self) -> None:
         self._move_to_textbox()
@@ -53,14 +60,12 @@ class TestKeyboard(BaseTestCase):
         el.click()
         el.set_value('Testing')
 
-        el = self.driver.find_element_by_class_name('UIAKeyboard')
-        assert el.is_displayed()
+        assert self._get_keyboard_el().is_displayed()
 
         self.driver.hide_keyboard()
-        sleep(10)
 
-        # currently fails.
-        assert not el.is_displayed()
+        with pytest.raises(NoSuchElementException):
+            self._get_keyboard_el()
 
     def test_is_keyboard_shown(self) -> None:
         self._move_to_textbox()
@@ -69,6 +74,9 @@ class TestKeyboard(BaseTestCase):
         el.click()
         el.set_value('Testing')
         assert self.driver.is_keyboard_shown()
+
+    def _get_keyboard_el(self) -> 'WebElement':
+        return self.driver.find_element_by_class_name('UIAKeyboard')
 
     def _move_to_textbox(self) -> None:
         el1 = self.driver.find_element_by_accessibility_id('Sliders')


### PR DESCRIPTION
### Background

Failed functional keyboard tests with appium v1.21.0-beta.0

Link: https://github.com/appium/python-client/issues/570#issuecomment-766890824

### TODO
Failing below TC (Does these failures come from upgrading xocde and target iOS?)

- [ ] iOS: webdriver_test, test_app_management
- [ ] iOS: application_test, test_app_management
- [ ] Android: application_test, test_app_management (-> might be just flaky)

Test results with iOS 13.6

https://dev.azure.com/AppiumCI/Appium%20CI/_build/results?buildId=13648&view=results