### PR TITLE
fix: set_value and set_text sent incorrect data

### DIFF
--- a/appium/webdriver/webdriver.py
+++ b/appium/webdriver/webdriver.py
@@ -14,6 +14,7 @@
 
 # pylint: disable=too-many-lines,too-many-public-methods,too-many-statements,no-self-use
 
+import warnings
 from typing import Any, Callable, Dict, List, Optional, Tuple, TypeVar, Union
 
 from selenium import webdriver
@@ -434,6 +435,7 @@ class WebDriver(
 
     def set_value(self: T, element: MobileWebElement, value: str) -> T:
         """Set the value on an element in the application.
+        deprecated:: 2.8.1
 
         Args:
             element: the element whose value will be set
@@ -442,10 +444,14 @@ class WebDriver(
         Returns:
             `appium.webdriver.webdriver.WebDriver`: Self instance
         """
-        data = {
-            'id': element.id,
-            'value': [value],
-        }
+        warnings.warn(
+            'The "setValue" API is deprecated and will be removed in future versions. '
+            'Instead the "send_keys" API or W3C Actions can be used. '
+            'See https://github.com/appium/python-client/pull/831',
+            DeprecationWarning,
+        )
+
+        data = {'text': value}
         self.execute(Command.SET_IMMEDIATE_VALUE, data)
         return self
 

--- a/appium/webdriver/webelement.py
+++ b/appium/webdriver/webelement.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import warnings
 from typing import Callable, Dict, List, Optional, Union
 
 from selenium.webdriver.common.utils import keys_to_typing
@@ -157,6 +158,7 @@ class WebElement(SeleniumWebElement):
 
     def set_text(self, keys: str = '') -> 'WebElement':
         """Sends text to the element.
+        deprecated:: 2.8.1
 
         Previous text is removed.
         Android only.
@@ -170,7 +172,14 @@ class WebElement(SeleniumWebElement):
         Returns:
             `appium.webdriver.webelement.WebElement`
         """
-        data = {'id': self._id, 'value': [keys]}
+        warnings.warn(
+            'The "setText" API is deprecated and will be removed in future versions. '
+            'Instead the "send_keys" API or W3C Actions can be used. '
+            'See https://github.com/appium/python-client/pull/831',
+            DeprecationWarning,
+        )
+
+        data = {'text': keys}
         self._execute(Command.REPLACE_KEYS, data)
         return self
 
@@ -190,6 +199,7 @@ class WebElement(SeleniumWebElement):
 
     def set_value(self, value: str) -> 'WebElement':
         """Set the value on this element in the application
+        deprecated:: 2.8.1
 
         Args:
             value: The value to be set
@@ -197,10 +207,14 @@ class WebElement(SeleniumWebElement):
         Returns:
             `appium.webdriver.webelement.WebElement`
         """
-        data = {
-            'id': self.id,
-            'value': [value],
-        }
+        warnings.warn(
+            'The "setValue" API is deprecated and will be removed in future versions. '
+            'Instead the "send_keys" API or W3C Actions can be used. '
+            'See https://github.com/appium/python-client/pull/831',
+            DeprecationWarning,
+        )
+
+        data = {'text': value}
         self._execute(Command.SET_IMMEDIATE_VALUE, data)
         return self
 

--- a/test/unit/webdriver/webelement_test.py
+++ b/test/unit/webdriver/webelement_test.py
@@ -46,7 +46,7 @@ class TestWebElement(object):
         element.set_value(value)
 
         d = get_httpretty_request_body(httpretty.last_request())
-        assert d['value'] == [value]
+        assert d['text'] == value
 
     @httpretty.activate
     def test_send_key(self):


### PR DESCRIPTION
`set_text` and `set_value` would not work, without these changes, on the latest beta56 of Appium.

These are the values that Appium corrected me with, that I have replaced in the code.

Is there any place where one would validate the parameters that should be sent? Either some documentation, or a reference library?

EDIT: is this the reference to use? https://w3c.github.io/webdriver/#element-send-keys