### PR TITLE
fix: Handle the situation where payload is already a dictionary

### DIFF
--- a/appium/webdriver/errorhandler.py
+++ b/appium/webdriver/errorhandler.py
@@ -86,12 +86,15 @@ class MobileErrorHandler(errorhandler.ErrorHandler):
         https://www.w3.org/TR/webdriver/#errors
         """
         payload = response.get('value', '')
-        try:
-            payload_dict = json.loads(payload)
-        except (json.JSONDecodeError, TypeError):
-            return
-        if not isinstance(payload_dict, dict):
-            return
+        if isinstance(payload, dict):
+            payload_dict = payload
+        else:
+            try:
+                payload_dict = json.loads(payload)
+            except (json.JSONDecodeError, TypeError):
+                return
+            if not isinstance(payload_dict, dict):
+                return
         value = payload_dict.get('value')
         if not isinstance(value, dict):
             return


### PR DESCRIPTION
In my tests the payload was always of string type, but such approach should be safer anyway