### PR TITLE
feat: allow to add a command dynamically

### DIFF
--- a/appium/webdriver/command_method.py
+++ b/appium/webdriver/command_method.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import enum
+
+
+class CommandMethod(enum.Enum):
+    GET = 'GET'
+    HEAD = 'HEAD'
+    POST = 'POST'
+    PUT = 'PUT'
+    DELETE = 'DELETE'
+    CONNECT = 'CONNECT'
+    OPTIONS = 'OPTIONS'
+    TRACE = 'TRACE'
+    PATCH = 'PATCH'

--- a/appium/webdriver/webdriver.py
+++ b/appium/webdriver/webdriver.py
@@ -363,10 +363,12 @@ class WebDriver(
 
         Args:
             method: The method of HTTP request. Available methods are AVAILABLE_METHOD.
-            url: The url to URL template as https://www.w3.org/TR/webdriver/#endpoints.
-                '$sessionId' is a placeholder of current session id.
-                '$id' is a placeholder of an element.
-            name: The name of command to call in `execute_custom_command`.
+            url: The url is URL template as https://www.w3.org/TR/webdriver/#endpoints.
+                 `$sessionId` is a placeholder of current session id.
+                 Other placeholders can be specified with `$` prefix like `$id`.
+                 Then, `{'id': 'some id'}` argument in `execute_custom_command` replaces
+                 the `$id` with the value, `some id`, in the request.
+            name: The name of a command to call in `execute_custom_command`.
 
         Returns:
             `appium.webdriver.webdriver.WebDriver`: Self instance

--- a/appium/webdriver/webdriver.py
+++ b/appium/webdriver/webdriver.py
@@ -356,14 +356,10 @@ class WebDriver(
 
         return MobileSwitchTo(self)
 
-    def add_command(self, method: str, url: str, name: str) -> Callable:
+    def registar_command(self, method: str, url: str, name: str) -> Callable:
         """"""
         self.command_executor._commands[name] = (method, url)
-
-        def function() -> Any:
-            return self.execute(name, {})
-
-        return function
+        return self
 
     # pylint: disable=protected-access
 

--- a/appium/webdriver/webdriver.py
+++ b/appium/webdriver/webdriver.py
@@ -15,7 +15,7 @@
 # pylint: disable=too-many-lines,too-many-public-methods,too-many-statements,no-self-use
 
 import copy
-from typing import Any, Dict, List, Optional, TypeVar, Union
+from typing import Any, Callable, Dict, List, Optional, TypeVar, Union
 
 from selenium.common.exceptions import InvalidArgumentException
 from selenium.webdriver.common.by import By
@@ -355,6 +355,15 @@ class WebDriver(
         """
 
         return MobileSwitchTo(self)
+
+    def add_command(self, method: str, url: str, name: str) -> Callable:
+        """"""
+        self.command_executor._commands[name] = (method, url)
+
+        def function() -> Any:
+            return self.execute(name, {})
+
+        return function
 
     # pylint: disable=protected-access
 

--- a/appium/webdriver/webdriver.py
+++ b/appium/webdriver/webdriver.py
@@ -15,7 +15,7 @@
 # pylint: disable=too-many-lines,too-many-public-methods,too-many-statements,no-self-use
 
 import copy
-from typing import Any, Callable, Dict, List, Optional, TypeVar, Union
+from typing import Any, Dict, List, Optional, TypeVar, Union
 
 from selenium.common.exceptions import InvalidArgumentException
 from selenium.webdriver.common.by import By
@@ -358,7 +358,7 @@ class WebDriver(
 
         return MobileSwitchTo(self)
 
-    def add_command(self, method: str, url: str, name: str) -> Callable:
+    def add_command(self, method: str, url: str, name: str) -> T:
         """Add a custom command as 'name'
 
         Args:

--- a/appium/webdriver/webdriver.py
+++ b/appium/webdriver/webdriver.py
@@ -390,7 +390,7 @@ class WebDriver(
             raise ValueError("{} is already defined".format(name))
 
         if not isinstance(method, CommandMethod):
-            raise ValueError("'{}' is invalid. Valid method is 'CommandMethod'.".format(method))
+            raise ValueError("'{}' is invalid. Valid method is in '{}'.".format(method, CommandMethod.__name__))
 
         self.command_executor._commands[name] = (method.value, url)
         return self

--- a/appium/webdriver/webdriver.py
+++ b/appium/webdriver/webdriver.py
@@ -411,11 +411,34 @@ class WebDriver(
         Examples:
             Calls 'test_command' command without arguments.
 
+            >>> from appium.webdriver.command_method import CommandMethod
+            >>> driver.add_command(
+                    method=CommandMethod.GET,
+                    url='session/$sessionId/path/to/custom/url',
+                    name='test_command'
+                )
             >>> result = driver.execute_custom_command('test_command')
 
             Calls 'test_command' command with arguments.
 
+            >>> from appium.webdriver.command_method import CommandMethod
+            >>> driver.add_command(
+                    method=CommandMethod.POST,
+                    url='session/$sessionId/path/to/custom/url',
+                    name='test_command'
+                )
             >>> result = driver.execute_custom_command('test_command', {'dummy': 'test argument'})
+
+            Calls 'test_command' command with arguments, and the path has 'element id'.
+            The '$id' will be 'element id' by 'id' key in the given argument.
+
+            >>> from appium.webdriver.command_method import CommandMethod
+            >>> driver.add_command(
+                    method=CommandMethod.POST,
+                    url='session/$sessionId/path/to/$id/url',
+                    name='test_command'
+                )
+            >>> result = driver.execute_custom_command('test_command', {'id': 'element id', 'dummy': 'test argument'})
 
         """
         if name not in self.command_executor._commands:

--- a/appium/webdriver/webdriver.py
+++ b/appium/webdriver/webdriver.py
@@ -390,7 +390,9 @@ class WebDriver(
             raise ValueError("{} is already defined".format(name))
 
         if not isinstance(method, CommandMethod):
-            raise ValueError("'{}' is invalid. Valid method is in '{}'.".format(method, CommandMethod.__name__))
+            raise ValueError(
+                "'{}' is invalid. Valid method should be one of '{}'.".format(method, CommandMethod.__name__)
+            )
 
         self.command_executor._commands[name] = (method.value, url)
         return self

--- a/appium/webdriver/webdriver.py
+++ b/appium/webdriver/webdriver.py
@@ -356,10 +356,16 @@ class WebDriver(
 
         return MobileSwitchTo(self)
 
-    def registar_command(self, method: str, url: str, name: str) -> Callable:
-        """"""
+    def add_command(self, method: str, url: str, name: str) -> Callable:
+        if name in self.command_executor._commands:
+            raise ValueError("{} is already defined".format(name))
         self.command_executor._commands[name] = (method, url)
         return self
+
+    def execute_custom_command(self, name: str, args: Dict) -> Any:
+        if name not in self.command_executor._commands:
+            raise ValueError("No {} custom command. Please add it with 'add_command'".format(name))
+        return self.execute(name, args)['value']
 
     # pylint: disable=protected-access
 

--- a/test/unit/webdriver/webdriver_test.py
+++ b/test/unit/webdriver/webdriver_test.py
@@ -279,6 +279,18 @@ class TestWebDriverWebDriver(object):
         assert d['dummy'] == 'test argument'
 
     @httpretty.activate
+    def test_add_command_with_element_id(self):
+        driver = ios_w3c_driver()
+        httpretty.register_uri(
+            httpretty.GET,
+            appium_command('session/1234567890/path/to/custom/element_id/url'),
+            body=json.dumps({'value': {}}),
+        )
+        driver.add_command(method='GET', url='session/$sessionId/path/to/custom/$id/url', name='test_command')
+        result = driver.execute_custom_command('test_command', {'id': 'element_id'})
+        assert result == {}
+
+    @httpretty.activate
     def test_add_command_already_defined(self):
         driver = ios_w3c_driver()
         driver.add_command(method='GET', url='session/$sessionId/path/to/custom/url', name='test_command')

--- a/test/unit/webdriver/webdriver_test.py
+++ b/test/unit/webdriver/webdriver_test.py
@@ -15,6 +15,7 @@
 import json
 
 import httpretty
+import pytest
 from mock import patch
 
 from appium import version as appium_version
@@ -294,30 +295,21 @@ class TestWebDriverWebDriver(object):
     def test_add_command_already_defined(self):
         driver = ios_w3c_driver()
         driver.add_command(method='GET', url='session/$sessionId/path/to/custom/url', name='test_command')
-        try:
+        with pytest.raises(ValueError):
             driver.add_command(method='GET', url='session/$sessionId/path/to/custom/url', name='test_command')
-            assert False, 'Should raise ValueError'
-        except ValueError:
-            assert True
 
     @httpretty.activate
     def test_execute_custom_command(self):
         driver = ios_w3c_driver()
         driver.add_command(method='GET', url='session/$sessionId/path/to/custom/url', name='test_command')
-        try:
+        with pytest.raises(ValueError):
             driver.add_command(method='GET', url='session/$sessionId/path/to/custom/url', name='test_command')
-            assert False, 'Should raise ValueError'
-        except ValueError:
-            assert True
 
     @httpretty.activate
     def test_invalid_method(self):
         driver = ios_w3c_driver()
-        try:
+        with pytest.raises(ValueError):
             driver.add_command(method='error', url='session/$sessionId/path/to/custom/url', name='test_command')
-            assert False, 'Should raise ValueError'
-        except ValueError:
-            assert True
 
 
 class SubWebDriver(WebDriver):

--- a/test/unit/webdriver/webdriver_test.py
+++ b/test/unit/webdriver/webdriver_test.py
@@ -258,7 +258,7 @@ class TestWebDriverWebDriver(object):
             appium_command('session/1234567890/path/to/custom/url'),
             body=json.dumps({'value': {}}),
         )
-        driver.registar_command(method='GET', url='session/$sessionId/path/to/custom/url', name='test_command')
+        driver.add_command(method='GET', url='session/$sessionId/path/to/custom/url', name='test_command')
         result = driver.execute('test_command', {})
 
         assert result == {'value': {}}
@@ -271,12 +271,32 @@ class TestWebDriverWebDriver(object):
             appium_command('session/1234567890/path/to/custom/url'),
             body=json.dumps({'value': {}}),
         )
-        driver.registar_command(method='POST', url='session/$sessionId/path/to/custom/url', name='test_command')
-        result = driver.execute('test_command', {'dummy': 'test argument'})
-        assert result == {'value': {}}
+        driver.add_command(method='POST', url='session/$sessionId/path/to/custom/url', name='test_command')
+        result = driver.execute_custom_command('test_command', {'dummy': 'test argument'})
+        assert result == {}
 
         d = get_httpretty_request_body(httpretty.last_request())
         assert d['dummy'] == 'test argument'
+
+    @httpretty.activate
+    def test_add_command_already_defined(self):
+        driver = ios_w3c_driver()
+        driver.add_command(method='GET', url='session/$sessionId/path/to/custom/url', name='test_command')
+        try:
+            driver.add_command(method='GET', url='session/$sessionId/path/to/custom/url', name='test_command')
+            assert False, 'Should raise InvalidArgumentException'
+        except ValueError:
+            assert True
+
+    @httpretty.activate
+    def test_execute_custom_command(self):
+        driver = ios_w3c_driver()
+        driver.add_command(method='GET', url='session/$sessionId/path/to/custom/url', name='test_command')
+        try:
+            driver.add_command(method='GET', url='session/$sessionId/path/to/custom/url', name='test_command')
+            assert False, 'Should raise InvalidArgumentException'
+        except ValueError:
+            assert True
 
 
 class SubWebDriver(WebDriver):

--- a/test/unit/webdriver/webdriver_test.py
+++ b/test/unit/webdriver/webdriver_test.py
@@ -250,6 +250,22 @@ class TestWebDriverWebDriver(object):
         mock_warning.assert_called_once()
         assert events == {}
 
+    @httpretty.activate
+    def test_add_command(self):
+        driver = ios_w3c_driver()
+        httpretty.register_uri(
+            httpretty.GET,
+            appium_command('session/1234567890/path/to/custom/url'),
+            body=json.dumps({'value': {}}),
+        )
+        driver.test_command = driver.add_command(
+            method='GET', url='session/$sessionId/path/to/custom/url', name='test_command'
+        )
+
+        result = driver.test_command()
+
+        assert result == {'value': {}}
+
 
 class SubWebDriver(WebDriver):
     def __init__(self, command_executor, desired_capabilities, direct_connection=False):

--- a/test/unit/webdriver/webdriver_test.py
+++ b/test/unit/webdriver/webdriver_test.py
@@ -20,6 +20,7 @@ from mock import patch
 
 from appium import version as appium_version
 from appium import webdriver
+from appium.webdriver.command_method import CommandMethod
 from appium.webdriver.webdriver import WebDriver
 from test.unit.helper.test_helper import android_w3c_driver, appium_command, get_httpretty_request_body, ios_w3c_driver
 
@@ -259,7 +260,7 @@ class TestWebDriverWebDriver(object):
             appium_command('session/1234567890/path/to/custom/url'),
             body=json.dumps({'value': {}}),
         )
-        driver.add_command(method='GET', url='session/$sessionId/path/to/custom/url', name='test_command')
+        driver.add_command(method=CommandMethod.GET, url='session/$sessionId/path/to/custom/url', name='test_command')
         result = driver.execute_custom_command('test_command')
 
         assert result == {}
@@ -272,7 +273,7 @@ class TestWebDriverWebDriver(object):
             appium_command('session/1234567890/path/to/custom/url'),
             body=json.dumps({'value': {}}),
         )
-        driver.add_command(method='POST', url='session/$sessionId/path/to/custom/url', name='test_command')
+        driver.add_command(method=CommandMethod.POST, url='session/$sessionId/path/to/custom/url', name='test_command')
         result = driver.execute_custom_command('test_command', {'dummy': 'test argument'})
         assert result == {}
 
@@ -287,23 +288,29 @@ class TestWebDriverWebDriver(object):
             appium_command('session/1234567890/path/to/custom/element_id/url'),
             body=json.dumps({'value': {}}),
         )
-        driver.add_command(method='GET', url='session/$sessionId/path/to/custom/$id/url', name='test_command')
+        driver.add_command(
+            method=CommandMethod.GET, url='session/$sessionId/path/to/custom/$id/url', name='test_command'
+        )
         result = driver.execute_custom_command('test_command', {'id': 'element_id'})
         assert result == {}
 
     @httpretty.activate
     def test_add_command_already_defined(self):
         driver = ios_w3c_driver()
-        driver.add_command(method='GET', url='session/$sessionId/path/to/custom/url', name='test_command')
+        driver.add_command(method=CommandMethod.GET, url='session/$sessionId/path/to/custom/url', name='test_command')
         with pytest.raises(ValueError):
-            driver.add_command(method='GET', url='session/$sessionId/path/to/custom/url', name='test_command')
+            driver.add_command(
+                method=CommandMethod.GET, url='session/$sessionId/path/to/custom/url', name='test_command'
+            )
 
     @httpretty.activate
     def test_execute_custom_command(self):
         driver = ios_w3c_driver()
-        driver.add_command(method='GET', url='session/$sessionId/path/to/custom/url', name='test_command')
+        driver.add_command(method=CommandMethod.GET, url='session/$sessionId/path/to/custom/url', name='test_command')
         with pytest.raises(ValueError):
-            driver.add_command(method='GET', url='session/$sessionId/path/to/custom/url', name='test_command')
+            driver.add_command(
+                method=CommandMethod.GET, url='session/$sessionId/path/to/custom/url', name='test_command'
+            )
 
     @httpretty.activate
     def test_invalid_method(self):

--- a/test/unit/webdriver/webdriver_test.py
+++ b/test/unit/webdriver/webdriver_test.py
@@ -259,9 +259,9 @@ class TestWebDriverWebDriver(object):
             body=json.dumps({'value': {}}),
         )
         driver.add_command(method='GET', url='session/$sessionId/path/to/custom/url', name='test_command')
-        result = driver.execute('test_command', {})
+        result = driver.execute_custom_command('test_command')
 
-        assert result == {'value': {}}
+        assert result == {}
 
     @httpretty.activate
     def test_add_command_body(self):
@@ -284,7 +284,7 @@ class TestWebDriverWebDriver(object):
         driver.add_command(method='GET', url='session/$sessionId/path/to/custom/url', name='test_command')
         try:
             driver.add_command(method='GET', url='session/$sessionId/path/to/custom/url', name='test_command')
-            assert False, 'Should raise InvalidArgumentException'
+            assert False, 'Should raise ValueError'
         except ValueError:
             assert True
 
@@ -294,7 +294,16 @@ class TestWebDriverWebDriver(object):
         driver.add_command(method='GET', url='session/$sessionId/path/to/custom/url', name='test_command')
         try:
             driver.add_command(method='GET', url='session/$sessionId/path/to/custom/url', name='test_command')
-            assert False, 'Should raise InvalidArgumentException'
+            assert False, 'Should raise ValueError'
+        except ValueError:
+            assert True
+
+    @httpretty.activate
+    def test_invalid_method(self):
+        driver = ios_w3c_driver()
+        try:
+            driver.add_command(method='error', url='session/$sessionId/path/to/custom/url', name='test_command')
+            assert False, 'Should raise ValueError'
         except ValueError:
             assert True
 


### PR DESCRIPTION
Appium 2.0 will allow custom drivers/plugins add their own endpoint.
Then, we want to allow clients to add custom commands for them.

In Ruby, I've added like https://github.com/appium/ruby_lib_core/blob/b9f015d7dea14964a0733f2385ebcff68da1e18e/test/unit/android/webdriver/w3c/commands_test.rb#L31-L98 as an experimental method. (The method was already used internally, so as Ruby client, it was just exposed the method as a public method.)

In Python, I've added two methods. `add_command` and `execute_custom_command`.

`add_command` adds the pair of HTTP method and a path in `self.command_executor._commands`.
`execute_custom_command` calls a method from `self.command_executor._commands` as `self.execute`.
We want to hide `self.execute` and `self.command_executor` since they are for internal usage so far. They may change by updating selenium library, for instance.

```python
# add commands
driver.add_command(method='POST', url='session/$sessionId/path/to/custom/url', name='test_command')

def do_command():
    # some logic for arguments
    return_value = driver.execute_custom_command('test_command', arguments)
    # dom some process for the return value
    return result

driver.custom_my_command = do_command
...
result = driver.custom_my_command()  # just call it
...
```

I considered decoration way, but so far, this exposing two methods as public methods are simpler I think.

What do you think?
Your thought is welcome such as better naming etc.