### PR TITLE
fix: add missing __init__.py

### DIFF
--- a/appium/webdriver/extensions/flutter_integration/__init__.py
+++ b/appium/webdriver/extensions/flutter_integration/__init__.py
@@ -11,5 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-from .base import FlutterOptions


### PR DESCRIPTION
To fix packaging:

```
The count of files in 'appium' and 'build/lib/appium' were different.
'appium' has '{'/webdriver/extensions/flutter_integration/flutter_commands.py', '/webdriver/extensions/flutter_integration/scroll_directions.py', '/webdriver/extensions/flutter_integration/flutter_finder.py'}' files than build/lib/appium
Python files in 'build/lib/appium' may differ from 'appium'. Please make sure setup.py is configured properly.
```