### PR TITLE
fix: Use total_seconds property of timedelta

### DIFF
--- a/appium/options/android/common/adb/adb_exec_timeout_option.py
+++ b/appium/options/android/common/adb/adb_exec_timeout_option.py
@@ -38,4 +38,6 @@ class AdbExecTimeoutOption(SupportsCapabilities):
         Maximum time to wait until single ADB command is executed.
         20000 ms by default.
         """
-        self.set_capability(ADB_EXEC_TIMEOUT, value.microseconds // 1000 if isinstance(value, timedelta) else value)
+        self.set_capability(
+            ADB_EXEC_TIMEOUT, int(value.total_seconds() * 1000) if isinstance(value, timedelta) else value
+        )

--- a/appium/options/android/common/app/android_install_timeout_option.py
+++ b/appium/options/android/common/app/android_install_timeout_option.py
@@ -39,5 +39,5 @@ class AndroidInstallTimeoutOption(SupportsCapabilities):
         90000 ms by default
         """
         self.set_capability(
-            ANDROID_INSTALL_TIMEOUT, value.microseconds // 1000 if isinstance(value, timedelta) else value
+            ANDROID_INSTALL_TIMEOUT, int(value.total_seconds() * 1000) if isinstance(value, timedelta) else value
         )

--- a/appium/options/android/common/app/app_wait_duration_option.py
+++ b/appium/options/android/common/app/app_wait_duration_option.py
@@ -38,4 +38,6 @@ class AppWaitDurationOption(SupportsCapabilities):
         Maximum amount of time to wait until the application under test is started
         (e.g. an activity returns the control to the caller). 20000 ms by default.
         """
-        self.set_capability(APP_WAIT_DURATION, value.microseconds // 1000 if isinstance(value, timedelta) else value)
+        self.set_capability(
+            APP_WAIT_DURATION, int(value.total_seconds() * 1000) if isinstance(value, timedelta) else value
+        )

--- a/appium/options/android/common/avd/avd_launch_timeout_option.py
+++ b/appium/options/android/common/avd/avd_launch_timeout_option.py
@@ -38,4 +38,6 @@ class AvdLaunchTimeoutOption(SupportsCapabilities):
         Maximum timeout to wait until Android Emulator is started.
         60000 ms by default.
         """
