### PR TITLE
fix: add return self in MultiAction#add

### DIFF
--- a/appium/webdriver/common/multi_action.py
+++ b/appium/webdriver/common/multi_action.py
@@ -45,7 +45,7 @@ class MultiAction:
         self._element = element
         self._touch_actions: List['TouchAction'] = []
 
-    def add(self, *touch_actions: 'TouchAction') -> None:
+    def add(self, *touch_actions: 'TouchAction') -> 'MultiAction':
         """Add TouchAction objects to the MultiAction, to be performed later.
 
         Args:
@@ -66,6 +66,8 @@ class MultiAction:
                 self._touch_actions = []
 
             self._touch_actions.append(copy.copy(touch_action))
+
+        return self
 
     def perform(self) -> 'MultiAction':
         """Perform the actions stored in the object.


### PR DESCRIPTION
For https://github.com/appium/python-client/pull/963

The usage addressed `MultiAction(driver).add(a1, a2).perform()` usage in the docstring, thus return self is probably correct way for this `add` as well.