### PR TITLE
chore: Update pipfile to respect isort v5

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,12 +2,12 @@
     rev: v4.3.21
     hooks:
     -   id: isort
-        args: ["-rc", "."]
+        args: ["."]
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: 'v0.782'
+    rev: 'v0.800'
     hooks:
     -   id: mypy
-        entry: mypy appium/ test/
+        entry: mypy appium/ test/functional
         pass_filenames: false
 -   repo: https://github.com/psf/black
     rev: 20.8b1

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ check-all: ## Run all lint checks and unittest
 
 .PHONY: isort
 isort: ## Run isort
-	python -m isort $(ARGS) -rc .
+	python -m isort $(ARGS) .
 
 .PHONY: black
 black: ## Run black
@@ -20,7 +20,7 @@ pylint: ## Run pylint
 
 .PHONY: mypy
 mypy:  ## Run mypy
-	python -m mypy appium test
+	python -m mypy appium test/functional
 
 .PHONY: unittest
 unittest: ## Run unittest

--- a/Pipfile
+++ b/Pipfile
@@ -4,25 +4,25 @@ url = "https://pypi.org/simple"
 verify_ssl = true
 
 [dev-packages]
-pre-commit = "~=2.6"
+pre-commit = "~=2.10"
 
 [packages]
 selenium = "~=3.141"
 
 black = "==20.8b1"
 
-pytest = "~=6.0"
-pytest-cov = "~=2.10"
+pytest = "~=6.2"
+pytest-cov = "~=2.11"
 
-tox = "~=3.19"
+tox = "~=3.21"
 tox-travis = "~=0.12"
 
 httpretty = "~=1.0"
 python-dateutil = "~=2.8"
 mock = "~=4.0"
 
-pylint = "~=2.5"
+pylint = "~=2.6"
 astroid = "~=2.4"
-isort = "~=4.3"  # TODO Can be 5> when pylint uses isort 5>
+isort = "~=5.0"
 
-mypy = "==0.782"
+mypy = "~=0.800"

--- a/appium/webdriver/common/multi_action.py
+++ b/appium/webdriver/common/multi_action.py
@@ -24,9 +24,9 @@ from typing import TYPE_CHECKING, Dict, List, Optional, TypeVar, Union
 from appium.webdriver.mobilecommand import MobileCommand as Command
 
 if TYPE_CHECKING:
+    from appium.webdriver.common.touch_action import TouchAction
     from appium.webdriver.webdriver import WebDriver
     from appium.webdriver.webelement import WebElement
-    from appium.webdriver.common.touch_action import TouchAction
 
 T = TypeVar('T', bound='MultiAction')
 

--- a/appium/webdriver/common/touch_action.py
+++ b/appium/webdriver/common/touch_action.py
@@ -29,8 +29,8 @@ from typing import TYPE_CHECKING, Dict, List, Optional, TypeVar, Union
 from appium.webdriver.mobilecommand import MobileCommand as Command
 
 if TYPE_CHECKING:
-    from appium.webdriver.webelement import WebElement
     from appium.webdriver.webdriver import WebDriver
+    from appium.webdriver.webelement import WebElement
 
 T = TypeVar('T', bound='TouchAction')
 

--- a/test/functional/android/helper/test_helper.py
+++ b/test/functional/android/helper/test_helper.py
@@ -26,8 +26,8 @@ from test.functional.test_helper import is_ci
 from . import desired_capabilities
 
 if TYPE_CHECKING:
-    from appium.webdriver.webelement import WebElement
     from appium.webdriver.webdriver import WebDriver
+    from appium.webdriver.webelement import WebElement
 
 # the emulator is sometimes slow and needs time to think
 SLEEPY_TIME = 10

--- a/test/unit/helper/test_helper.py
+++ b/test/unit/helper/test_helper.py
@@ -23,8 +23,9 @@ from appium import webdriver
 SERVER_URL_BASE = 'http://localhost:4723/wd/hub'
 
 if TYPE_CHECKING:
-    from appium.webdriver.webdriver import WebDriver
     from httpretty.core import HTTPrettyRequestEmpty
+
+    from appium.webdriver.webdriver import WebDriver
 
 
 def appium_command(command: str) -> str:


### PR DESCRIPTION
### Background

Since isort v4 is used.

### Note

Currently mypy target is only `functional` under `test.`( `test/unit` is ignored by mypy v0.782 somehow.)
(But in my opinion, it isn't so impact even if `test/unit` is not target.)
