### PR TITLE
feat: respect the given executor

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,9 +209,12 @@ from appium.options.ios import XCUITestOptions
 import urllib3
 from appium.webdriver.appium_connection import AppiumConnection
 
-appium_executor = AppiumConnection(remote_server_addr='http://127.0.0.1:4723')
 # Retry connection error up to 3 times.
-appium_executor.set_init_args_for_pool_manager(retries=urllib3.util.retry.Retry(total=3, connect=3, read=False))
+init_args_for_pool_manage = {
+    'retries': urllib3.util.retry.Retry(total=3, connect=3, read=False)
+}
+appium_executor = AppiumConnection(remote_server_addr='http://127.0.0.1:4723',
+    init_args_for_pool_manage=init_args_for_pool_manage)
 
 options = XCUITestOptions().load_capabilities({
     'platformVersion': '13.4',

--- a/README.md
+++ b/README.md
@@ -216,11 +216,10 @@ init_args_for_pool_manage = {
 appium_executor = AppiumConnection(remote_server_addr='http://127.0.0.1:4723',
     init_args_for_pool_manage=init_args_for_pool_manage)
 
-options = XCUITestOptions().load_capabilities({
-    'platformVersion': '13.4',
-    'deviceName': 'iPhone Simulator',
-    'app': PATH('../../apps/UICatalog.app.zip'),
-})
+options = XCUITestOptions()
+options.platformVersion = '13.4'
+options.udid = '123456789ABC'
+options.app = PATH('../../apps/UICatalog.app.zip')
 driver = webdriver.Remote(appium_executor, options=options)
 ```
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ options = UiAutomator2Options()
 options.platformVersion = '10'
 options.udid = '123456789ABC'
 options.app = PATH('../../../apps/test-app.apk')
-# Appium1 points to http://127.0.0.1:4723/wd/hub by default 
+# Appium1 points to http://127.0.0.1:4723/wd/hub by default
 self.driver = webdriver.Remote('http://127.0.0.1:4723', options=options)
 el = self.driver.find_element(by=AppiumBy.ACCESSIBILITY_ID, value='item')
 el.click()
@@ -134,7 +134,7 @@ options = XCUITestOptions()
 options.platformVersion = '13.4'
 options.udid = '123456789ABC'
 options.app = PATH('../../apps/UICatalog.app.zip')
-# Appium1 points to http://127.0.0.1:4723/wd/hub by default 
+# Appium1 points to http://127.0.0.1:4723/wd/hub by default
 self.driver = webdriver.Remote('http://127.0.0.1:4723', options=options)
 el = self.driver.find_element(by=AppiumBy.ACCESSIBILITY_ID, value='item')
 el.click()
@@ -158,7 +158,7 @@ from appium import webdriver
 # instead: https://github.com/appium/python-client/pull/720
 from appium.options.ios import XCUITestOptions
 
-# load_capabilities API could be used to 
+# load_capabilities API could be used to
 # load options mapping stored in a dictionary
 options = XCUITestOptions().load_capabilities({
     'platformVersion': '13.4',
@@ -167,9 +167,9 @@ options = XCUITestOptions().load_capabilities({
 })
 
 self.driver = webdriver.Remote(
-    # Appium1 points to http://127.0.0.1:4723/wd/hub by default 
-    'http://127.0.0.1:4723', 
-    options=options, 
+    # Appium1 points to http://127.0.0.1:4723/wd/hub by default
+    'http://127.0.0.1:4723',
+    options=options,
     direct_connection=True
 )
 ```
@@ -192,9 +192,59 @@ options.automation_name = 'safari'
 # calls to it could be chained
 options.set_capability('browser_name', 'safari')
 
-# Appium1 points to http://127.0.0.1:4723/wd/hub by default 
+# Appium1 points to http://127.0.0.1:4723/wd/hub by default
 self.driver = webdriver.Remote('http://127.0.0.1:4723', options=options, strict_ssl=False)
 ```
+
+## Set custom `AppiumConnection`
+
+The first argument of `webdriver.Remote` can set an arbitrary command executor.
+
+1. Set init arguments for the pool manager Appium Python client uses to manage http requests.
+
+```python
+from appium import webdriver
+from appium.options.ios import XCUITestOptions
+
+import urllib3
+from appium.webdriver.appium_connection import AppiumConnection
+
+appium_executor = AppiumConnection(remote_server_addr='http://127.0.0.1:4723')
+# Retry connection error up to 3 times.
+appium_executor.set_init_args_for_pool_manager(retries=urllib3.util.retry.Retry(total=3, connect=3, read=False))
+
+options = XCUITestOptions().load_capabilities({
+    'platformVersion': '13.4',
+    'deviceName': 'iPhone Simulator',
+    'app': PATH('../../apps/UICatalog.app.zip'),
+})
+driver = webdriver.Remote(appium_executor, options=options)
+```
+
+
+2. Define a subclass of `AppiumConnection`
+
+```python
+from appium import webdriver
+from appium.options.ios import XCUITestOptions
+
+from appium.webdriver.appium_connection import AppiumConnection
+
+class CustomAppiumConnection(AppiumConnection):
+    # Can add your own methods for the custom class
+    pass
+
+custom_executor = CustomAppiumConnection(remote_server_addr='http://127.0.0.1:4723')
+
+options = XCUITestOptions().load_capabilities({
+    'platformVersion': '13.4',
+    'deviceName': 'iPhone Simulator',
+    'app': PATH('../../apps/UICatalog.app.zip'),
+})
+driver = webdriver.Remote(custom_executor, options=options)
+
+```
+
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ self.driver = webdriver.Remote('http://127.0.0.1:4723', options=options, strict_
 
 ## Set custom `AppiumConnection`
 
-The first argument of `webdriver.Remote` can set an arbitrary command executor.
+The first argument of `webdriver.Remote` can set an arbitrary command executor for you.
 
 1. Set init arguments for the pool manager Appium Python client uses to manage http requests.
 

--- a/appium/webdriver/appium_connection.py
+++ b/appium/webdriver/appium_connection.py
@@ -26,37 +26,38 @@ if TYPE_CHECKING:
 
 class AppiumConnection(RemoteConnection):
     def __init__(
-        self, remote_server_addr: Union[str, bytes], keep_alive: bool = False, ignore_proxy: Optional[bool] = False
+        self,
+        remote_server_addr: str,
+        keep_alive: bool = False,
+        ignore_proxy: Optional[bool] = False,
+        init_args_for_pool_manager: Union[Dict[str, Any], None] = None,
     ):
-        self._pool_manager_init_args: Dict[str, Any] = {}
+
+        # Need to call before super().__init__ in order to pass arguments for the pool manager in the super.
+        if init_args_for_pool_manager is None:
+            self._init_args_for_pool_manager = {}
+        else:
+            self._init_args_for_pool_manager = init_args_for_pool_manager
 
         super().__init__(remote_server_addr, keep_alive=keep_alive, ignore_proxy=ignore_proxy)
 
-    def set_init_args_for_pool_manager(self, **kwargs: Dict[str, Any]) -> None:
-        """Set keyword arguments for the pool manager.
-
-        Appium Python client manages http requests with urllib3.PoolManager or urllib3.ProxyManager.
-        This method allows to set keyword arguments for the pool manager.
-
-        For example, "urllib3.util.retry.Retry" provides flexible retry strategy for http requests.
-        """
-        self._pool_manager_init_args = {'timeout': self._timeout}
-        # pylint: disable=E1101
-        if self._ca_certs:
-            self._pool_manager_init_args['cert_reqs'] = 'CERT_REQUIRED'
-            self._pool_manager_init_args['ca_certs'] = self._ca_certs
-        else:
-            # This line is necessary to disable certificate verification
-            self._pool_manager_init_args['cert_reqs'] = 'CERT_NONE'
-
-        self._pool_manager_init_args.update(**kwargs)
-
     def _get_connection_manager(self) -> Union[urllib3.PoolManager, urllib3.ProxyManager]:
         # https://github.com/SeleniumHQ/selenium/blob/0e0194b0e52a34e7df4b841f1ed74506beea5c3e/py/selenium/webdriver/remote/remote_connection.py#L134
+        pool_manager_init_args = {'timeout': self._timeout}
+
+        if self._ca_certs:
+            pool_manager_init_args['cert_reqs'] = 'CERT_REQUIRED'
+            pool_manager_init_args['ca_certs'] = self._ca_certs
+        else:
+            # This line is necessary to disable certificate verification
+            pool_manager_init_args['cert_reqs'] = 'CERT_NONE'
+
+        pool_manager_init_args.update(self._init_args_for_pool_manager)
+
         return (
-            urllib3.PoolManager(**self._pool_manager_init_args)
+            urllib3.PoolManager(**pool_manager_init_args)
             if self._proxy_url is None
-            else urllib3.ProxyManager(self._proxy_url, **self._pool_manager_init_args)
+            else urllib3.ProxyManager(self._proxy_url, **pool_manager_init_args)
         )
 
     @classmethod

--- a/appium/webdriver/appium_connection.py
+++ b/appium/webdriver/appium_connection.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import uuid
-from typing import TYPE_CHECKING, Any, Dict, Union, Optional
+from typing import TYPE_CHECKING, Any, Dict, Optional, Union
 
 import urllib3
 from selenium.webdriver.remote.remote_connection import RemoteConnection

--- a/appium/webdriver/appium_connection.py
+++ b/appium/webdriver/appium_connection.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import uuid
-from typing import TYPE_CHECKING, Any, Dict, Union
+from typing import TYPE_CHECKING, Any, Dict, Union, Optional
 
 import urllib3
 from selenium.webdriver.remote.remote_connection import RemoteConnection
@@ -25,21 +25,29 @@ if TYPE_CHECKING:
 
 
 class AppiumConnection(RemoteConnection):
-    def _get_connection_manager(self) -> Union[urllib3.PoolManager, urllib3.ProxyManager]:
-        # https://github.com/SeleniumHQ/selenium/blob/0e0194b0e52a34e7df4b841f1ed74506beea5c3e/py/selenium/webdriver/remote/remote_connection.py#L134
-        pool_manager_init_args = {'timeout': self._timeout}
+    def __init__(self, remote_server_addr, keep_alive=False, ignore_proxy: Optional[bool] = False):
+        super().__init__(remote_server_addr, keep_alive=keep_alive, ignore_proxy=ignore_proxy)
+        self._pool_manager_init_args = {}
+
+    def set_init_args_for_pool_manager(self, **kwargs):
+        """Set keyword arguments for the pool manager"""
+        self._pool_manager_init_args = {'timeout': self._timeout}
         # pylint: disable=E1101
         if self._ca_certs:
-            pool_manager_init_args['cert_reqs'] = 'CERT_REQUIRED'
-            pool_manager_init_args['ca_certs'] = self._ca_certs
+            self._pool_manager_init_args['cert_reqs'] = 'CERT_REQUIRED'
+            self._pool_manager_init_args['ca_certs'] = self._ca_certs
         else:
             # This line is necessary to disable certificate verification
-            pool_manager_init_args['cert_reqs'] = 'CERT_NONE'
+            self._pool_manager_init_args['cert_reqs'] = 'CERT_NONE'
 
+        self._pool_manager_init_args.update(**kwargs)
+
+    def _get_connection_manager(self) -> Union[urllib3.PoolManager, urllib3.ProxyManager]:
+        # https://github.com/SeleniumHQ/selenium/blob/0e0194b0e52a34e7df4b841f1ed74506beea5c3e/py/selenium/webdriver/remote/remote_connection.py#L134
         return (
-            urllib3.PoolManager(**pool_manager_init_args)
+            urllib3.PoolManager(**self._pool_manager_init_args)
             if self._proxy_url is None
-            else urllib3.ProxyManager(self._proxy_url, **pool_manager_init_args)
+            else urllib3.ProxyManager(self._proxy_url, **self._pool_manager_init_args)
         )
 
     @classmethod

--- a/appium/webdriver/appium_connection.py
+++ b/appium/webdriver/appium_connection.py
@@ -34,10 +34,7 @@ class AppiumConnection(RemoteConnection):
     ):
 
         # Need to call before super().__init__ in order to pass arguments for the pool manager in the super.
-        if init_args_for_pool_manager is None:
-            self._init_args_for_pool_manager = {}
-        else:
-            self._init_args_for_pool_manager = init_args_for_pool_manager
+        self._init_args_for_pool_manager = init_args_for_pool_manager or {}
 
         super().__init__(remote_server_addr, keep_alive=keep_alive, ignore_proxy=ignore_proxy)
 

--- a/appium/webdriver/appium_connection.py
+++ b/appium/webdriver/appium_connection.py
@@ -26,11 +26,18 @@ if TYPE_CHECKING:
 
 class AppiumConnection(RemoteConnection):
     def __init__(self, remote_server_addr, keep_alive=False, ignore_proxy: Optional[bool] = False):
-        super().__init__(remote_server_addr, keep_alive=keep_alive, ignore_proxy=ignore_proxy)
         self._pool_manager_init_args = {}
 
+        super().__init__(remote_server_addr, keep_alive=keep_alive, ignore_proxy=ignore_proxy)
+
     def set_init_args_for_pool_manager(self, **kwargs):
-        """Set keyword arguments for the pool manager"""
+        """Set keyword arguments for the pool manager.
+
+        Appium Python client manages http requests with urllib3.PoolManager or urllib3.ProxyManager.
+        This method allows to set keyword arguments for the pool manager.
+
+        For example, "urllib3.util.retry.Retry" provides flexible retry strategy for http requests.
+        """
         self._pool_manager_init_args = {'timeout': self._timeout}
         # pylint: disable=E1101
         if self._ca_certs:

--- a/appium/webdriver/appium_connection.py
+++ b/appium/webdriver/appium_connection.py
@@ -25,12 +25,14 @@ if TYPE_CHECKING:
 
 
 class AppiumConnection(RemoteConnection):
-    def __init__(self, remote_server_addr, keep_alive=False, ignore_proxy: Optional[bool] = False):
-        self._pool_manager_init_args = {}
+    def __init__(
+        self, remote_server_addr: Union[str, bytes], keep_alive: bool = False, ignore_proxy: Optional[bool] = False
+    ):
+        self._pool_manager_init_args: Dict[str, Any] = {}
 
         super().__init__(remote_server_addr, keep_alive=keep_alive, ignore_proxy=ignore_proxy)
 
-    def set_init_args_for_pool_manager(self, **kwargs):
+    def set_init_args_for_pool_manager(self, **kwargs: Dict[str, Any]) -> None:
         """Set keyword arguments for the pool manager.
 
         Appium Python client manages http requests with urllib3.PoolManager or urllib3.ProxyManager.

--- a/appium/webdriver/webdriver.py
+++ b/appium/webdriver/webdriver.py
@@ -228,7 +228,7 @@ class WebDriver(
             AppiumConnection.set_certificate_bundle_path(None)
             urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
-        if isinstance(command_executor, (str, bytes)):
+        if isinstance(command_executor, str):
             command_executor = AppiumConnection(command_executor, keep_alive=keep_alive)
 
         super().__init__(

--- a/appium/webdriver/webdriver.py
+++ b/appium/webdriver/webdriver.py
@@ -228,7 +228,7 @@ class WebDriver(
             AppiumConnection.set_certificate_bundle_path(None)
             urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
-        if isinstance(self.command_executor, (str, bytes)):
+        if isinstance(command_executor, (str, bytes)):
             command_executor = AppiumConnection(command_executor, keep_alive=keep_alive)
 
         super().__init__(

--- a/appium/webdriver/webdriver.py
+++ b/appium/webdriver/webdriver.py
@@ -204,7 +204,7 @@ class WebDriver(
 ):
     def __init__(
         self,
-        command_executor: str = 'http://127.0.0.1:4444/wd/hub',
+        command_executor: Union[str, AppiumConnection] = 'http://127.0.0.1:4444/wd/hub',
         desired_capabilities: Optional[Dict] = None,
         browser_profile: Union[str, None] = None,
         proxy: Union[str, None] = None,
@@ -228,8 +228,11 @@ class WebDriver(
             AppiumConnection.set_certificate_bundle_path(None)
             urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
+        if isinstance(self.command_executor, (str, bytes)):
+            command_executor = AppiumConnection(command_executor, keep_alive=keep_alive)
+
         super().__init__(
-            command_executor=AppiumConnection(command_executor, keep_alive=keep_alive),
+            command_executor=command_executor,
             desired_capabilities=desired_capabilities,
             browser_profile=browser_profile,
             proxy=proxy,

--- a/test/unit/webdriver/webdriver_test.py
+++ b/test/unit/webdriver/webdriver_test.py
@@ -15,12 +15,13 @@
 import json
 
 import httpretty
-from mock import patch
 import urllib3
+from mock import patch
 
 from appium import version as appium_version
 from appium import webdriver
 from appium.options.android import UiAutomator2Options
+from appium.webdriver.appium_connection import AppiumConnection
 from appium.webdriver.webdriver import ExtensionBase, WebDriver
 from test.helpers.constants import SERVER_URL_BASE
 from test.unit.helper.test_helper import (
@@ -30,7 +31,6 @@ from test.unit.helper.test_helper import (
     ios_w3c_driver,
     ios_w3c_driver_with_extensions,
 )
-from appium.webdriver.appium_connection import AppiumConnection
 
 
 class TestWebDriverWebDriver(object):

--- a/test/unit/webdriver/webdriver_test.py
+++ b/test/unit/webdriver/webdriver_test.py
@@ -343,6 +343,52 @@ class TestWebDriverWebDriver(object):
 
         assert isinstance(driver.command_executor, CustomAppiumConnection)
 
+    @httpretty.activate
+    def test_create_session_with_custom_connection_with_keepalive(self):
+        httpretty.register_uri(
+            httpretty.POST,
+            f'{SERVER_URL_BASE}/session',
+            body='{ "value": {"sessionId": "session-id", "capabilities": {"deviceName": "Android Emulator"}} }',
+        )
+
+        desired_caps = {
+            'deviceName': 'Android Emulator',
+            'app': 'path/to/app',
+        }
+
+        class CustomAppiumConnection(AppiumConnection):
+            # To explicitly check if the given executor is used
+            pass
+
+        init_args_for_pool_manager = {'retries': urllib3.util.retry.Retry(total=3, connect=3, read=False)}
+        custom_appium_connection = CustomAppiumConnection(
+            # keep alive has different route to set init args for the pool manager
+            keep_alive=True,
+            remote_server_addr=SERVER_URL_BASE,
+            init_args_for_pool_manager=init_args_for_pool_manager,
+        )
+
+        driver = webdriver.Remote(
+            custom_appium_connection, options=UiAutomator2Options().load_capabilities(desired_caps)
+        )
+
+        request = httpretty.HTTPretty.latest_requests[0]
+        assert request.headers['content-type'] == 'application/json;charset=UTF-8'
+        assert 'appium/python {} (selenium'.format(appium_version.version) in request.headers['user-agent']
+
+        request_json = json.loads(httpretty.HTTPretty.latest_requests[0].body.decode('utf-8'))
+        assert request_json.get('capabilities') is not None
+        assert request_json['capabilities']['alwaysMatch'] == {
+            'platformName': 'Android',
+            'appium:deviceName': 'Android Emulator',
+            'appium:app': 'path/to/app',
+            'appium:automationName': 'UIAutomator2',
+        }
+        assert request_json.get('desiredCapabilities') is None
+        assert driver.session_id == 'session-id'
+
+        assert isinstance(driver.command_executor, CustomAppiumConnection)
+
 
 class SubWebDriver(WebDriver):
     def __init__(self, command_executor, desired_capabilities=None, direct_connection=False, options=None):

--- a/test/unit/webdriver/webdriver_test.py
+++ b/test/unit/webdriver/webdriver_test.py
@@ -317,9 +317,9 @@ class TestWebDriverWebDriver(object):
             # To explicitly check if the given executor is used
             pass
 
-        custom_appium_connection = CustomAppiumConnection(remote_server_addr=SERVER_URL_BASE)
-        custom_appium_connection.set_init_args_for_pool_manager(
-            retries=urllib3.util.retry.Retry(total=3, connect=3, read=False)
+        init_args_for_pool_manager = {'retries': urllib3.util.retry.Retry(total=3, connect=3, read=False)}
+        custom_appium_connection = CustomAppiumConnection(
+            remote_server_addr=SERVER_URL_BASE, init_args_for_pool_manager=init_args_for_pool_manager
         )
 
         driver = webdriver.Remote(

--- a/test/unit/webdriver/webdriver_test.py
+++ b/test/unit/webdriver/webdriver_test.py
@@ -314,6 +314,7 @@ class TestWebDriverWebDriver(object):
         }
 
         class CustomAppiumConnection(AppiumConnection):
+            # To explicitly check if the given executor is used
             pass
 
         custom_appium_connection = CustomAppiumConnection(remote_server_addr=SERVER_URL_BASE)

--- a/test/unit/webdriver/webdriver_test.py
+++ b/test/unit/webdriver/webdriver_test.py
@@ -318,18 +318,13 @@ class TestWebDriverWebDriver(object):
             pass
 
         custom_appium_connection = CustomAppiumConnection(remote_server_addr=SERVER_URL_BASE)
-        custom_appium_connection.set_init_args_for_pool_manager(proxies=urllib3.util.retry.Retry(total=3, connect=3, read=False))
+        custom_appium_connection.set_init_args_for_pool_manager(retries=urllib3.util.retry.Retry(total=3, connect=3, read=False))
 
         driver = webdriver.Remote(custom_appium_connection, options=UiAutomator2Options().load_capabilities(desired_caps))
-
-        # This tests counts the same request twice on Azure only for now (around 20th May, 2021). Local running works.
-        # Should investigate the cause.
-        # assert len(httpretty.HTTPretty.latest_requests) == 1
 
         request = httpretty.HTTPretty.latest_requests[0]
         assert request.headers['content-type'] == 'application/json;charset=UTF-8'
         assert 'appium/python {} (selenium'.format(appium_version.version) in request.headers['user-agent']
-
 
         request_json = json.loads(httpretty.HTTPretty.latest_requests[0].body.decode('utf-8'))
         assert request_json.get('capabilities') is not None
@@ -340,10 +335,9 @@ class TestWebDriverWebDriver(object):
             'appium:automationName': 'UIAutomator2',
         }
         assert request_json.get('desiredCapabilities') is None
-
         assert driver.session_id == 'session-id'
 
-        assert type(driver.command_executor) == CustomAppiumConnection
+        assert isinstance(driver.command_executor, CustomAppiumConnection)
 
 
 class SubWebDriver(WebDriver):

--- a/test/unit/webdriver/webdriver_test.py
+++ b/test/unit/webdriver/webdriver_test.py
@@ -300,7 +300,6 @@ class TestWebDriverWebDriver(object):
         assert result == {}
         driver.delete_extensions()
 
-
     @httpretty.activate
     def test_create_session_with_custom_connection(self):
         httpretty.register_uri(
@@ -318,9 +317,13 @@ class TestWebDriverWebDriver(object):
             pass
 
         custom_appium_connection = CustomAppiumConnection(remote_server_addr=SERVER_URL_BASE)
-        custom_appium_connection.set_init_args_for_pool_manager(retries=urllib3.util.retry.Retry(total=3, connect=3, read=False))
+        custom_appium_connection.set_init_args_for_pool_manager(
+            retries=urllib3.util.retry.Retry(total=3, connect=3, read=False)
+        )
 
-        driver = webdriver.Remote(custom_appium_connection, options=UiAutomator2Options().load_capabilities(desired_caps))
+        driver = webdriver.Remote(
+            custom_appium_connection, options=UiAutomator2Options().load_capabilities(desired_caps)
+        )
 
         request = httpretty.HTTPretty.latest_requests[0]
         assert request.headers['content-type'] == 'application/json;charset=UTF-8'


### PR DESCRIPTION
Got a request to use the given executor if the first argument was the instance as same as Selenium does.

Example usage is in the README.