### PR TITLE
feat: use 'touch' pointer action

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,26 @@ If you would like to use the old protocol (MJSONWP), please use v1 Appium Python
             - https://appiumpro.com/editions/29-automating-complex-gestures-with-the-w3c-actions-api
     - `launch_app`, `close_app` and `reset` are deprecated. Please read [issues#15807](https://github.com/appium/appium/issues/15807) for more details
 
+#### MultiAction/TouchAction to W3C actions
+
+On UIA2, some elements can be handled with `touch` pointer action insead of the default `mouse` pointer action in the Selenium Python cleint.
+For example, the below action builder is to replace the default one with the `touch` pointer action.
+
+```python
+from selenium.webdriver.common.actions import interaction
+from selenium.webdriver.common.actions.action_builder import ActionBuilder
+
+actions = ActionChains(driver)
+# override as 'touch' pointer action
+actions.w3c_actions = ActionBuilder(driver, mouse=PointerInput(interaction.POINTER_TOUCH, "touch"))
+actions.w3c_actions.pointer_action.move_to_location(start_x, start_y)
+actions.w3c_actions.pointer_action.pointer_down()
+actions.w3c_actions.pointer_action.pause(2)
+actions.w3c_actions.pointer_action.move_to_location(end_x, end_y)
+actions.w3c_actions.pointer_action.release()
+actions.perform()
+```
+
 ## Getting the Appium Python client
 
 There are three ways to install and use the Appium Python client.

--- a/appium/webdriver/extensions/action_helpers.py
+++ b/appium/webdriver/extensions/action_helpers.py
@@ -85,7 +85,7 @@ class ActionHelpers(webdriver.Remote):
             Union['WebDriver', 'ActionHelpers']: Self instance
         """
         actions = ActionChains(self)
-        # actions.w3c_actions = ActionBuilder(self, mouse=PointerInput(interaction.POINTER_TOUCH, "touch"))
+        # 'mouse' pointer action
         actions.w3c_actions.pointer_action.click_and_hold(origin_el)
         actions.w3c_actions.pointer_action.move_to(destination_el)
         actions.w3c_actions.pointer_action.release()
@@ -160,7 +160,6 @@ class ActionHelpers(webdriver.Remote):
             Union['WebDriver', 'ActionHelpers']: Self instance
         """
         actions = ActionChains(self)
-        # override
         actions.w3c_actions = ActionBuilder(self, mouse=PointerInput(interaction.POINTER_TOUCH, "touch"))
         actions.w3c_actions.pointer_action.move_to_location(start_x, start_y)
         actions.w3c_actions.pointer_action.pointer_down()

--- a/appium/webdriver/extensions/action_helpers.py
+++ b/appium/webdriver/extensions/action_helpers.py
@@ -85,7 +85,7 @@ class ActionHelpers(webdriver.Remote):
             Union['WebDriver', 'ActionHelpers']: Self instance
         """
         actions = ActionChains(self)
-        actions.w3c_actions = ActionBuilder(self, mouse=PointerInput(interaction.POINTER_TOUCH, "touch"))
+        # actions.w3c_actions = ActionBuilder(self, mouse=PointerInput(interaction.POINTER_TOUCH, "touch"))
         actions.w3c_actions.pointer_action.click_and_hold(origin_el)
         actions.w3c_actions.pointer_action.move_to(destination_el)
         actions.w3c_actions.pointer_action.release()

--- a/appium/webdriver/extensions/action_helpers.py
+++ b/appium/webdriver/extensions/action_helpers.py
@@ -16,10 +16,11 @@ from typing import TYPE_CHECKING, List, Optional, Tuple, TypeVar, Union
 
 from selenium import webdriver
 from selenium.webdriver.common.action_chains import ActionChains
+from selenium.webdriver.common.actions import interaction
+from selenium.webdriver.common.actions.action_builder import ActionBuilder
 from selenium.webdriver.common.actions.mouse_button import MouseButton
+from selenium.webdriver.common.actions.pointer_input import PointerInput
 
-from appium.webdriver.common.multi_action import MultiAction
-from appium.webdriver.common.touch_action import TouchAction
 from appium.webdriver.webelement import WebElement
 
 if TYPE_CHECKING:
@@ -54,6 +55,7 @@ class ActionHelpers(webdriver.Remote):
         duration_sec = duration / 1000
 
         actions = ActionChains(self)
+        actions.w3c_actions = ActionBuilder(self, mouse=PointerInput(interaction.POINTER_TOUCH, "touch"))
         dest_el_rect = destination_el.rect
 
         # https://github.com/SeleniumHQ/selenium/blob/3c82c868d4f2a7600223a1b3817301d0b04d28e4/py/selenium/webdriver/common/actions/pointer_actions.py#L83
@@ -83,6 +85,7 @@ class ActionHelpers(webdriver.Remote):
             Union['WebDriver', 'ActionHelpers']: Self instance
         """
         actions = ActionChains(self)
+        actions.w3c_actions = ActionBuilder(self, mouse=PointerInput(interaction.POINTER_TOUCH, "touch"))
         actions.w3c_actions.pointer_action.click_and_hold(origin_el)
         actions.w3c_actions.pointer_action.move_to(destination_el)
         actions.w3c_actions.pointer_action.release()
@@ -106,6 +109,7 @@ class ActionHelpers(webdriver.Remote):
         """
         if len(positions) == 1:
             actions = ActionChains(self)
+            actions.w3c_actions = ActionBuilder(self, mouse=PointerInput(interaction.POINTER_TOUCH, "touch"))
             x = positions[0][0]
             y = positions[0][1]
             actions.w3c_actions.pointer_action.move_to_location(x, y)
@@ -156,6 +160,8 @@ class ActionHelpers(webdriver.Remote):
             Union['WebDriver', 'ActionHelpers']: Self instance
         """
         actions = ActionChains(self)
+        # override
+        actions.w3c_actions = ActionBuilder(self, mouse=PointerInput(interaction.POINTER_TOUCH, "touch"))
         actions.w3c_actions.pointer_action.move_to_location(start_x, start_y)
         actions.w3c_actions.pointer_action.pointer_down()
         actions.w3c_actions.pointer_action.pause(duration / 1000)
@@ -180,6 +186,7 @@ class ActionHelpers(webdriver.Remote):
             Union['WebDriver', 'ActionHelpers']: Self instance
         """
         actions = ActionChains(self)
+        actions.w3c_actions = ActionBuilder(self, mouse=PointerInput(interaction.POINTER_TOUCH, "touch"))
         actions.w3c_actions.pointer_action.move_to_location(start_x, start_y)
         actions.w3c_actions.pointer_action.pointer_down()
         actions.w3c_actions.pointer_action.move_to_location(end_x, end_y)

--- a/appium/webdriver/extensions/search_context/android.py
+++ b/appium/webdriver/extensions/search_context/android.py
@@ -25,7 +25,7 @@ from .base_search_context import BaseSearchContext
 if TYPE_CHECKING:
     from appium.webdriver.webelement import WebElement
 
-T = TypeVar('T', bound=Union[BaseSearchContext, 'AndroidSearchContext'])
+T = TypeVar('T', bound='AndroidSearchContext')
 
 
 class AndroidSearchContext(BaseSearchContext):

--- a/appium/webdriver/webdriver.py
+++ b/appium/webdriver/webdriver.py
@@ -493,7 +493,9 @@ class WebDriver(
         # https://github.com/appium/python-client/issues/342
         for mixin_class in filter(lambda x: not issubclass(x, WebDriver), self.__class__.__mro__):
             if hasattr(mixin_class, self._addCommands.__name__):
-                getattr(mixin_class, self._addCommands.__name__, None)(self)
+                get_atter = getattr(mixin_class, self._addCommands.__name__, None)
+                if get_atter:
+                    get_atter(self)
 
         self.command_executor._commands[Command.TOUCH_ACTION] = ('POST', '/session/$sessionId/touch/perform')
         self.command_executor._commands[Command.MULTI_ACTION] = ('POST', '/session/$sessionId/touch/multi/perform')


### PR DESCRIPTION
For https://github.com/appium/python-client/issues/667#issuecomment-1000146316

By default, python clients set `mouse` mode. I guess it could be `touch`.