### PR TITLE
ci: set pipenv==2021.5.29 to prevent dependencies error

### DIFF
--- a/ci-jobs/functional/run_appium.yml
+++ b/ci-jobs/functional/run_appium.yml
@@ -18,8 +18,8 @@ steps:
 - script: python setup.py install
   displayName: Install python language bindings for Appium
 - script: |
-    pip install pipenv
-    pipenv lock --pre --clear
+    pip install pipenv==2021.5.29
+    pipenv lock --clear
     pipenv install --system
   displayName: Resolve dependencies (Python)
 - script: |

--- a/ci-jobs/functional/run_appium.yml
+++ b/ci-jobs/functional/run_appium.yml
@@ -19,7 +19,7 @@ steps:
   displayName: Install python language bindings for Appium
 - script: |
     pip install pipenv
-    pipenv lock --clear
+    pipenv lock --pre --clear
     pipenv install --system
   displayName: Resolve dependencies (Python)
 - script: |

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ envlist =
 
 [testenv]
 deps =
-    pipenv
+    pipenv == 2021.5.29
 commands =
     pipenv lock --clear
     pipenv install

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,6 @@ envlist =
 deps =
     pipenv
 commands =
-    pipenv lock --clear
+    pipenv lock --pre --clear
     pipenv install
     ./ci.sh

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,6 @@ envlist =
 deps =
     pipenv
 commands =
-    pipenv lock --pre --clear
+    pipenv lock --clear
     pipenv install
     ./ci.sh


### PR DESCRIPTION
The below error started last readme update.  let me run this...

```
[ResolutionFailure]:   File "/home/vsts/work/1/s/.tox/py/lib/python3.7/site-packages/pipenv/resolver.py", line 743, in _main
[ResolutionFailure]:       resolve_packages(pre, clear, verbose, system, write, requirements_dir, packages, dev)
[ResolutionFailure]:   File "/home/vsts/work/1/s/.tox/py/lib/python3.7/site-packages/pipenv/resolver.py", line 711, in resolve_packages
[ResolutionFailure]:       requirements_dir=requirements_dir,
[ResolutionFailure]:   File "/home/vsts/work/1/s/.tox/py/lib/python3.7/site-packages/pipenv/resolver.py", line 693, in resolve
[ResolutionFailure]:       req_dir=requirements_dir
[ResolutionFailure]:   File "/home/vsts/work/1/s/.tox/py/lib/python3.7/site-packages/pipenv/utils.py", line 1377, in resolve_deps
[ResolutionFailure]:       req_dir=req_dir,
[ResolutionFailure]:   File "/home/vsts/work/1/s/.tox/py/lib/python3.7/site-packages/pipenv/utils.py", line 1098, in actually_resolve_deps
[ResolutionFailure]:       resolver.resolve()
[ResolutionFailure]:   File "/home/vsts/work/1/s/.tox/py/lib/python3.7/site-packages/pipenv/utils.py", line 876, in resolve
[ResolutionFailure]:       raise ResolutionFailure(message=str(e))
[pipenv.exceptions.ResolutionFailure]: Warning: Your dependencies could not be resolved. You likely have a mismatch in your sub-dependencies.
  You can use $ pipenv install --skip-lock to bypass this mechanism, then run $ pipenv graph to inspect the situation.
  Hint: try $ pipenv lock --pre if it is a pre-release dependency.
ERROR: Disabling PEP 517 processing is invalid: project specifies a build backend of setuptools.build_meta in pyproject.toml

ERROR: InvocationError for command /home/vsts/work/1/s/.tox/py/bin/pipenv lock --clear (exited with code 1)
___________________________________ summary ____________________________________
ERROR:   py: commands failed
```