### PR TITLE
fix: Add missing dependencies for types-python-dateutil

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,6 +10,7 @@ repos:
       - id: mypy
         entry: mypy appium/ test/functional
         pass_filenames: false
+        additional_dependencies: [types-python-dateutil==2.8.19.13]
   - repo: https://github.com/psf/black
     rev: 23.3.0
     hooks:

--- a/test/functional/android/applications_tests.py
+++ b/test/functional/android/applications_tests.py
@@ -34,11 +34,11 @@ class TestApplications(BaseTestCase):
         assert not self.driver.is_app_installed('sdfsdf')
         assert self.driver.is_app_installed(APIDEMO_PKG_NAME)
 
-    @pytest.mark.skip('This causes the server to crash. no idea why')
     def test_install_app(self) -> None:
-        assert not self.driver.is_app_installed('io.selendroid.testapp')
-        self.driver.install_app(PATH(os.path.join('../..', 'apps', 'selendroid-test-app.apk')))
-        assert self.driver.is_app_installed('io.selendroid.testapp')
+        self.driver.remove_app(APIDEMO_PKG_NAME)
+        assert not self.driver.is_app_installed(APIDEMO_PKG_NAME)
+        self.driver.install_app(PATH(os.path.join('../..', 'apps', 'ApiDemos-debug.apk.zip')))
+        assert self.driver.is_app_installed(APIDEMO_PKG_NAME)
 
     def test_remove_app(self) -> None:
         assert self.driver.is_app_installed(APIDEMO_PKG_NAME)

--- a/test/functional/android/applications_tests.py
+++ b/test/functional/android/applications_tests.py
@@ -34,11 +34,11 @@ class TestApplications(BaseTestCase):
         assert not self.driver.is_app_installed('sdfsdf')
         assert self.driver.is_app_installed(APIDEMO_PKG_NAME)
 
+    @pytest.mark.skip('This causes the server to crash. no idea why')
     def test_install_app(self) -> None:
-        self.driver.remove_app(APIDEMO_PKG_NAME)
-        assert not self.driver.is_app_installed(APIDEMO_PKG_NAME)
-        self.driver.install_app(PATH(os.path.join('../..', 'apps', 'ApiDemos-debug.apk.zip')))
-        assert self.driver.is_app_installed(APIDEMO_PKG_NAME)
+        assert not self.driver.is_app_installed('io.selendroid.testapp')
+        self.driver.install_app(PATH(os.path.join('../..', 'apps', 'selendroid-test-app.apk')))
+        assert self.driver.is_app_installed('io.selendroid.testapp')
 
     def test_remove_app(self) -> None:
         assert self.driver.is_app_installed(APIDEMO_PKG_NAME)


### PR DESCRIPTION
Currently, when trying to commit, mypy hook is failing on `Library stubs not installed for "dateutil.parser"` although they are installed.
```
(venv) E:\Git\python-client>mypy --python-executable venv\Scripts\python --install-types
Installing missing stub packages:
venv\Scripts\python -m pip install types-python-dateutil

Install? [yN] y

Requirement already satisfied: types-python-dateutil in e:\git\python-client\venv\lib\site-packages (2.8.19.13)
```
The solution I found, for now, is adding additional_dependencies to mypy .pre-commit hook
See https://github.com/dateutil/dateutil/issues/383 for more info