### PR TITLE
chore: restrict selenium client version

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -7,7 +7,7 @@ verify_ssl = true
 pre-commit = "~=2.17"
 
 [packages]
-selenium = "~=4.0"
+selenium = "~=4.0.0"
 
 black = "==22.1.0"
 

--- a/setup.py
+++ b/setup.py
@@ -48,5 +48,5 @@ setup(
         'Topic :: Software Development :: Quality Assurance',
         'Topic :: Software Development :: Testing',
     ],
-    install_requires=['selenium ~= 4.0'],
+    install_requires=['selenium ~= 4.0.0'],
 )


### PR DESCRIPTION
https://github.com/appium/appium/issues/16503
Selenium 4.1 dropped non-w3c commands, while still appium client needs them.