### PR TITLE
chore: allow selenium client v4.5

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -19,4 +19,4 @@ typing-extensions = "~=4.3"
 types-python-dateutil = "~=2.8"
 
 [packages]
-selenium = "~=4.4"
+selenium = ">=4.4,<4.6"


### PR DESCRIPTION
https://github.com/appium/python-client/pull/780 tests seems good except for the test host machine's flakiness