### PR TITLE
ci: add initial gha to run by manual

### DIFF
--- a/.github/functional-test.yml
+++ b/.github/functional-test.yml
@@ -1,0 +1,67 @@
+name: Functional Tests
+
+on:
+  # Run by manual at this time
+  workflow_dispatch:
+  # push:
+  #   branches: [ master ]
+  # pull_request:
+  #   branches: [ master ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  ios_test:
+    strategy:
+      fail-fast: false
+      matrix:
+        test_targets:
+          - target: search_context/find_by_*.py remote_fs_tests.py safari_tests.py execute_driver_tests.py
+            name: func_test_ios1
+
+    runs-on: macos-14
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Install Node.js
+      uses: actions/setup-node@v3
+      with:
+        node-version: 'lts/*'
+
+    - name: Select Xcode
+      uses: maxim-lobanov/setup-xcode@v1
+      with:
+        xcode-version: 15.3
+    - run: defaults write com.apple.iphonesimulator PasteboardAutomaticSync -bool false
+
+    - uses: futureware-tech/simulator-action@v3
+      with:
+        # https://github.com/actions/runner-images/blob/main/images/macos/macos-14-arm64-Readme.md
+        model: 'iPhone 15 Plus'
+        os_version: '17.4'
+
+    # Start Appium
+    - run: npm install -g appium
+    - run: |
+        appium driver install xcuitest
+        appium plugin install images
+        appium plugin install execute-driver
+        nohup appium --use-plugins=images,execute-driver --relaxed-security --log-timestamp --log-no-colors --base-path=/wd/hub > appium.log &
+
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v3
+      with:
+        python-version: 3.9
+
+    - run: python -m pytest ${{ test_targets.target}} --doctest-modules --junitxml=junit/test-results.xml --cov=com --cov-report=xml --cov-report=html
+      working-directory: test/functional/ios
+
+    - name: Save server output
+      if: ${{ always() }}
+      uses: actions/upload-artifact@master
+      with:
+        name: appium-ios-${{matrix.test_targets.name}}.log
+        path: appium.log


### PR DESCRIPTION
I'm working on Azure replacement with newer macOS env on gha. This PR is to run tests by manual kick, so let me merge this right now.
A followup PR will have more updates after running tests.