### PR TITLE
fix: self.command_executor instance in _update_command_executor

### DIFF
--- a/appium/webdriver/webdriver.py
+++ b/appium/webdriver/webdriver.py
@@ -296,8 +296,7 @@ class WebDriver(
 
         logger.debug('Updated request endpoint to %s', executor)
         # Override command executor.
-        # TODO: add custome executor case by the user.
-        if isinstance(self.command_executor, AppiumConnection):
+        if isinstance(self.command_executor, AppiumConnection):  # type: ignore
             self.command_executor = AppiumConnection(executor, keep_alive=keep_alive)
         else:
             self.command_executor = RemoteConnection(executor, keep_alive=keep_alive)

--- a/appium/webdriver/webdriver.py
+++ b/appium/webdriver/webdriver.py
@@ -295,8 +295,12 @@ class WebDriver(
         executor = f'{protocol}://{hostname}:{port}{path}'
 
         logger.debug('Updated request endpoint to %s', executor)
-        # Override command executor
-        self.command_executor = RemoteConnection(executor, keep_alive=keep_alive)
+        # Override command executor.
+        # TODO: add custome executor case by the user.
+        if isinstance(self.command_executor, AppiumConnection):
+            self.command_executor = AppiumConnection(executor, keep_alive=keep_alive)
+        else:
+            self.command_executor = RemoteConnection(executor, keep_alive=keep_alive)
         self._add_commands()
 
     # https://github.com/SeleniumHQ/selenium/blob/06fdf2966df6bca47c0ae45e8201cd30db9b9a49/py/selenium/webdriver/remote/webdriver.py#L277

--- a/test/unit/webdriver/webdriver_test.py
+++ b/test/unit/webdriver/webdriver_test.py
@@ -134,6 +134,7 @@ class TestWebDriverWebDriver:
 
         assert 'http://localhost2:4800/special/path/wd/hub' == driver.command_executor._url
         assert ['NATIVE_APP', 'CHROMIUM'] == driver.contexts
+        assert isinstance(driver.command_executor, AppiumConnection)
 
     @httpretty.activate
     def test_create_session_register_uridirect_no_direct_connect_path(self):
@@ -173,6 +174,7 @@ class TestWebDriverWebDriver:
 
         assert SERVER_URL_BASE == driver.command_executor._url
         assert ['NATIVE_APP', 'CHROMIUM'] == driver.contexts
+        assert isinstance(driver.command_executor, AppiumConnection)
 
     @httpretty.activate
     def test_get_events(self):


### PR DESCRIPTION
The new replaced instance was always `RemoteConnection`, which was not Appium's one. Use AppiumConnection if the executor was already made by AppiumConnection