### PR TITLE
chore: adding deprecation mark in touch actions and multi touch

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,15 @@ New
 
 Other
 ~~~~~
+- Bump 2.0.0.rc5. [Kazuaki Matsuo]
+- Chore(deps): update sphinx requirement from <4.0,>=3.0 to >=3.0,<5.0
+  (#603) [Kazuaki Matsuo, dependabot[bot]]
+
+  Updates the requirements on [sphinx](https://github.com/sphinx-doc/sphinx) to permit the latest version.
+  - [Release notes](https://github.com/sphinx-doc/sphinx/releases)
+  - [Changelog](https://github.com/sphinx-doc/sphinx/blob/4.x/CHANGES)
+  - [Commits](https://github.com/sphinx-doc/sphinx/compare/v3.0.0...v4.0.0)
+- Update gitchangelog once. [Kazuaki Matsuo]
 - Chore(deps): update sphinx-rtd-theme requirement from <1.0 to <2.0
   (#637) [Kazuaki Matsuo, dependabot[bot]]
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,20 @@ Since **v2.0.0**, the base selenium client version is v4.
 The version only works in W3C WebDriver protocol format.
 If you would like to use the old protocol (MJSONWP), please use v1 Appium Python client.
 
+### Quick migration guide from v1 to v2
+- Update base Selenium Python binding version to v4
+- Removed `forceMjsonwp` since Selenium v4/this vlient v2 expect only W3C WebDriver protocol
+- Methods `ActionHelpers#scroll`, `ActionHelpers#drag_and_drop`, `ActionHelpers#tap`, `ActionHelpers#swipe` and `ActionHelpers#flick` now call W3C actions as its backend
+- Adds `strict_ssl` to relax SSL error such as self-signed ones
+- Deprecated
+    - `MultiAction` and `TouchAction` are deprecated. Please use W3C WebDriver actions.
+        - e.g.
+            - [appium/webdriver/extensions/action_helpers.py](appium/webdriver/extensions/action_helpers.py)
+            - https://www.selenium.dev/documentation/support_packages/mouse_and_keyboard_actions_in_detail/
+            - https://www.youtube.com/watch?v=oAJ7jwMNFVU
+            - https://appiumpro.com/editions/30-ios-specific-touch-action-methods
+            - https://appiumpro.com/editions/29-automating-complex-gestures-with-the-w3c-actions-api
+
 ## Getting the Appium Python client
 
 There are three ways to install and use the Appium Python client.

--- a/appium/webdriver/common/multi_action.py
+++ b/appium/webdriver/common/multi_action.py
@@ -33,6 +33,11 @@ T = TypeVar('T', bound='MultiAction')
 
 
 class MultiAction:
+    """
+    Deprecated.
+    Please use W3C actions instead: http://appium.io/docs/en/commands/interactions/actions/
+    """
+
     def __init__(self, driver: 'WebDriver', element: Optional['WebElement'] = None) -> None:
         logger.warning("[Deprecated] 'TouchAction' action is deprecated. Please use W3C actions instead.")
 

--- a/appium/webdriver/common/multi_action.py
+++ b/appium/webdriver/common/multi_action.py
@@ -21,6 +21,7 @@
 import copy
 from typing import TYPE_CHECKING, Dict, List, Optional, TypeVar, Union
 
+from appium.common.logger import logger
 from appium.webdriver.mobilecommand import MobileCommand as Command
 
 if TYPE_CHECKING:
@@ -33,6 +34,8 @@ T = TypeVar('T', bound='MultiAction')
 
 class MultiAction:
     def __init__(self, driver: 'WebDriver', element: Optional['WebElement'] = None) -> None:
+        logger.warning("[Deprecated] 'TouchAction' action is deprecated. Please use W3C actions instead.")
+
         self._driver = driver
         self._element = element
         self._touch_actions: List['TouchAction'] = []

--- a/appium/webdriver/common/touch_action.py
+++ b/appium/webdriver/common/touch_action.py
@@ -44,6 +44,7 @@ class TouchAction:
 
     def __init__(self, driver: Optional['WebDriver'] = None):
         logger.warning("[Deprecated] 'TouchAction' action is deprecated. Please use W3C actions instead.")
+
         self._driver = driver
         self._actions: List = []
 

--- a/appium/webdriver/common/touch_action.py
+++ b/appium/webdriver/common/touch_action.py
@@ -26,6 +26,7 @@
 import copy
 from typing import TYPE_CHECKING, Dict, List, Optional, TypeVar, Union
 
+from appium.common.logger import logger
 from appium.webdriver.mobilecommand import MobileCommand as Command
 
 if TYPE_CHECKING:
@@ -36,7 +37,13 @@ T = TypeVar('T', bound='TouchAction')
 
 
 class TouchAction:
+    """
+    Deprecated.
+    Please use W3C actions instead: http://appium.io/docs/en/commands/interactions/actions/
+    """
+
     def __init__(self, driver: Optional['WebDriver'] = None):
+        logger.warning("[Deprecated] 'TouchAction' action is deprecated. Please use W3C actions instead.")
         self._driver = driver
         self._actions: List = []
 

--- a/appium/webdriver/extensions/action_helpers.py
+++ b/appium/webdriver/extensions/action_helpers.py
@@ -50,14 +50,14 @@ class ActionHelpers(webdriver.Remote):
         if duration is None:
             duration = 600
 
-        # w3c action requires ms
-        duration = duration / 1000
+        # w3c action requires seconds
+        duration_sec = duration / 1000
 
         actions = ActionChains(self)
         dest_el_rect = destination_el.rect
 
         # https://github.com/SeleniumHQ/selenium/blob/3c82c868d4f2a7600223a1b3817301d0b04d28e4/py/selenium/webdriver/common/actions/pointer_actions.py#L83
-        if duration is None:
+        if duration_sec is None:
             actions.w3c_actions.pointer_action.move_to(origin_el)
             actions.w3c_actions.pointer_action.pointer_down()
             actions.w3c_actions.pointer_action.move_to_location(dest_el_rect['x'], dest_el_rect['y'])
@@ -66,7 +66,7 @@ class ActionHelpers(webdriver.Remote):
         else:
             actions.w3c_actions.pointer_action.move_to(origin_el)
             actions.w3c_actions.pointer_action.pointer_down()
-            actions.w3c_actions.pointer_action.pause(duration)
+            actions.w3c_actions.pointer_action.pause(duration_sec)
             actions.w3c_actions.pointer_action.move_to_location(dest_el_rect['x'], dest_el_rect['y'])
             actions.w3c_actions.pointer_action.release()
             actions.perform()
@@ -111,14 +111,12 @@ class ActionHelpers(webdriver.Remote):
             actions.w3c_actions.pointer_action.move_to_location(x, y)
             actions.w3c_actions.pointer_action.pointer_down()
             if duration:
-                actions.w3c_actions.pointer_action.pause(duration)
+                actions.w3c_actions.pointer_action.pause(duration / 1000)
             else:
                 actions.w3c_actions.pointer_action.pause(100)
             actions.w3c_actions.pointer_action.release()
             actions.perform()
         else:
-            ma = []
-
             finger = 0
             actions = ActionChains(self)
             actions.w3c_actions.devices = []
@@ -131,7 +129,6 @@ class ActionHelpers(webdriver.Remote):
                 # https://github.com/SeleniumHQ/selenium/blob/64447d4b03f6986337d1ca8d8b6476653570bcc1/py/selenium/webdriver/common/actions/pointer_input.py#L24
                 new_input = actions.w3c_actions.add_pointer_input('touch', f'finger{finger}')
                 new_input.create_pointer_move(x=x, y=y)
-                # TODO
                 new_input.create_pointer_down(MouseButton.LEFT)
                 if duration:
                     new_input.create_pause(duration / 1000)
@@ -161,7 +158,7 @@ class ActionHelpers(webdriver.Remote):
         actions = ActionChains(self)
         actions.w3c_actions.pointer_action.move_to_location(start_x, start_y)
         actions.w3c_actions.pointer_action.pointer_down()
-        actions.w3c_actions.pointer_action.pause(duration)
+        actions.w3c_actions.pointer_action.pause(duration / 1000)
         actions.w3c_actions.pointer_action.move_to_location(end_x, end_y)
         actions.w3c_actions.pointer_action.release()
         actions.perform()

--- a/appium/webdriver/extensions/action_helpers.py
+++ b/appium/webdriver/extensions/action_helpers.py
@@ -15,6 +15,7 @@
 from typing import TYPE_CHECKING, List, Optional, Tuple, TypeVar, Union
 
 from selenium import webdriver
+from selenium.webdriver.common.action_chains import ActionChains
 
 from appium.webdriver.common.multi_action import MultiAction
 from appium.webdriver.common.touch_action import TouchAction
@@ -48,11 +49,11 @@ class ActionHelpers(webdriver.Remote):
         if duration is None:
             duration = 600
 
-        action = TouchAction(self)
+        actions = ActionChains(self)
         if duration is None:
-            action.press(origin_el).move_to(destination_el).release().perform()
+            actions.click_and_hold(origin_el).move_to_element(destination_el).release().perform()
         else:
-            action.press(origin_el).wait(duration).move_to(destination_el).release().perform()
+            actions.click_and_hold(origin_el).pause(duration).move_to_element(destination_el).release().perform()
         return self
 
     def drag_and_drop(self: T, origin_el: WebElement, destination_el: WebElement) -> T:
@@ -65,8 +66,8 @@ class ActionHelpers(webdriver.Remote):
         Returns:
             Union['WebDriver', 'ActionHelpers']: Self instance
         """
-        action = TouchAction(self)
-        action.long_press(origin_el).move_to(destination_el).release().perform()
+        actions = ActionChains(self)
+        actions.drag_and_drop(origin_el, destination_el).perform()
         return self
 
     def tap(self: T, positions: List[Tuple[int, int]], duration: Optional[int] = None) -> T:

--- a/appium/webdriver/webdriver.py
+++ b/appium/webdriver/webdriver.py
@@ -324,7 +324,7 @@ class WebDriver(
             message = 'Direct connect capabilities from server were:\n'
             for key in [direct_protocol, direct_host, direct_port, direct_path]:
                 message += '{}: \'{}\' '.format(key, self.caps.get(key, ''))
-            logger.warning(message)
+            logger.debug(message)
             return
 
         protocol = self.caps[direct_protocol]

--- a/appium/webdriver/webdriver.py
+++ b/appium/webdriver/webdriver.py
@@ -477,21 +477,6 @@ class WebDriver(
 
         return MobileSwitchTo(self)
 
-    def perform_actions(self, multi_actions=[]) -> None:
-        """Perform multiple W3C actions
-
-        Returns:
-            None
-        """
-        enc = {'actions': []}
-        for action in multi_actions:
-            for device in action.w3c_actions.devices:
-                encoded = device.encode()
-                if encoded['actions']:
-                    enc['actions'].append(encoded)
-                    device.actions = []
-        self.execute(RemoteCommand.W3C_ACTIONS, enc)
-
     # pylint: disable=protected-access
 
     def _addCommands(self) -> None:

--- a/appium/webdriver/webdriver.py
+++ b/appium/webdriver/webdriver.py
@@ -323,7 +323,7 @@ class WebDriver(
         if not {direct_protocol, direct_host, direct_port, direct_path}.issubset(set(self.caps)):
             message = 'Direct connect capabilities from server were:\n'
             for key in [direct_protocol, direct_host, direct_port, direct_path]:
-                message += '{}: \'{}\'\n'.format(key, self.caps.get(key, ''))
+                message += '{}: \'{}\' '.format(key, self.caps.get(key, ''))
             logger.warning(message)
             return
 
@@ -476,6 +476,21 @@ class WebDriver(
         """
 
         return MobileSwitchTo(self)
+
+    def perform_actions(self, multi_actions=[]) -> None:
+        """Perform multiple W3C actions
+
+        Returns:
+            None
+        """
+        enc = {'actions': []}
+        for action in multi_actions:
+            for device in action.w3c_actions.devices:
+                encoded = device.encode()
+                if encoded['actions']:
+                    enc['actions'].append(encoded)
+                    device.actions = []
+        self.execute(RemoteCommand.W3C_ACTIONS, enc)
 
     # pylint: disable=protected-access
 


### PR DESCRIPTION
closes https://github.com/appium/python-client/issues/647

- [x] address scroll (swipe), tap, double tap
    - Do tests have them?
- [x] Convert https://github.com/appium/python-client/blob/c7d4193a26c766da66fa16ecb89fc698a781826c/appium/webdriver/extensions/action_helpers.py#L31 to W3C based actions and test them