### PR TITLE
chore: run pre-commit autoupdate

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,13 +5,13 @@ repos:
       - id: isort
         args: [ "." ]
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.961
+    rev: v1.4.1
     hooks:
       - id: mypy
         entry: mypy appium/ test/functional
         pass_filenames: false
   - repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 23.3.0
     hooks:
       - id: black
         args: [ ".", "-l", "120", "-S" ]


### PR DESCRIPTION
Ran `pre-commit autoupdate`. Pipfile.lock has the same version.

I wondered if we could sync the rev and Pipfile.lock, but probably no good way...?