### PR TITLE
chore: remove IOS_UIAUTOMATION

### DIFF
--- a/appium/webdriver/common/appiumby.py
+++ b/appium/webdriver/common/appiumby.py
@@ -17,7 +17,6 @@ from selenium.webdriver.common.by import By
 
 class AppiumBy(By):
     IOS_PREDICATE = '-ios predicate string'
-    IOS_UIAUTOMATION = '-ios uiautomation'
     IOS_CLASS_CHAIN = '-ios class chain'
     ANDROID_UIAUTOMATOR = '-android uiautomator'
     ANDROID_VIEWTAG = '-android viewtag'

--- a/appium/webdriver/webdriver.py
+++ b/appium/webdriver/webdriver.py
@@ -240,7 +240,6 @@ class WebDriver(
             self._update_command_executor(keep_alive=keep_alive)
 
         # add new method to the `find_by_*` pantheon
-        By.IOS_UIAUTOMATION = AppiumBy.IOS_UIAUTOMATION
         By.IOS_PREDICATE = AppiumBy.IOS_PREDICATE
         By.IOS_CLASS_CHAIN = AppiumBy.IOS_CLASS_CHAIN
         By.ANDROID_UIAUTOMATOR = AppiumBy.ANDROID_UIAUTOMATOR


### PR DESCRIPTION
The objective of this PR is to remove the IOS_UIAUTOMATION locator, which is deprecated.


closes https://github.com/appium/python-client/issues/913

BREAKING: remove obsolete IOS_UIAUTOMATION