-        self.set_capability(AVD_LAUNCH_TIMEOUT, value.microseconds // 1000 if isinstance(value, timedelta) else value)
+        self.set_capability(
+            AVD_LAUNCH_TIMEOUT, int(value.total_seconds() * 1000) if isinstance(value, timedelta) else value
+        )

--- a/appium/options/android/common/avd/avd_ready_timeout_option.py
+++ b/appium/options/android/common/avd/avd_ready_timeout_option.py
@@ -38,4 +38,6 @@ class AvdReadyTimeoutOption(SupportsCapabilities):
         Maximum timeout to wait until Android Emulator is fully booted and is ready for usage.
         60000 ms by default
         """
-        self.set_capability(AVD_READY_TIMEOUT, value.microseconds // 1000 if isinstance(value, timedelta) else value)
+        self.set_capability(
+            AVD_READY_TIMEOUT, int(value.total_seconds() * 1000) if isinstance(value, timedelta) else value
+        )

--- a/appium/options/android/common/context/auto_webview_timeout_option.py
+++ b/appium/options/android/common/context/auto_webview_timeout_option.py
@@ -38,4 +38,6 @@ class AutoWebviewTimeoutOption(SupportsCapabilities):
         """
         Timeout to wait until a web view is available.
         """
-        self.set_capability(AUTO_WEBVIEW_TIMEOUT, value.microseconds // 1000 if isinstance(value, timedelta) else value)
+        self.set_capability(
+            AUTO_WEBVIEW_TIMEOUT, int(value.total_seconds() * 1000) if isinstance(value, timedelta) else value
+        )

--- a/appium/options/android/common/locking/unlock_success_timeout_option.py
+++ b/appium/options/android/common/locking/unlock_success_timeout_option.py
@@ -39,5 +39,5 @@ class UnlockSuccessTimeoutOption(SupportsCapabilities):
         2000 ms by default.
         """
         self.set_capability(
-            UNLOCK_SUCCESS_TIMEOUT, value.microseconds // 1000 if isinstance(value, timedelta) else value
+            UNLOCK_SUCCESS_TIMEOUT, int(value.total_seconds() * 1000) if isinstance(value, timedelta) else value
         )

--- a/appium/options/android/espresso/espresso_server_launch_timeout_option.py
+++ b/appium/options/android/espresso/espresso_server_launch_timeout_option.py
@@ -39,5 +39,5 @@ class EspressoServerLaunchTimeoutOption(SupportsCapabilities):
         45000 ms by default
         """
         self.set_capability(
-            ESPRESSO_SERVER_LAUNCH_TIMEOUT, value.microseconds // 1000 if isinstance(value, timedelta) else value
+            ESPRESSO_SERVER_LAUNCH_TIMEOUT, int(value.total_seconds() * 1000) if isinstance(value, timedelta) else value
         )

--- a/appium/options/android/uiautomator2/uiautomator2_server_install_timeout_option.py
+++ b/appium/options/android/uiautomator2/uiautomator2_server_install_timeout_option.py
@@ -39,5 +39,6 @@ class Uiautomator2ServerInstallTimeoutOption(SupportsCapabilities):
         20000 ms by default
         """
         self.set_capability(
-            UIAUTOMATOR2_SERVER_INSTALL_TIMEOUT, value.microseconds // 1000 if isinstance(value, timedelta) else value
+            UIAUTOMATOR2_SERVER_INSTALL_TIMEOUT,
+            int(value.total_seconds() * 1000) if isinstance(value, timedelta) else value,
         )

--- a/appium/options/android/uiautomator2/uiautomator2_server_launch_timeout_option.py
+++ b/appium/options/android/uiautomator2/uiautomator2_server_launch_timeout_option.py
@@ -39,5 +39,6 @@ class Uiautomator2ServerLaunchTimeoutOption(SupportsCapabilities):
         the device. 30000 ms by default
         """
         self.set_capability(
-            UIAUTOMATOR2_SERVER_LAUNCH_TIMEOUT, value.microseconds // 1000 if isinstance(value, timedelta) else value
+            UIAUTOMATOR2_SERVER_LAUNCH_TIMEOUT,
+            int(value.total_seconds() * 1000) if isinstance(value, timedelta) else value,
         )

--- a/appium/options/android/uiautomator2/uiautomator2_server_read_timeout_option.py
+++ b/appium/options/android/uiautomator2/uiautomator2_server_read_timeout_option.py
@@ -41,5 +41,6 @@ class Uiautomator2ServerReadTimeoutOption(SupportsCapabilities):
         240000 ms by default
         """
         self.set_capability(
-            UIAUTOMATOR2_SERVER_READ_TIMEOUT, value.microseconds // 1000 if isinstance(value, timedelta) else value
+            UIAUTOMATOR2_SERVER_READ_TIMEOUT,
+            int(value.total_seconds() * 1000) if isinstance(value, timedelta) else value,
         )

--- a/appium/options/common/new_command_timeout_option.py
+++ b/appium/options/common/new_command_timeout_option.py
@@ -38,4 +38,4 @@ class NewCommandTimeoutOption(SupportsCapabilities):
         Set the allowed time before seeing a new server command.
         The value could either be provided as timedelta instance or an integer number of seconds.
         """
-        self.set_capability(NEW_COMMAND_TIMEOUT, value.seconds if isinstance(value, timedelta) else value)
+        self.set_capability(NEW_COMMAND_TIMEOUT, value.total_seconds() if isinstance(value, timedelta) else value)

--- a/appium/options/ios/xcuitest/app/app_push_timeout_option.py
+++ b/appium/options/ios/xcuitest/app/app_push_timeout_option.py
@@ -39,4 +39,6 @@ class AppPushTimeoutOption(SupportsCapabilities):
         Works for real devices only.
         The default value is 30000ms.
         """
-        self.set_capability(APP_PUSH_TIMEOUT, value.microseconds // 1000 if isinstance(value, timedelta) else value)
+        self.set_capability(
+            APP_PUSH_TIMEOUT, int(value.total_seconds() * 1000) if isinstance(value, timedelta) else value
+        )

--- a/appium/options/ios/xcuitest/other/command_timeouts_option.py
+++ b/appium/options/ios/xcuitest/other/command_timeouts_option.py
@@ -50,8 +50,8 @@ class CommandTimeoutsOption(SupportsCapabilities):
         were not explicitly mentioned as dictionary keys
         """
         if isinstance(value, dict):
-            self.set_capability(COMMAND_TIMEOUTS, {k: v.microseconds // 1000 for k, v in value.items()})
+            self.set_capability(COMMAND_TIMEOUTS, {k: int(v.total_seconds() * 1000) for k, v in value.items()})
         elif isinstance(value, timedelta):
-            self.set_capability(COMMAND_TIMEOUTS, f'{value.microseconds // 1000}')
+            self.set_capability(COMMAND_TIMEOUTS, f'{int(value.total_seconds() * 1000)}')
         else:
             self.set_capability(COMMAND_TIMEOUTS, value)

--- a/appium/options/ios/xcuitest/simulator/simulator_startup_timeout_option.py
+++ b/appium/options/ios/xcuitest/simulator/simulator_startup_timeout_option.py
@@ -42,5 +42,5 @@ class SimulatorStartupTimeoutOption(SupportsCapabilities):
         during the boot up procedure.
         """
         self.set_capability(
-            SIMULATOR_STARTUP_TIMEOUT, value.microseconds // 1000 if isinstance(value, timedelta) else value
+            SIMULATOR_STARTUP_TIMEOUT, int(value.total_seconds() * 1000) if isinstance(value, timedelta) else value
         )

--- a/appium/options/ios/xcuitest/wda/wait_for_idle_timeout_option.py
+++ b/appium/options/ios/xcuitest/wda/wait_for_idle_timeout_option.py
@@ -42,4 +42,4 @@ class WaitForIdleTimeoutOption(SupportsCapabilities):
         (not recommended) and has the same effect as setting waitForQuiescence to false.
         Available since Appium 1.20.0.
         """
-        self.set_capability(WAIT_FOR_IDLE_TIMEOUT, value.seconds if isinstance(value, timedelta) else value)
+        self.set_capability(WAIT_FOR_IDLE_TIMEOUT, value.total_seconds() if isinstance(value, timedelta) else value)

--- a/appium/options/ios/xcuitest/wda/wda_connection_timeout_option.py
+++ b/appium/options/ios/xcuitest/wda/wda_connection_timeout_option.py
@@ -39,5 +39,5 @@ class WdaConnectionTimeoutOption(SupportsCapabilities):
         Defaults to 240000ms.
         """
         self.set_capability(
-            WDA_CONNECTION_TIMEOUT, value.microseconds // 1000 if isinstance(value, timedelta) else value
+            WDA_CONNECTION_TIMEOUT, int(value.total_seconds() * 1000) if isinstance(value, timedelta) else value
         )

--- a/appium/options/ios/xcuitest/wda/wda_eventloop_idle_delay_option.py
+++ b/appium/options/ios/xcuitest/wda/wda_eventloop_idle_delay_option.py
@@ -43,4 +43,4 @@ class WdaEventloopIdleDelayOption(SupportsCapabilities):
         If you enable this capability start with at least 3 seconds and try increasing it,
         if creating the session still fails. Defaults to 0.
         """
-        self.set_capability(WDA_EVENTLOOP_IDLE_DELAY, value.seconds if isinstance(value, timedelta) else value)
+        self.set_capability(WDA_EVENTLOOP_IDLE_DELAY, value.total_seconds() if isinstance(value, timedelta) else value)

--- a/appium/options/ios/xcuitest/wda/wda_launch_timeout_option.py
+++ b/appium/options/ios/xcuitest/wda/wda_launch_timeout_option.py
@@ -38,4 +38,6 @@ class WdaLaunchTimeoutOption(SupportsCapabilities):
         Timeout to wait for WebDriverAgent to be pingable,
         after its building is finished. Defaults to 60000ms.
         """
-        self.set_capability(WDA_LAUNCH_TIMEOUT, value.microseconds // 1000 if isinstance(value, timedelta) else value)
+        self.set_capability(
+            WDA_LAUNCH_TIMEOUT, int(value.total_seconds() * 1000) if isinstance(value, timedelta) else value
+        )

--- a/appium/options/ios/xcuitest/wda/wda_startup_retry_interval_option.py
+++ b/appium/options/ios/xcuitest/wda/wda_startup_retry_interval_option.py
@@ -39,5 +39,5 @@ class WdaStartupRetryIntervalOption(SupportsCapabilities):
         Defaults to 10000ms.
         """
         self.set_capability(
-            WDA_STARTUP_RETRY_INTERVAL, value.microseconds // 1000 if isinstance(value, timedelta) else value
+            WDA_STARTUP_RETRY_INTERVAL, int(value.total_seconds() * 1000) if isinstance(value, timedelta) else value
         )

--- a/appium/options/ios/xcuitest/webview/webkit_response_timeout_option.py
+++ b/appium/options/ios/xcuitest/webview/webkit_response_timeout_option.py
@@ -39,5 +39,5 @@ class WebkitResponseTimeoutOption(SupportsCapabilities):
         WebKit in a Safari session. Defaults to 5000ms.
         """
         self.set_capability(
-            WEBKIT_RESPONSE_TIMEOUT, value.microseconds // 1000 if isinstance(value, timedelta) else value
+            WEBKIT_RESPONSE_TIMEOUT, int(value.total_seconds() * 1000) if isinstance(value, timedelta) else value
         )

--- a/appium/options/ios/xcuitest/webview/webview_connect_timeout_option.py
+++ b/appium/options/ios/xcuitest/webview/webview_connect_timeout_option.py
@@ -39,5 +39,5 @@ class WebviewConnectTimeoutOption(SupportsCapabilities):
         MobileSafari or hybrid apps. Defaults to 0ms.
         """
         self.set_capability(
-            WEBVIEW_CONNECT_TIMEOUT, value.microseconds // 1000 if isinstance(value, timedelta) else value
+            WEBVIEW_CONNECT_TIMEOUT, int(value.total_seconds() * 1000) if isinstance(value, timedelta) else value
         )

--- a/appium/options/mac/mac2/server_startup_timeout_option.py
+++ b/appium/options/mac/mac2/server_startup_timeout_option.py
@@ -40,5 +40,5 @@ class ServerStartupTimeoutOption(SupportsCapabilities):
         project is built and started.
         """
         self.set_capability(
-            SERVER_STARTUP_TIMEOUT, value.microseconds // 1000 if isinstance(value, timedelta) else value
+            SERVER_STARTUP_TIMEOUT, int(value.total_seconds() * 1000) if isinstance(value, timedelta) else value
         )

--- a/appium/options/windows/windows/create_session_timeout_option.py
+++ b/appium/options/windows/windows/create_session_timeout_option.py
@@ -41,5 +41,5 @@ class CreateSessionTimeoutOption(SupportsCapabilities):
         with appId: TestCompany.my_app4!App, and processId: 8480).
         """
         self.set_capability(
-            CREATE_SESSION_TIMEOUT, value.microseconds // 1000 if isinstance(value, timedelta) else value
+            CREATE_SESSION_TIMEOUT, int(value.total_seconds() * 1000) if isinstance(value, timedelta) else value
         )

--- a/appium/options/windows/windows/wait_for_app_launch_option.py
+++ b/appium/options/windows/windows/wait_for_app_launch_option.py
@@ -40,4 +40,4 @@ class WaitForAppLaunchOption(SupportsCapabilities):
         a defined amount of time after an app launch is initiated prior to
         attaching to the application session. The limit for this is 50 seconds.
         """
-        self.set_capability(WAIT_FOR_APP_LAUNCH, value.seconds if isinstance(value, timedelta) else value)
+        self.set_capability(WAIT_FOR_APP_LAUNCH, value.total_seconds() if isinstance(value, timedelta) else value)


### PR DESCRIPTION
It turns out timedelta class normalises its seconds, microseconds and days properties as mentioned in https://docs.python.org/3/library/datetime.html#datetime.timedelta

Thus we need to use the total_seconds() property in order to avoid unexpected normalization side effects in case longer deltas are provided