### PR TITLE
fix: unclosed file <_io.BufferedReader name error by proper cleanup of subprocess.Popen process

### DIFF
--- a/appium/webdriver/appium_service.py
+++ b/appium/webdriver/appium_service.py
@@ -235,6 +235,7 @@ class AppiumService:
         if self.is_running:
             assert self._process
             self._process.terminate()
+            self._process.communicate(timeout=5)
             is_terminated = True
         self._process = None
         self._cmd = None


### PR DESCRIPTION
https://github.com/appium/python-client/issues/962

After self._process.terminate() a call to Popen.communicate()](https://docs.python.org/3/library/subprocess.html#subprocess.Popen.communicate) shall be made, which will close the file handles.
This will ensure that file stdout and sdterr file descriptors are closed properly.