### PR TITLE
chore: Restore some APIs that were removed from selenium, but are still used by Appium

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -7,7 +7,7 @@ verify_ssl = true
 pre-commit = "~=2.17"
 
 [packages]
-selenium = "~=4.0.0"
+selenium = "~=4.1.0"
 
 black = "==22.1.0"
 

--- a/appium/webdriver/extensions/action_helpers.py
+++ b/appium/webdriver/extensions/action_helpers.py
@@ -129,7 +129,7 @@ class ActionHelpers:
                 # https://github.com/SeleniumHQ/selenium/blob/64447d4b03f6986337d1ca8d8b6476653570bcc1/py/selenium/webdriver/common/actions/pointer_input.py#L24
                 new_input = actions.w3c_actions.add_pointer_input('touch', f'finger{finger}')
                 new_input.create_pointer_move(x=x, y=y)
-                new_input.create_pointer_down(MouseButton.LEFT)
+                new_input.create_pointer_down(button=MouseButton.LEFT)
                 if duration:
                     new_input.create_pause(duration / 1000)
                 else:

--- a/appium/webdriver/mobilecommand.py
+++ b/appium/webdriver/mobilecommand.py
@@ -17,6 +17,7 @@ class MobileCommand:
     # Common
     GET_SESSION = 'getSession'
     GET_ALL_SESSIONS = 'getAllSessions'
+    IS_ELEMENT_DISPLAYED = 'isElementDisplayed'
 
     GET_LOCATION = 'getLocation'
     SET_LOCATION = 'setLocation'

--- a/appium/webdriver/webdriver.py
+++ b/appium/webdriver/webdriver.py
@@ -525,9 +525,7 @@ class WebDriver(
             'GET',
             '/session/$sessionId/element/$id/location_in_view',
         )
-        commands[Command.IS_ELEMENT_DISPLAYED] = (
-            'GET', '/session/$sessionId/element/$id/displayed'
-        )
+        commands[Command.IS_ELEMENT_DISPLAYED] = ('GET', '/session/$sessionId/element/$id/displayed')
 
         # override for Appium 1.x
         # Appium 2.0 and Appium 1.22 work with `/se/log` and `/se/log/types`

--- a/appium/webdriver/webdriver.py
+++ b/appium/webdriver/webdriver.py
@@ -497,21 +497,25 @@ class WebDriver(
         # https://github.com/appium/python-client/issues/342
         for mixin_class in filter(lambda x: not issubclass(x, WebDriver), self.__class__.__mro__):
             if hasattr(mixin_class, self._add_commands.__name__):
-                get_atter = getattr(mixin_class, self._add_commands.__name__, None)
-                if get_atter:
-                    get_atter(self)
+                additional_commands_setter = getattr(mixin_class, self._add_commands.__name__, None)
+                if additional_commands_setter:
+                    additional_commands_setter(self)
+
+        # Perhaps, we'd need to "restore" some more stuff below
+        # https://github.com/SeleniumHQ/selenium/commit/7a6bf7e30d8bd834b6982b1d28f002bb4b26f380
 
         # noinspection PyProtectedMember,PyUnresolvedReferences
         commands = self.command_executor._commands
 
+        # TODO: Remove these old JWP commands for good in favour if W3C actions
         commands[Command.TOUCH_ACTION] = ('POST', '/session/$sessionId/touch/perform')
         commands[Command.MULTI_ACTION] = ('POST', '/session/$sessionId/touch/multi/perform')
+
+        # Element commands
         commands[Command.SET_IMMEDIATE_VALUE] = (
             'POST',
             '/session/$sessionId/appium/element/$id/value',
         )
-
-        # TODO Move commands for element to webelement
         commands[Command.REPLACE_KEYS] = (
             'POST',
             '/session/$sessionId/appium/element/$id/replace_value',
@@ -520,6 +524,9 @@ class WebDriver(
         commands[Command.LOCATION_IN_VIEW] = (
             'GET',
             '/session/$sessionId/element/$id/location_in_view',
+        )
+        commands[Command.IS_ELEMENT_DISPLAYED] = (
+            'GET', '/session/$sessionId/element/$id/displayed'
         )
 
         # override for Appium 1.x


### PR DESCRIPTION
Related to https://github.com/appium/python-client/issues/698