### PR TITLE
ci: use npm v6 as a workaround

### DIFF
--- a/ci-jobs/functional/setup_appium.yml
+++ b/ci-jobs/functional/setup_appium.yml
@@ -3,6 +3,8 @@ steps:
   inputs:
     versionSpec: '16.x'
   displayName: Install Node 16.x
+- script: npm -g install npm@6
+  displayName: Install NPM v6 as a workaround for Appium 2.0.0.beta.41
 - script: npm install -g appium@next --chromedriver_version='2.44'
   displayName: Install appium
 - task: UsePythonVersion@0


### PR DESCRIPTION
As same as https://github.com/appium/ruby_lib_core/pull/397, until a new beta will be released to keep CI working


https://github.com/appium/python-client/runs/7590168516 is the current CI I just re-ran yesterday.