### PR TITLE
add try & catch to always return a list for find_elements method

### DIFF
--- a/appium/webdriver/webdriver.py
+++ b/appium/webdriver/webdriver.py
@@ -415,7 +415,10 @@ class WebDriver(
         # Return empty list if driver returns null
         # See https://github.com/SeleniumHQ/selenium/issues/4555
 
-        return self.execute(RemoteCommand.FIND_ELEMENTS, {'using': by, 'value': value})['value'] or []
+        try:
+            return self.execute(RemoteCommand.FIND_ELEMENTS, {'using': by, 'value': value})['value'] or []
+        except NoSuchElementException:
+            return []
 
     def create_web_element(self, element_id: Union[int, str]) -> MobileWebElement:
         """Creates a web element with the specified element_id.


### PR DESCRIPTION
### This PR adds a try & catch to return an empty list if no result is found with the "find_element" method


I do not know if this is right because the Selenium documentation remains unclear but it appeared to me that the method **find_elements** should return an empty list and **NOT** throw an error if no match is found.

The behaviour from **find_element** and **find_elements** should be different. [Here](https://www.w3.org/TR/webdriver/#find-elements)  we can see that there is no 10th step for find **elements** whereas there is this step for **find element** :   
```
10. If result is empty, return error with error code no such element. Otherwise, return the first element of result. 
``` 


I noticed that the Java client does not throw an error : 
```java
    /**
     * Find the element.
     */
    public WebElement findElement() {
        SearchContext searchContext = getSearchContext()
                .orElseThrow(() -> new IllegalStateException(
                        String.format("The element %s is not locatable anymore "
                                + "because its context has been garbage collected", by)
                ));

        By bySearching = getBy(this.by, searchContext);
        try {
            WebElement result = waitFor(() -> searchContext.findElement(bySearching));
            return result;
        } catch (TimeoutException | StaleElementReferenceException e) {
            throw new NoSuchElementException(format(EXCEPTION_MESSAGE_IF_ELEMENT_NOT_FOUND, bySearching.toString()), e);
        }
    }

    /**
     * Find the element list.
     */
    public List<WebElement> findElements() {
        SearchContext searchContext = getSearchContext()
                .orElseThrow(() -> new IllegalStateException(
                    String.format("Elements %s are not locatable anymore "
                            + "because their context has been garbage collected", by)
                ));

        List<WebElement> result;
        try {
            result = waitFor(() -> {
                List<WebElement> list = searchContext.findElements(getBy(by, searchContext));
                return list.isEmpty() ? null : list;
            });
        } catch (TimeoutException | StaleElementReferenceException e) {
            result = new ArrayList<>();
        }
     }
``` 

And it seems to me that is also the case with the C# client: 
```c#
        /// <summary>
        /// Finds the first <see cref="IWebElement"/> using the given method. 
        /// </summary>
        /// <param name="by">The locating mechanism to use.</param>
        /// <returns>The first matching <see cref="IWebElement"/> on the current context.</returns>
        /// <exception cref="NoSuchElementException">If no element matches the criteria.</exception>
        W FindElement(By by);

        /// <summary>
        /// Finds all <see cref="IWebElement">IWebElements</see> within the current context 
        /// using the given mechanism.
        /// </summary>
        /// <param name="by">The locating mechanism to use.</param>
        /// <returns>A <see cref="ReadOnlyCollection{T}"/> of all <see cref="IWebElement">WebElements</see>
        /// matching the current criteria, or an empty list if nothing matches.</returns>
        ReadOnlyCollection<W> FindElements(By by);
``` 

Open to feedback