### PR TITLE
feat: add app_path property ("appPath") to Mac2Options

### DIFF
--- a/appium/options/mac/mac2/app_path_option.py
+++ b/appium/options/mac/mac2/app_path_option.py
@@ -1,0 +1,39 @@
+# Licensed to the Software Freedom Conservancy (SFC) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The SFC licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from os import PathLike, fspath
+from typing import Optional, Union
+
+from appium.options.common.supports_capabilities import SupportsCapabilities
+
+APP_PATH = 'appPath'
+
+
+class AppPathOption(SupportsCapabilities):
+    @property
+    def app_path(self) -> Optional[str]:
+        """
+        The path of the application to automate.
+        """
+        return self.get_capability(APP_PATH)
+
+    @app_path.setter
+    def app_path(self, value: Union[str, PathLike]) -> None:
+        """
+        Set the path of the application to automate.
+        """
+        self.set_capability(APP_PATH, fspath(value))

--- a/appium/options/mac/mac2/base.py
+++ b/appium/options/mac/mac2/base.py
@@ -25,6 +25,7 @@ from appium.options.common.prerun_option import PrerunOption
 from appium.options.common.system_host_option import SystemHostOption
 from appium.options.common.system_port_option import SystemPortOption
 
+from .app_path_option import AppPathOption
 from .arguments_option import ArgumentsOption
 from .bootstrap_root_option import BootstrapRootOption
 from .environment_option import EnvironmentOption
@@ -36,6 +37,7 @@ from .web_driver_agent_mac_url_option import WebDriverAgentMacUrlOption
 
 class Mac2Options(
     AppiumOptions,
+    AppPathOption,
     PrerunOption,
     PostrunOption,
     ArgumentsOption,


### PR DESCRIPTION
This PR adds support for setting the optional appPath capability via Mac2Options().app_path, aligning with the related "bundle_id" setting. Presently it is necessary to pass in a value for appPath as part of the capabilities dictionary to Mac2Options().load_capabilities() if you wish to set it.

appPath is implemented in the Mac2 driver:
https://github.com/appium/appium-mac2-driver?tab=readme-ov-file#capabilities