### PR TITLE
docs: address version management recommendation in the readme

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}

--- a/README.md
+++ b/README.md
@@ -84,6 +84,13 @@ download and unarchive the source tarball (Appium-Python-Client-X.X.tar.gz).
     python setup.py install
     ```
 
+> **Note**
+> The Appium Python Client depends on [Selenium Python binding](https://pypi.org/project/selenium/), thus
+> the Selenium Python binding update might affect the Appium Python Client.
+> For exampple, some changes in the Selenium binding could break the Appium client.
+> To reduce such unexpected behavior, we strongly recommend you to manage dependencies
+> with version management tool such as Pipenv and Pipfile.
+
 ## Usage
 
 The Appium Python Client is fully compliant with the WebDriver Protocol

--- a/README.md
+++ b/README.md
@@ -84,12 +84,22 @@ download and unarchive the source tarball (Appium-Python-Client-X.X.tar.gz).
     python setup.py install
     ```
 
+## Compatibility Matrix
+
+|Appium Python Client| Selenium binding|
+|----|----|
+|`2.10.0`+ |`4.1.0`+ |
+|`2.2.0` - `2.9.0` |`4.1.0` - `4.9.0` |
+|`2.0.0` - `2.1.4` |`4.0.0` |
+|`1.1.0` and below|`3.x`|
+
+The Appium Python Client depends on [Selenium Python binding](https://pypi.org/project/selenium/), thus
+the Selenium Python binding update might affect the Appium Python Client behavior.
+For exampple, some changes in the Selenium binding could break the Appium client.
+
 > **Note**
-> The Appium Python Client depends on [Selenium Python binding](https://pypi.org/project/selenium/), thus
-> the Selenium Python binding update might affect the Appium Python Client.
-> For exampple, some changes in the Selenium binding could break the Appium client.
-> To reduce such unexpected behavior, we strongly recommend you to manage dependencies
-> with version management tools such as Pipenv and requirements.txt.
+> We strongly recommend you to manage dependencies with version management tools such as Pipenv and requirements.txt
+> to keep compatible version combinations.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -103,41 +103,102 @@ As a base for the following code examples, the following sets up the [UnitTest](
 environment:
 
 ```python
-# Android environment
+# Python/Pytest
+import pytest
+
 from appium import webdriver
 # Options are only available since client version 2.3.0
 # If you use an older client then switch to desired_capabilities
 # instead: https://github.com/appium/python-client/pull/720
 from appium.options.android import UiAutomator2Options
-from appium.webdriver.common.appiumby import AppiumBy
-
-options = UiAutomator2Options()
-options.platformVersion = '10'
-options.udid = '123456789ABC'
-options.app = PATH('../../../apps/test-app.apk')
-# Appium1 points to http://127.0.0.1:4723/wd/hub by default
-self.driver = webdriver.Remote('http://127.0.0.1:4723', options=options)
-el = self.driver.find_element(by=AppiumBy.ACCESSIBILITY_ID, value='item')
-el.click()
-```
-
-```python
-# iOS environment
-from appium import webdriver
-# Options are only available since client version 2.3.0
-# If you use an older client then switch to desired_capabilities
-# instead: https://github.com/appium/python-client/pull/720
 from appium.options.ios import XCUITestOptions
+from appium.webdriver.appium_service import AppiumService
 from appium.webdriver.common.appiumby import AppiumBy
 
-options = XCUITestOptions()
-options.platformVersion = '13.4'
-options.udid = '123456789ABC'
-options.app = PATH('../../apps/UICatalog.app.zip')
-# Appium1 points to http://127.0.0.1:4723/wd/hub by default
-self.driver = webdriver.Remote('http://127.0.0.1:4723', options=options)
-el = self.driver.find_element(by=AppiumBy.ACCESSIBILITY_ID, value='item')
-el.click()
+APPIUM_PORT = 4723
+APPIUM_HOST = '127.0.0.1'
+
+
+# HINT: fixtures below could be extracted into conftest.py
+# HINT: and shared across all tests in the suite
+@pytest.fixture(scope='session')
+def appium_service():
+    service = AppiumService()
+    service.start(
+        # Check the output of `appium server --help` for the complete list of 
+        # server command line arguments
+        args=['--address', APPIUM_HOST, '-p', str(APPIUM_PORT)],
+        timeout_ms=20000,
+    )
+    yield service
+    service.stop()
+
+
+def create_ios_driver(custom_opts = None):    
+    options = XCUITestOptions()
+    options.platformVersion = '13.4'
+    options.udid = '123456789ABC'
+    if custom_opts is not None:
+        options.load_capabilities(custom_opts)
+    # Appium1 points to http://127.0.0.1:4723/wd/hub by default
+    return webdriver.Remote(f'http://{APPIUM_HOST}:{APPIUM_PORT}', options=options)
+    
+
+def create_android_driver(custom_opts = None):    
+    options = UiAutomator2Options()
+    options.platformVersion = '10'
+    options.udid = '123456789ABC'
+    if custom_opts is not None:
+        options.load_capabilities(custom_opts)
+    # Appium1 points to http://127.0.0.1:4723/wd/hub by default
+    return webdriver.Remote(f'http://{APPIUM_HOST}:{APPIUM_PORT}', options=options)
+
+
+@pytest.fixture
+def ios_driver_factory():
+    return create_ios_driver
+    
+
+@pytest.fixture
+def ios_driver():
+    # prefer this fixture if there is no need to customize driver options in tests 
+    driver = create_ios_driver()
+    yield driver
+    driver.quit()
+
+    
+@pytest.fixture
+def android_driver_factory():
+    return create_android_driver
+
+
+@pytest.fixture
+def android_driver():
+    # prefer this fixture if there is no need to customize driver options in tests 
+    driver = create_android_driver()
+    yield driver
+    driver.quit()
+
+            
+def test_ios_click(appium_service, ios_driver_factory):
+    # Usage of the context manager ensures the driver session is closed properly
+    # after the test completes. Otherwise, make sure to call `driver.quit()` on teardown.
+    with ios_driver_factory({
+        'appium:app': '/path/to/app/UICatalog.app.zip'
+    }) as driver:
+        el = driver.find_element(by=AppiumBy.ACCESSIBILITY_ID, value='item')
+        el.click()
+
+
+def test_android_click(appium_service, android_driver_factory):
+    # Usage of the context manager ensures the driver session is closed properly
+    # after the test completes. Otherwise, make sure to call `driver.quit()` on teardown.
+    with android_driver_factory({
+        'appium:app': '/path/to/app/test-app.apk',
+        'appium:udid': '567890',
+    }) as driver:
+        el = driver.find_element(by=AppiumBy.ACCESSIBILITY_ID, value='item')
+        el.click()
 ```
 
 ## Direct Connect URLs
@@ -163,10 +224,10 @@ from appium.options.ios import XCUITestOptions
 options = XCUITestOptions().load_capabilities({
     'platformVersion': '13.4',
     'deviceName': 'iPhone Simulator',
-    'app': PATH('../../apps/UICatalog.app.zip'),
+    'app': '/full/path/to/app/UICatalog.app.zip',
 })
 
-self.driver = webdriver.Remote(
+driver = webdriver.Remote(
     # Appium1 points to http://127.0.0.1:4723/wd/hub by default
     'http://127.0.0.1:4723',
     options=options,
@@ -193,7 +254,7 @@ options.automation_name = 'safari'
 options.set_capability('browser_name', 'safari')
 
 # Appium1 points to http://127.0.0.1:4723/wd/hub by default
-self.driver = webdriver.Remote('http://127.0.0.1:4723', options=options, strict_ssl=False)
+driver = webdriver.Remote('http://127.0.0.1:4723', options=options, strict_ssl=False)
 ```
 
 ## Set custom `AppiumConnection`
@@ -213,13 +274,15 @@ from appium.webdriver.appium_connection import AppiumConnection
 init_args_for_pool_manage = {
     'retries': urllib3.util.retry.Retry(total=3, connect=3, read=False)
 }
-appium_executor = AppiumConnection(remote_server_addr='http://127.0.0.1:4723',
-    init_args_for_pool_manage=init_args_for_pool_manage)
+appium_executor = AppiumConnection(
+    remote_server_addr='http://127.0.0.1:4723',
+    init_args_for_pool_manage=init_args_for_pool_manage
+)
 
 options = XCUITestOptions()
 options.platformVersion = '13.4'
 options.udid = '123456789ABC'
-options.app = PATH('../../apps/UICatalog.app.zip')
+options.app = '/full/path/to/app/UICatalog.app.zip'
 driver = webdriver.Remote(appium_executor, options=options)
 ```
 
@@ -241,7 +304,7 @@ custom_executor = CustomAppiumConnection(remote_server_addr='http://127.0.0.1:47
 options = XCUITestOptions().load_capabilities({
     'platformVersion': '13.4',
     'deviceName': 'iPhone Simulator',
-    'app': PATH('../../apps/UICatalog.app.zip'),
+    'app': '/full/path/to/app/UICatalog.app.zip',
 })
 driver = webdriver.Remote(custom_executor, options=options)
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ download and unarchive the source tarball (Appium-Python-Client-X.X.tar.gz).
 > the Selenium Python binding update might affect the Appium Python Client.
 > For exampple, some changes in the Selenium binding could break the Appium client.
 > To reduce such unexpected behavior, we strongly recommend you to manage dependencies
-> with version management tool such as Pipenv and Pipfile.
+> with version management tools such as Pipenv and requirements.txt.
 
 ## Usage
 

--- a/setup.py
+++ b/setup.py
@@ -50,5 +50,5 @@ setup(
         'Topic :: Software Development :: Quality Assurance',
         'Topic :: Software Development :: Testing',
     ],
-    install_requires=['selenium >= 4.1, < 4.10'],
+    install_requires=['selenium ~= 4.1'],
 )

--- a/setup.py
+++ b/setup.py
@@ -48,5 +48,5 @@ setup(
         'Topic :: Software Development :: Quality Assurance',
         'Topic :: Software Development :: Testing',
     ],
-    install_requires=['selenium ~= 4.1'],
+    install_requires=['selenium >= 4.1, < 4.10'],
 )

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,8 @@ setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
         'Environment :: Console',
         'Environment :: MacOS X',
         'Environment :: Win32 (MS Windows)',


### PR DESCRIPTION
To prevent unexpected changes that could break this client's functionality.
Actually, the last break was by a patch version, but maybe it is reasonable to set the limit in the minor version for now.