### PR TITLE
Add back `set_value` and remove deprecated mark

### DIFF
--- a/appium/webdriver/mobilecommand.py
+++ b/appium/webdriver/mobilecommand.py
@@ -33,6 +33,8 @@ class MobileCommand:
     TOUCH_ACTION = 'touchAction'
     MULTI_ACTION = 'multiAction'
 
+    SET_IMMEDIATE_VALUE = 'setImmediateValue'
+
     BACKGROUND = 'background'
     GET_APP_STRINGS = 'getAppStrings'
 

--- a/appium/webdriver/webdriver.py
+++ b/appium/webdriver/webdriver.py
@@ -430,6 +430,19 @@ class WebDriver(
         """
         return MobileWebElement(self, element_id)
 
+    def set_value(self, element: MobileWebElement, value: str) -> 'WebDriver':
+        """Set the value on an element in the application.
+        Args:
+            element: the element whose value will be set
+            value: the value to set on the element
+        Returns:
+            `appium.webdriver.webdriver.WebDriver`: Self instance
+        """
+
+        data = {'text': value}
+        self.execute(Command.SET_IMMEDIATE_VALUE, data)
+        return self
+
     @property
     def switch_to(self) -> MobileSwitchTo:
         """Returns an object containing all options to switch focus into
@@ -515,6 +528,10 @@ class WebDriver(
         # FIXME: remove after a while as MJSONWP
         commands[Command.TOUCH_ACTION] = ('POST', '/session/$sessionId/touch/perform')
         commands[Command.MULTI_ACTION] = ('POST', '/session/$sessionId/touch/multi/perform')
+        commands[Command.SET_IMMEDIATE_VALUE] = (
+            'POST',
+            '/session/$sessionId/appium/element/$id/value',
+        )
 
         # TODO Move commands for element to webelement
         commands[Command.CLEAR] = ('POST', '/session/$sessionId/element/$id/clear')

--- a/appium/webdriver/webelement.py
+++ b/appium/webdriver/webelement.py
@@ -172,6 +172,18 @@ class WebElement(SeleniumWebElement):
         """
         return self._execute(Command.LOCATION_IN_VIEW)['value']
 
+    def set_value(self, value: str) -> 'WebElement':
+        """Set the value on this element in the application
+        Args:
+            value: The value to be set
+        Returns:
+            `appium.webdriver.webelement.WebElement`
+        """
+
+        data = {'text': value}
+        self._execute(Command.SET_IMMEDIATE_VALUE, data)
+        return self
+
     # Override
     def send_keys(self, *value: str) -> 'WebElement':
         """Simulates typing into the element.

--- a/test/unit/webdriver/webelement_test.py
+++ b/test/unit/webdriver/webelement_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import json
+import os
 import tempfile
 
 import httpretty
@@ -34,6 +35,18 @@ class TestWebElement(object):
         s = driver.get_status()
 
         assert s == response
+
+    @httpretty.activate
+    def test_set_value(self):
+        driver = android_w3c_driver()
+        httpretty.register_uri(httpretty.POST, appium_command('/session/1234567890/appium/element/element_id/value'))
+
+        element = MobileWebElement(driver, 'element_id')
+        value = 'happy testing'
+        element.set_value(value)
+
+        d = get_httpretty_request_body(httpretty.last_request())
+        assert d['text'] == value
 
     @httpretty.activate
     def test_send_key(self):


### PR DESCRIPTION
Otherwise there is no way to change a slider's value in Appium tests.

This partially reverts https://github.com/appium/python-client/pull/909

Ref: https://invent.kde.org/sdk/selenium-webdriver-at-spi/-/blob/f17f6fbbe7175e96ceb89ea3426901875d20228a/selenium-webdriver-at-spi.py#L735