### PR TITLE
feat: support selenium 4.26+: support ClientConfig and refactoring internal implementation

### DIFF
--- a/.github/workflows/functional-test.yml
+++ b/.github/workflows/functional-test.yml
@@ -29,7 +29,7 @@ jobs:
       XCODE_VERSION: 15.3
       IOS_VERSION: 17.4
       IPHONE_MODEL: iPhone 15 Plus
-      GLOBAL_DEFAULT_TIMEOUT: 300
+      GLOBAL_DEFAULT_TIMEOUT: 600
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/functional-test.yml
+++ b/.github/workflows/functional-test.yml
@@ -29,6 +29,7 @@ jobs:
       XCODE_VERSION: 15.3
       IOS_VERSION: 17.4
       IPHONE_MODEL: iPhone 15 Plus
+      GLOBAL_DEFAULT_TIMEOUT: 300
 
     steps:
     - uses: actions/checkout@v3

--- a/Pipfile
+++ b/Pipfile
@@ -15,5 +15,5 @@ tox = "~=4.23"
 types-python-dateutil = "~=2.9"
 
 [packages]
-selenium = "~=4.25"
+selenium = "~=4.26"
 typing-extensions = "~=4.12.2"

--- a/Pipfile
+++ b/Pipfile
@@ -15,5 +15,5 @@ tox = "~=4.23"
 types-python-dateutil = "~=2.9"
 
 [packages]
-selenium = "~=4.26"
+selenium = "==4.26.1"
 typing-extensions = "~=4.12.2"

--- a/README.md
+++ b/README.md
@@ -291,6 +291,8 @@ driver = webdriver.Remote(
 
 ## Relax SSL validation
 
+TODO: add 'ClientConfig' method way.
+
 `strict_ssl` option allows you to send commands to an invalid certificate host like a self-signed one.
 
 ```python
@@ -312,6 +314,8 @@ driver = webdriver.Remote('http://127.0.0.1:4723', options=options, strict_ssl=F
 ```
 
 ## Set custom `AppiumConnection`
+
+TODO: add 'ClientConfig' example as well.
 
 The first argument of `webdriver.Remote` can set an arbitrary command executor for you.
 

--- a/README.md
+++ b/README.md
@@ -382,15 +382,15 @@ driver = webdriver.Remote(custom_executor, options=options)
 
 The `AppiumConnection` can set `selenium.webdriver.remote.client_config.ClientConfig` as well.
 
-## Relaxing read timeout
+## Relaxing HTTP request read timeout
 
 Appium Python Client has `120` seconds read timeout on each HTTP request since the version v4.3.0 because of
-the corresponding selenium bindings set the read timeout by default.
-A couple of methods below would help to configure the timeout.
+the corresponding selenium binding version.
+You have two methods to extend the read timeout.
 
 1. Set `GLOBAL_DEFAULT_TIMEOUT` environment variable
 2. Configure timeout via `selenium.webdriver.remote.client_config.ClientConfig`
-    - `timeout` argument or
+    - `timeout` argument, or
     - `init_args_for_pool_manager` argument for `urllib3.PoolManager`
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ download and unarchive the source tarball (Appium-Python-Client-X.X.tar.gz).
 
 |Appium Python Client| Selenium binding| Python version |
 |----|----|----|
-|`3.0.0`+ |`4.12.0`+ | 3.8+ |
+|`3.0.0` - `4.2.0` |`4.12.0` - `4.25.0` | 3.8+ |
 |`2.10.0` - `2.11.1` |`4.1.0` - `4.11.2` | 3.7+ |
 |`2.2.0` - `2.9.0` |`4.1.0` - `4.9.0` | 3.7+ |
 |`2.0.0` - `2.1.4` |`4.0.0` | 3.7+ |

--- a/README.md
+++ b/README.md
@@ -313,7 +313,7 @@ driver = webdriver.Remote('http://127.0.0.1:4723', options=options, strict_ssl=F
 ```
 
 Since Appium Python client v4.3.0, we recommend using `selenium.webdriver.remote.client_config.ClientConfig`
-instead to configure the validation.
+instead of giving `strict_ssl` as an argument of `webdriver.Remote` below to configure the validation.
 
 ```python
 from appium import webdriver

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ download and unarchive the source tarball (Appium-Python-Client-X.X.tar.gz).
 
 |Appium Python Client| Selenium binding| Python version |
 |----|----|----|
+|`4.3.0`+ |`4.26.0`+ | 3.8+ |
 |`3.0.0` - `4.2.1` |`4.12.0` - `4.25.0` | 3.8+ |
 |`2.10.0` - `2.11.1` |`4.1.0` - `4.11.2` | 3.7+ |
 |`2.2.0` - `2.9.0` |`4.1.0` - `4.9.0` | 3.7+ |
@@ -383,8 +384,9 @@ The `AppiumConnection` can set `selenium.webdriver.remote.client_config.ClientCo
 
 ## Relaxing read timeout
 
-Appium Python Client has 120 seconds read timeout on each HTTP request since v4.3.0 as selenium bindings behavior change.
-You would get 120 seconds read timeout error in some test results.
+Appium Python Client has `120` seconds read timeout on each HTTP request since the version v4.3.0 because of
+the corresponding selenium bindings set the read timeout by default.
+A couple of methods below would help to configure the timeout.
 
 1. Set `GLOBAL_DEFAULT_TIMEOUT` environment variable
 2. Configure timeout via `selenium.webdriver.remote.client_config.ClientConfig`

--- a/README.md
+++ b/README.md
@@ -291,8 +291,6 @@ driver = webdriver.Remote(
 
 ## Relax SSL validation
 
-TODO: add 'ClientConfig' method way.
-
 `strict_ssl` option allows you to send commands to an invalid certificate host like a self-signed one.
 
 ```python
@@ -313,9 +311,21 @@ options.set_capability('browser_name', 'safari')
 driver = webdriver.Remote('http://127.0.0.1:4723', options=options, strict_ssl=False)
 ```
 
-## Set custom `AppiumConnection`
+Since Appium Python client v5, we recommend using ClientConfig instead.
 
-TODO: add 'ClientConfig' example as well.
+```python
+from appium import webdriver
+
+from selenium.webdriver.remote.client_config import ClientConfig
+
+client_config = ClientConfig(
+    remote_server_addr='http://127.0.0.1:4723',
+    ignore_certificates=True
+)
+driver = webdriver.Remote(client_config.remote_server_addr, options=options, client_config=client_config)
+```
+
+## Set custom `AppiumConnection`
 
 The first argument of `webdriver.Remote` can set an arbitrary command executor for you.
 
@@ -368,6 +378,7 @@ driver = webdriver.Remote(custom_executor, options=options)
 
 ```
 
+The `AppiumConnection` can set `selenium.webdriver.remote.client_config.ClientConfig` as well.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -311,7 +311,8 @@ options.set_capability('browser_name', 'safari')
 driver = webdriver.Remote('http://127.0.0.1:4723', options=options, strict_ssl=False)
 ```
 
-Since Appium Python client v5, we recommend using ClientConfig instead.
+Since Appium Python client v4.3.0, we recommend using `selenium.webdriver.remote.client_config.ClientConfig`
+instead to configure the validation.
 
 ```python
 from appium import webdriver
@@ -379,6 +380,16 @@ driver = webdriver.Remote(custom_executor, options=options)
 ```
 
 The `AppiumConnection` can set `selenium.webdriver.remote.client_config.ClientConfig` as well.
+
+## Relaxing read timeout
+
+Appium Python Client has 120 seconds read timeout on each HTTP request since v4.3.0 as selenium bindings behavior change.
+You would get 120 seconds read timeout error in some test results.
+
+1. Set `GLOBAL_DEFAULT_TIMEOUT` environment variable
+2. Configure timeout via `selenium.webdriver.remote.client_config.ClientConfig`
+    - `timeout` argument or
+    - `init_args_for_pool_manager` argument for `urllib3.PoolManager`
 
 ## Documentation
 

--- a/appium/webdriver/appium_connection.py
+++ b/appium/webdriver/appium_connection.py
@@ -13,9 +13,8 @@
 # limitations under the License.
 
 import uuid
-from typing import TYPE_CHECKING, Any, Dict, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, Optional
 
-import urllib3
 from selenium.webdriver.remote.remote_connection import RemoteConnection
 
 from appium.common.helper import library_version
@@ -30,51 +29,16 @@ PREFIX_HEADER = 'appium/'
 class AppiumConnection(RemoteConnection):
     _proxy_url: Optional[str]
 
-    def __init__(
-        self,
-        remote_server_addr: str,
-        keep_alive: bool = False,
-        ignore_proxy: Optional[bool] = False,
-        init_args_for_pool_manager: Union[Dict[str, Any], None] = None,
-    ):
-        # Need to call before super().__init__ in order to pass arguments for the pool manager in the super.
-        self._init_args_for_pool_manager = init_args_for_pool_manager or {}
-
-        super().__init__(remote_server_addr, keep_alive=keep_alive, ignore_proxy=ignore_proxy)
-
-    def _get_connection_manager(self) -> Union[urllib3.PoolManager, urllib3.ProxyManager]:
-        # https://github.com/SeleniumHQ/selenium/blob/0e0194b0e52a34e7df4b841f1ed74506beea5c3e/py/selenium/webdriver/remote/remote_connection.py#L134
-        pool_manager_init_args = {'timeout': self.get_timeout()}
-
-        if self._ca_certs:
-            pool_manager_init_args['cert_reqs'] = 'CERT_REQUIRED'
-            pool_manager_init_args['ca_certs'] = self._ca_certs
-        else:
-            # This line is necessary to disable certificate verification
-            pool_manager_init_args['cert_reqs'] = 'CERT_NONE'
-
-        pool_manager_init_args.update(self._init_args_for_pool_manager)
-
-        if self._proxy_url:
-            if self._proxy_url.lower().startswith('sock'):
-                from urllib3.contrib.socks import SOCKSProxyManager
-
-                return SOCKSProxyManager(self._proxy_url, **pool_manager_init_args)
-            if self._identify_http_proxy_auth():
-                self._proxy_url, self._basic_proxy_auth = self._separate_http_proxy_auth()
-                pool_manager_init_args['proxy_headers'] = urllib3.make_headers(proxy_basic_auth=self._basic_proxy_auth)
-            return urllib3.ProxyManager(self._proxy_url, **pool_manager_init_args)
-
-        return urllib3.PoolManager(**pool_manager_init_args)
+    RemoteConnection.user_agent = f'{PREFIX_HEADER}{library_version()} ({RemoteConnection.user_agent})'
 
     @classmethod
     def get_remote_connection_headers(cls, parsed_url: 'ParseResult', keep_alive: bool = True) -> Dict[str, Any]:
         """Override get_remote_connection_headers in RemoteConnection"""
         headers = RemoteConnection.get_remote_connection_headers(parsed_url, keep_alive=keep_alive)
-        # e.g. appium/0.49 (selenium/3.141.0 (python linux))
-        headers['User-Agent'] = f'{PREFIX_HEADER}{library_version()} ({headers["User-Agent"]})'
         if parsed_url.path.endswith('/session'):
             # https://github.com/appium/appium-base-driver/pull/400
-            headers['X-Idempotency-Key'] = str(uuid.uuid4())
+            RemoteConnection.extra_headers = {'X-Idempotency-Key': str(uuid.uuid4())}
+        else:
+            RemoteConnection.extra_headers = {}
 
         return headers

--- a/appium/webdriver/appium_connection.py
+++ b/appium/webdriver/appium_connection.py
@@ -15,6 +15,7 @@
 import uuid
 from typing import TYPE_CHECKING, Any, Dict, Optional
 
+from selenium.webdriver.remote.client_config import ClientConfig
 from selenium.webdriver.remote.remote_connection import RemoteConnection
 
 from appium.common.helper import library_version
@@ -30,6 +31,21 @@ class AppiumConnection(RemoteConnection):
     _proxy_url: Optional[str]
 
     RemoteConnection.user_agent = f'{PREFIX_HEADER}{library_version()} ({RemoteConnection.user_agent})'
+
+    def __init__(
+        self,
+        remote_server_addr: Optional[str] = None,
+        keep_alive: Optional[bool] = True,
+        init_args_for_pool_manager: Optional[dict] = None,
+        client_config: Optional[ClientConfig] = None,
+    ):
+        if client_config is None:
+            client_config = ClientConfig(remote_server_addr=remote_server_addr)
+        client_config.keep_alive = keep_alive
+        if init_args_for_pool_manager is not None:
+            client_config.init_args_for_pool_manager = init_args_for_pool_manager
+
+        super().__init__(client_config=client_config)
 
     @classmethod
     def get_remote_connection_headers(cls, parsed_url: 'ParseResult', keep_alive: bool = True) -> Dict[str, Any]:

--- a/appium/webdriver/appium_connection.py
+++ b/appium/webdriver/appium_connection.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import uuid
-from typing import TYPE_CHECKING, Any, Dict, Optional
+from typing import TYPE_CHECKING, Any, Dict, Optional, Union
 
 from selenium.webdriver.remote.client_config import ClientConfig
 from selenium.webdriver.remote.remote_connection import RemoteConnection
@@ -34,14 +34,17 @@ class AppiumConnection(RemoteConnection):
 
     def __init__(
         self,
-        remote_server_addr: Optional[str] = None,
-        keep_alive: Optional[bool] = True,
-        init_args_for_pool_manager: Optional[dict] = None,
+        remote_server_addr: str,
+        keep_alive: bool = True,
+        ignore_proxy: Optional[bool] = False,
+        init_args_for_pool_manager: Union[Dict[str, Any], None] = None,
         client_config: Optional[ClientConfig] = None,
     ):
         if client_config is None:
             client_config = ClientConfig(remote_server_addr=remote_server_addr)
         client_config.keep_alive = keep_alive
+        if ignore_proxy is not None:
+            client_config.ignore_proxy = ignore_proxy
         if init_args_for_pool_manager is not None:
             client_config.init_args_for_pool_manager = init_args_for_pool_manager
 

--- a/appium/webdriver/appium_connection.py
+++ b/appium/webdriver/appium_connection.py
@@ -43,7 +43,9 @@ class AppiumConnection(RemoteConnection):
 
     @classmethod
     def get_remote_connection_headers(cls, parsed_url: 'ParseResult', keep_alive: bool = True) -> Dict[str, Any]:
-        """Override get_remote_connection_headers in RemoteConnection"""
+        """Override get_remote_connection_headers in RemoteConnection to control the extra headers.
+        This method will be used in sending a request method in this class.
+        """
         headers = RemoteConnection.get_remote_connection_headers(parsed_url, keep_alive=keep_alive)
         if parsed_url.path.endswith('/session'):
             # https://github.com/appium/appium-base-driver/pull/400

--- a/appium/webdriver/appium_connection.py
+++ b/appium/webdriver/appium_connection.py
@@ -13,9 +13,8 @@
 # limitations under the License.
 
 import uuid
-from typing import TYPE_CHECKING, Any, Dict, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict
 
-from selenium.webdriver.remote.client_config import ClientConfig
 from selenium.webdriver.remote.remote_connection import RemoteConnection
 
 from appium.common.helper import library_version
@@ -30,26 +29,17 @@ _HEADER_IDEMOTENCY_KEY = 'X-Idempotency-Key'
 
 
 class AppiumConnection(RemoteConnection):
+    """
+    A subclass of selenium.webdriver.remote.remote_connection.Remoteconnection.
+
+    The changes are:
+        - The default user agent
+        - Adds 'X-Idempotency-Key' header in a new session request to avoid proceeding
+          the same request multiple times in the Appium server side.
+            - https://github.com/appium/appium-base-driver/pull/400
+    """
+
     RemoteConnection.user_agent = f'{PREFIX_HEADER}{library_version()} ({RemoteConnection.user_agent})'
-
-    def __init__(
-        self,
-        remote_server_addr: str,
-        keep_alive: Optional[bool] = False,
-        ignore_proxy: Optional[bool] = False,
-        init_args_for_pool_manager: Union[Dict[str, Any], None] = None,
-        client_config: Optional[ClientConfig] = None,
-    ):
-        if client_config is None:
-            client_config = ClientConfig(remote_server_addr=remote_server_addr)
-        if keep_alive is not None:
-            client_config.keep_alive = keep_alive
-        if ignore_proxy is not None:
-            client_config.ignore_proxy = ignore_proxy
-        if init_args_for_pool_manager is not None:
-            client_config.init_args_for_pool_manager = init_args_for_pool_manager
-
-        super().__init__(client_config=client_config)
 
     @classmethod
     def get_remote_connection_headers(cls, parsed_url: 'ParseResult', keep_alive: bool = True) -> Dict[str, Any]:

--- a/appium/webdriver/appium_connection.py
+++ b/appium/webdriver/appium_connection.py
@@ -62,3 +62,7 @@ class AppiumConnection(RemoteConnection):
             RemoteConnection.extra_headers = {}
 
         return headers
+
+    # TODO: remove after https://github.com/SeleniumHQ/selenium/pull/14692 merge
+    def _request(self, method, url, body=None):
+        return super()._request(method, url, body=body, timeout=self._client_config.timeout)

--- a/appium/webdriver/appium_connection.py
+++ b/appium/webdriver/appium_connection.py
@@ -28,7 +28,7 @@ PREFIX_HEADER = 'appium/'
 _HEADER_IDEMOTENCY_KEY = 'X-Idempotency-Key'
 
 
-def _get_new_headers(key: str, headers: dict[str, str]) -> dict[str, str]:
+def _get_new_headers(key: str, headers: Dict[str, str]) -> Dict[str, str]:
     """Return a new dictionary of heafers without the given key.
     The key match is case-insensitive."""
     new_headers = dict()

--- a/appium/webdriver/appium_connection.py
+++ b/appium/webdriver/appium_connection.py
@@ -40,6 +40,7 @@ class AppiumConnection(RemoteConnection):
     """
 
     user_agent = f'{PREFIX_HEADER}{library_version()} ({RemoteConnection.user_agent})'
+    extra_headers = {}
 
     @classmethod
     def get_remote_connection_headers(cls, parsed_url: 'ParseResult', keep_alive: bool = True) -> Dict[str, Any]:
@@ -49,12 +50,8 @@ class AppiumConnection(RemoteConnection):
 
         if parsed_url.path.endswith('/session'):
             # https://github.com/appium/appium-base-driver/pull/400
-            if cls.extra_headers is None:
-                cls.extra_headers = {_HEADER_IDEMOTENCY_KEY: str(uuid.uuid4())}
-            else:
-                cls.extra_headers[_HEADER_IDEMOTENCY_KEY] = str(uuid.uuid4())
-        elif cls.extra_headers is not None and _HEADER_IDEMOTENCY_KEY in cls.extra_headers:
+            cls.extra_headers[_HEADER_IDEMOTENCY_KEY] = str(uuid.uuid4())
+        elif _HEADER_IDEMOTENCY_KEY in cls.extra_headers:
             del cls.extra_headers[_HEADER_IDEMOTENCY_KEY]
 
-        base_headers = super().get_remote_connection_headers(parsed_url, keep_alive=keep_alive)
-        return base_headers if cls.extra_headers is None else {**base_headers, **cls.extra_headers}
+        return {**super().get_remote_connection_headers(parsed_url, keep_alive=keep_alive), **cls.extra_headers}

--- a/appium/webdriver/appium_connection.py
+++ b/appium/webdriver/appium_connection.py
@@ -28,6 +28,19 @@ PREFIX_HEADER = 'appium/'
 _HEADER_IDEMOTENCY_KEY = 'X-Idempotency-Key'
 
 
+def _get_new_headers(key: str, headers: dict[str, str]) -> dict[str, str]:
+    """Return a new dictionary of heafers without the given key.
+    The key match is case-insensitive."""
+    new_headers = dict()
+
+    key = key.lower()
+    for k, v in headers.items():
+        if k.lower() == key:
+            continue
+        new_headers[k] = v
+    return new_headers
+
+
 class AppiumConnection(RemoteConnection):
     """
     A subclass of selenium.webdriver.remote.remote_connection.Remoteconnection.
@@ -51,7 +64,7 @@ class AppiumConnection(RemoteConnection):
         if parsed_url.path.endswith('/session'):
             # https://github.com/appium/appium-base-driver/pull/400
             cls.extra_headers[_HEADER_IDEMOTENCY_KEY] = str(uuid.uuid4())
-        elif _HEADER_IDEMOTENCY_KEY in cls.extra_headers:
-            del cls.extra_headers[_HEADER_IDEMOTENCY_KEY]
+        else:
+            cls.extra_headers = _get_new_headers(_HEADER_IDEMOTENCY_KEY, cls.extra_headers)
 
         return {**super().get_remote_connection_headers(parsed_url, keep_alive=keep_alive), **cls.extra_headers}

--- a/appium/webdriver/appium_connection.py
+++ b/appium/webdriver/appium_connection.py
@@ -25,20 +25,14 @@ if TYPE_CHECKING:
 
 PREFIX_HEADER = 'appium/'
 
-_HEADER_IDEMOTENCY_KEY = 'X-Idempotency-Key'
+HEADER_IDEMOTENCY_KEY = 'X-Idempotency-Key'
 
 
 def _get_new_headers(key: str, headers: Dict[str, str]) -> Dict[str, str]:
     """Return a new dictionary of heafers without the given key.
     The key match is case-insensitive."""
-    new_headers = dict()
-
     key = key.lower()
-    for k, v in headers.items():
-        if k.lower() == key:
-            continue
-        new_headers[k] = v
-    return new_headers
+    return {k: v for k, v in headers.items() if k.lower() != key}
 
 
 class AppiumConnection(RemoteConnection):
@@ -63,8 +57,8 @@ class AppiumConnection(RemoteConnection):
 
         if parsed_url.path.endswith('/session'):
             # https://github.com/appium/appium-base-driver/pull/400
-            cls.extra_headers[_HEADER_IDEMOTENCY_KEY] = str(uuid.uuid4())
+            cls.extra_headers[HEADER_IDEMOTENCY_KEY] = str(uuid.uuid4())
         else:
-            cls.extra_headers = _get_new_headers(_HEADER_IDEMOTENCY_KEY, cls.extra_headers)
+            cls.extra_headers = _get_new_headers(HEADER_IDEMOTENCY_KEY, cls.extra_headers)
 
         return {**super().get_remote_connection_headers(parsed_url, keep_alive=keep_alive), **cls.extra_headers}

--- a/appium/webdriver/appium_connection.py
+++ b/appium/webdriver/appium_connection.py
@@ -35,14 +35,15 @@ class AppiumConnection(RemoteConnection):
     def __init__(
         self,
         remote_server_addr: str,
-        keep_alive: bool = True,
+        keep_alive: Optional[bool] = True,
         ignore_proxy: Optional[bool] = False,
         init_args_for_pool_manager: Union[Dict[str, Any], None] = None,
         client_config: Optional[ClientConfig] = None,
     ):
         if client_config is None:
             client_config = ClientConfig(remote_server_addr=remote_server_addr)
-        client_config.keep_alive = keep_alive
+        if keep_alive is not None:
+            client_config.keep_alive = keep_alive
         if ignore_proxy is not None:
             client_config.ignore_proxy = ignore_proxy
         if init_args_for_pool_manager is not None:

--- a/appium/webdriver/appium_connection.py
+++ b/appium/webdriver/appium_connection.py
@@ -31,8 +31,8 @@ HEADER_IDEMOTENCY_KEY = 'X-Idempotency-Key'
 def _get_new_headers(key: str, headers: Dict[str, str]) -> Dict[str, str]:
     """Return a new dictionary of heafers without the given key.
     The key match is case-insensitive."""
-    key = key.lower()
-    return {k: v for k, v in headers.items() if k.lower() != key}
+    lower_key = key.lower()
+    return {k: v for k, v in headers.items() if k.lower() != lower_key}
 
 
 class AppiumConnection(RemoteConnection):

--- a/appium/webdriver/appium_connection.py
+++ b/appium/webdriver/appium_connection.py
@@ -35,7 +35,7 @@ class AppiumConnection(RemoteConnection):
     def __init__(
         self,
         remote_server_addr: str,
-        keep_alive: Optional[bool] = True,
+        keep_alive: Optional[bool] = False,
         ignore_proxy: Optional[bool] = False,
         init_args_for_pool_manager: Union[Dict[str, Any], None] = None,
         client_config: Optional[ClientConfig] = None,

--- a/appium/webdriver/extensions/android/activities.py
+++ b/appium/webdriver/extensions/android/activities.py
@@ -56,9 +56,8 @@ class Activities(CanExecuteCommands, CanExecuteScripts, CanRememberExtensionPres
             return False
 
     def _add_commands(self) -> None:
-        # noinspection PyProtectedMember,PyUnresolvedReferences
-        commands = self.command_executor._commands
-        commands[Command.GET_CURRENT_ACTIVITY] = (
+        self.command_executor.add_command(
+            Command.GET_CURRENT_ACTIVITY,
             'GET',
             '/session/$sessionId/appium/device/current_activity',
         )

--- a/appium/webdriver/extensions/android/common.py
+++ b/appium/webdriver/extensions/android/common.py
@@ -47,13 +47,13 @@ class Common(CanExecuteCommands, CanExecuteScripts, CanRememberExtensionPresence
             return self.mark_extension_absence(ext_name).execute(Command.GET_CURRENT_PACKAGE)['value']
 
     def _add_commands(self) -> None:
-        # noinspection PyProtectedMember,PyUnresolvedReferences
-        commands = self.command_executor._commands
-        commands[Command.GET_CURRENT_PACKAGE] = (
+        self.command_executor.add_command(
+            Command.GET_CURRENT_PACKAGE,
             'GET',
             '/session/$sessionId/appium/device/current_package',
         )
-        commands[Command.OPEN_NOTIFICATIONS] = (
+        self.command_executor.add_command(
+            Command.OPEN_NOTIFICATIONS,
             'POST',
             '/session/$sessionId/appium/device/open_notifications',
         )

--- a/appium/webdriver/extensions/android/display.py
+++ b/appium/webdriver/extensions/android/display.py
@@ -41,9 +41,8 @@ class Display(CanExecuteCommands, CanExecuteScripts, CanRememberExtensionPresenc
             return self.mark_extension_absence(ext_name).execute(Command.GET_DISPLAY_DENSITY)['value']
 
     def _add_commands(self) -> None:
-        # noinspection PyProtectedMember,PyUnresolvedReferences
-        commands = self.command_executor._commands
-        commands[Command.GET_DISPLAY_DENSITY] = (
+        self.command_executor.add_command(
+            Command.GET_DISPLAY_DENSITY,
             'GET',
             '/session/$sessionId/appium/device/display_density',
         )

--- a/appium/webdriver/extensions/android/gsm.py
+++ b/appium/webdriver/extensions/android/gsm.py
@@ -143,10 +143,6 @@ class Gsm(CanExecuteCommands, CanExecuteScripts, CanRememberExtensionPresence):
 
     def _add_commands(self) -> None:
         # noinspection PyProtectedMember,PyUnresolvedReferences
-        commands = self.command_executor._commands
-        commands[Command.MAKE_GSM_CALL] = ('POST', '/session/$sessionId/appium/device/gsm_call')
-        commands[Command.SET_GSM_SIGNAL] = (
-            'POST',
-            '/session/$sessionId/appium/device/gsm_signal',
-        )
-        commands[Command.SET_GSM_VOICE] = ('POST', '/session/$sessionId/appium/device/gsm_voice')
+        self.command_executor.add_command(Command.MAKE_GSM_CALL, 'POST', '/session/$sessionId/appium/device/gsm_call')
+        self.command_executor.add_command(Command.SET_GSM_SIGNAL, 'POST', '/session/$sessionId/appium/device/gsm_signal')
+        self.command_executor.add_command(Command.SET_GSM_VOICE, 'POST', '/session/$sessionId/appium/device/gsm_voice')

--- a/appium/webdriver/extensions/android/gsm.py
+++ b/appium/webdriver/extensions/android/gsm.py
@@ -142,7 +142,6 @@ class Gsm(CanExecuteCommands, CanExecuteScripts, CanRememberExtensionPresence):
         return self
 
     def _add_commands(self) -> None:
-        # noinspection PyProtectedMember,PyUnresolvedReferences
         self.command_executor.add_command(Command.MAKE_GSM_CALL, 'POST', '/session/$sessionId/appium/device/gsm_call')
         self.command_executor.add_command(Command.SET_GSM_SIGNAL, 'POST', '/session/$sessionId/appium/device/gsm_signal')
         self.command_executor.add_command(Command.SET_GSM_VOICE, 'POST', '/session/$sessionId/appium/device/gsm_voice')

--- a/appium/webdriver/extensions/android/network.py
+++ b/appium/webdriver/extensions/android/network.py
@@ -157,18 +157,19 @@ class Network(CanExecuteCommands, CanExecuteScripts, CanRememberExtensionPresenc
         return self
 
     def _add_commands(self) -> None:
-        # noinspection PyProtectedMember,PyUnresolvedReferences
-        commands = self.command_executor._commands
-        commands[Command.TOGGLE_WIFI] = ('POST', '/session/$sessionId/appium/device/toggle_wifi')
-        commands[Command.GET_NETWORK_CONNECTION] = (
+        self.command_executor.add_command(Command.TOGGLE_WIFI, 'POST', '/session/$sessionId/appium/device/toggle_wifi')
+        self.command_executor.add_command(
+            Command.GET_NETWORK_CONNECTION,
             'GET',
             '/session/$sessionId/network_connection',
         )
-        commands[Command.SET_NETWORK_CONNECTION] = (
+        self.command_executor.add_command(
+            Command.SET_NETWORK_CONNECTION,
             'POST',
             '/session/$sessionId/network_connection',
         )
-        commands[Command.SET_NETWORK_SPEED] = (
+        self.command_executor.add_command(
+            Command.SET_NETWORK_SPEED,
             'POST',
             '/session/$sessionId/appium/device/network_speed',
         )

--- a/appium/webdriver/extensions/android/performance.py
+++ b/appium/webdriver/extensions/android/performance.py
@@ -73,13 +73,13 @@ class Performance(CanExecuteCommands, CanExecuteScripts, CanRememberExtensionPre
             return self.mark_extension_absence(ext_name).execute(Command.GET_PERFORMANCE_DATA_TYPES)['value']
 
     def _add_commands(self) -> None:
-        # noinspection PyProtectedMember,PyUnresolvedReferences
-        commands = self.command_executor._commands
-        commands[Command.GET_PERFORMANCE_DATA] = (
+        self.command_executor.add_command(
+            Command.GET_PERFORMANCE_DATA,
             'POST',
             '/session/$sessionId/appium/getPerformanceData',
         )
-        commands[Command.GET_PERFORMANCE_DATA_TYPES] = (
+        self.command_executor.add_command(
+            Command.GET_PERFORMANCE_DATA_TYPES,
             'POST',
             '/session/$sessionId/appium/performanceData/types',
         )

--- a/appium/webdriver/extensions/android/power.py
+++ b/appium/webdriver/extensions/android/power.py
@@ -72,10 +72,9 @@ class Power(CanExecuteCommands, CanExecuteScripts, CanRememberExtensionPresence)
         return self
 
     def _add_commands(self) -> None:
-        # noinspection PyProtectedMember,PyUnresolvedReferences
-        commands = self.command_executor._commands
-        commands[Command.SET_POWER_CAPACITY] = (
+        self.command_executor.add_command(
+            Command.SET_POWER_CAPACITY,
             'POST',
             '/session/$sessionId/appium/device/power_capacity',
         )
-        commands[Command.SET_POWER_AC] = ('POST', '/session/$sessionId/appium/device/power_ac')
+        self.command_executor.add_command(Command.SET_POWER_AC, 'POST', '/session/$sessionId/appium/device/power_ac')

--- a/appium/webdriver/extensions/android/sms.py
+++ b/appium/webdriver/extensions/android/sms.py
@@ -47,6 +47,4 @@ class Sms(CanExecuteCommands, CanExecuteScripts, CanRememberExtensionPresence):
         return self
 
     def _add_commands(self) -> None:
-        # noinspection PyProtectedMember,PyUnresolvedReferences
-        commands = self.command_executor._commands
-        commands[Command.SEND_SMS] = ('POST', '/session/$sessionId/appium/device/send_sms')
+        self.command_executor.add_command(Command.SEND_SMS, 'POST', '/session/$sessionId/appium/device/send_sms')

--- a/appium/webdriver/extensions/android/system_bars.py
+++ b/appium/webdriver/extensions/android/system_bars.py
@@ -51,9 +51,8 @@ class SystemBars(CanExecuteCommands, CanExecuteScripts, CanRememberExtensionPres
             return self.mark_extension_absence(ext_name).execute(Command.GET_SYSTEM_BARS)['value']
 
     def _add_commands(self) -> None:
-        # noinspection PyProtectedMember,PyUnresolvedReferences
-        commands = self.command_executor._commands
-        commands[Command.GET_SYSTEM_BARS] = (
+        self.command_executor.add_command(
+            Command.GET_SYSTEM_BARS,
             'GET',
             '/session/$sessionId/appium/device/system_bars',
         )

--- a/appium/webdriver/extensions/applications.py
+++ b/appium/webdriver/extensions/applications.py
@@ -248,25 +248,27 @@ class Applications(CanExecuteCommands, CanExecuteScripts, CanRememberExtensionPr
             return self.mark_extension_absence(ext_name).execute(Command.GET_APP_STRINGS, data)['value']
 
     def _add_commands(self) -> None:
-        # noinspection PyProtectedMember,PyUnresolvedReferences
-        commands = self.command_executor._commands
-        commands[Command.BACKGROUND] = ('POST', '/session/$sessionId/appium/app/background')
-        commands[Command.IS_APP_INSTALLED] = (
+        self.command_executor.add_command(Command.BACKGROUND, 'POST', '/session/$sessionId/appium/app/background')
+        self.command_executor.add_command(
+            Command.IS_APP_INSTALLED,
             'POST',
             '/session/$sessionId/appium/device/app_installed',
         )
-        commands[Command.INSTALL_APP] = ('POST', '/session/$sessionId/appium/device/install_app')
-        commands[Command.REMOVE_APP] = ('POST', '/session/$sessionId/appium/device/remove_app')
-        commands[Command.TERMINATE_APP] = (
+        self.command_executor.add_command(Command.INSTALL_APP, 'POST', '/session/$sessionId/appium/device/install_app')
+        self.command_executor.add_command(Command.REMOVE_APP, 'POST', '/session/$sessionId/appium/device/remove_app')
+        self.command_executor.add_command(
+            Command.TERMINATE_APP,
             'POST',
             '/session/$sessionId/appium/device/terminate_app',
         )
-        commands[Command.ACTIVATE_APP] = (
+        self.command_executor.add_command(
+            Command.ACTIVATE_APP,
             'POST',
             '/session/$sessionId/appium/device/activate_app',
         )
-        commands[Command.QUERY_APP_STATE] = (
+        self.command_executor.add_command(
+            Command.QUERY_APP_STATE,
             'POST',
             '/session/$sessionId/appium/device/app_state',
         )
-        commands[Command.GET_APP_STRINGS] = ('POST', '/session/$sessionId/appium/app/strings')
+        self.command_executor.add_command(Command.GET_APP_STRINGS, 'POST', '/session/$sessionId/appium/app/strings')

--- a/appium/webdriver/extensions/clipboard.py
+++ b/appium/webdriver/extensions/clipboard.py
@@ -95,13 +95,13 @@ class Clipboard(CanExecuteCommands, CanExecuteScripts, CanRememberExtensionPrese
         return self.get_clipboard(ClipboardContentType.PLAINTEXT).decode('UTF-8')
 
     def _add_commands(self) -> None:
-        # noinspection PyProtectedMember,PyUnresolvedReferences
-        commands = self.command_executor._commands
-        commands[Command.SET_CLIPBOARD] = (
+        self.command_executor.add_command(
+            Command.SET_CLIPBOARD,
             'POST',
             '/session/$sessionId/appium/device/set_clipboard',
         )
-        commands[Command.GET_CLIPBOARD] = (
+        self.command_executor.add_command(
+            Command.GET_CLIPBOARD,
             'POST',
             '/session/$sessionId/appium/device/get_clipboard',
         )

--- a/appium/webdriver/extensions/context.py
+++ b/appium/webdriver/extensions/context.py
@@ -58,8 +58,6 @@ class Context(CanExecuteCommands):
         return self.current_context
 
     def _add_commands(self) -> None:
-        # noinspection PyProtectedMember,PyUnresolvedReferences
-        commands = self.command_executor._commands
-        commands[Command.CONTEXTS] = ('GET', '/session/$sessionId/contexts')
-        commands[Command.GET_CURRENT_CONTEXT] = ('GET', '/session/$sessionId/context')
-        commands[Command.SWITCH_TO_CONTEXT] = ('POST', '/session/$sessionId/context')
+        self.command_executor.add_command(Command.CONTEXTS, 'GET', '/session/$sessionId/contexts')
+        self.command_executor.add_command(Command.GET_CURRENT_CONTEXT, 'GET', '/session/$sessionId/context')
+        self.command_executor.add_command(Command.SWITCH_TO_CONTEXT, 'POST', '/session/$sessionId/context')

--- a/appium/webdriver/extensions/device_time.py
+++ b/appium/webdriver/extensions/device_time.py
@@ -63,13 +63,13 @@ class DeviceTime(CanExecuteCommands, CanExecuteScripts, CanRememberExtensionPres
             return self.mark_extension_absence(ext_name).execute(Command.GET_DEVICE_TIME_POST, {'format': format})['value']
 
     def _add_commands(self) -> None:
-        # noinspection PyProtectedMember,PyUnresolvedReferences
-        commands = self.command_executor._commands
-        commands[Command.GET_DEVICE_TIME_GET] = (
+        self.command_executor.add_command(
+            Command.GET_DEVICE_TIME_GET,
             'GET',
             '/session/$sessionId/appium/device/system_time',
         )
-        commands[Command.GET_DEVICE_TIME_POST] = (
+        self.command_executor.add_command(
+            Command.GET_DEVICE_TIME_POST,
             'POST',
             '/session/$sessionId/appium/device/system_time',
         )

--- a/appium/webdriver/extensions/execute_driver.py
+++ b/appium/webdriver/extensions/execute_driver.py
@@ -57,6 +57,4 @@ class ExecuteDriver(CanExecuteCommands):
         return Result(response)
 
     def _add_commands(self) -> None:
-        # noinspection PyProtectedMember,PyUnresolvedReferences
-        commands = self.command_executor._commands
-        commands[Command.EXECUTE_DRIVER] = ('POST', '/session/$sessionId/appium/execute_driver')
+        self.command_executor.add_command(Command.EXECUTE_DRIVER, 'POST', '/session/$sessionId/appium/execute_driver')

--- a/appium/webdriver/extensions/hw_actions.py
+++ b/appium/webdriver/extensions/hw_actions.py
@@ -132,18 +132,18 @@ class HardwareActions(CanExecuteCommands, CanExecuteScripts, CanRememberExtensio
         return self
 
     def _add_commands(self) -> None:
-        # noinspection PyProtectedMember,PyUnresolvedReferences
-        commands = self.command_executor._commands
-        commands[Command.LOCK] = ('POST', '/session/$sessionId/appium/device/lock')
-        commands[Command.UNLOCK] = ('POST', '/session/$sessionId/appium/device/unlock')
-        commands[Command.IS_LOCKED] = ('POST', '/session/$sessionId/appium/device/is_locked')
-        commands[Command.SHAKE] = ('POST', '/session/$sessionId/appium/device/shake')
-        commands[Command.TOUCH_ID] = ('POST', '/session/$sessionId/appium/simulator/touch_id')
-        commands[Command.TOGGLE_TOUCH_ID_ENROLLMENT] = (
+        self.command_executor.add_command(Command.LOCK, 'POST', '/session/$sessionId/appium/device/lock')
+        self.command_executor.add_command(Command.UNLOCK, 'POST', '/session/$sessionId/appium/device/unlock')
+        self.command_executor.add_command(Command.IS_LOCKED, 'POST', '/session/$sessionId/appium/device/is_locked')
+        self.command_executor.add_command(Command.SHAKE, 'POST', '/session/$sessionId/appium/device/shake')
+        self.command_executor.add_command(Command.TOUCH_ID, 'POST', '/session/$sessionId/appium/simulator/touch_id')
+        self.command_executor.add_command(
+            Command.TOGGLE_TOUCH_ID_ENROLLMENT,
             'POST',
             '/session/$sessionId/appium/simulator/toggle_touch_id_enrollment',
         )
-        commands[Command.FINGER_PRINT] = (
+        self.command_executor.add_command(
+            Command.FINGER_PRINT,
             'POST',
             '/session/$sessionId/appium/device/finger_print',
         )

--- a/appium/webdriver/extensions/images_comparison.py
+++ b/appium/webdriver/extensions/images_comparison.py
@@ -129,6 +129,4 @@ class ImagesComparison(CanExecuteCommands):
         return self.execute(Command.COMPARE_IMAGES, options)['value']
 
     def _add_commands(self) -> None:
-        # noinspection PyProtectedMember,PyUnresolvedReferences
-        commands = self.command_executor._commands
-        commands[Command.COMPARE_IMAGES] = ('POST', '/session/$sessionId/appium/compare_images')
+        self.command_executor.add_command(Command.COMPARE_IMAGES, 'POST', '/session/$sessionId/appium/compare_images')

--- a/appium/webdriver/extensions/keyboard.py
+++ b/appium/webdriver/extensions/keyboard.py
@@ -145,22 +145,24 @@ class Keyboard(CanExecuteCommands, CanExecuteScripts, CanRememberExtensionPresen
         return self
 
     def _add_commands(self) -> None:
-        # noinspection PyProtectedMember,PyUnresolvedReferences
-        commands = self.command_executor._commands
-        commands[Command.HIDE_KEYBOARD] = (
+        self.command_executor.add_command(
+            Command.HIDE_KEYBOARD,
             'POST',
             '/session/$sessionId/appium/device/hide_keyboard',
         )
-        commands[Command.IS_KEYBOARD_SHOWN] = (
+        self.command_executor.add_command(
+            Command.IS_KEYBOARD_SHOWN,
             'GET',
             '/session/$sessionId/appium/device/is_keyboard_shown',
         )
-        commands[Command.KEY_EVENT] = ('POST', '/session/$sessionId/appium/device/keyevent')
-        commands[Command.PRESS_KEYCODE] = (
+        self.command_executor.add_command(Command.KEY_EVENT, 'POST', '/session/$sessionId/appium/device/keyevent')
+        self.command_executor.add_command(
+            Command.PRESS_KEYCODE,
             'POST',
             '/session/$sessionId/appium/device/press_keycode',
         )
-        commands[Command.LONG_PRESS_KEYCODE] = (
+        self.command_executor.add_command(
+            Command.LONG_PRESS_KEYCODE,
             'POST',
             '/session/$sessionId/appium/device/long_press_keycode',
         )

--- a/appium/webdriver/extensions/location.py
+++ b/appium/webdriver/extensions/location.py
@@ -89,11 +89,10 @@ class Location(CanExecuteCommands, CanExecuteScripts):
 
     def _add_commands(self) -> None:
         """Add location endpoints. They are not int w3c spec."""
-        # noinspection PyProtectedMember,PyUnresolvedReferences
-        commands = self.command_executor._commands
-        commands[Command.TOGGLE_LOCATION_SERVICES] = (
+        self.command_executor.add_command(
+            Command.TOGGLE_LOCATION_SERVICES,
             'POST',
             '/session/$sessionId/appium/device/toggle_location_services',
         )
-        commands[Command.GET_LOCATION] = ('GET', '/session/$sessionId/location')
-        commands[Command.SET_LOCATION] = ('POST', '/session/$sessionId/location')
+        self.command_executor.add_command(Command.GET_LOCATION, 'GET', '/session/$sessionId/location')
+        self.command_executor.add_command(Command.SET_LOCATION, 'POST', '/session/$sessionId/location')

--- a/appium/webdriver/extensions/log_event.py
+++ b/appium/webdriver/extensions/log_event.py
@@ -64,7 +64,5 @@ class LogEvent(CanExecuteCommands):
         return self
 
     def _add_commands(self) -> None:
-        # noinspection PyProtectedMember,PyUnresolvedReferences
-        commands = self.command_executor._commands
-        commands[Command.GET_EVENTS] = ('POST', '/session/$sessionId/appium/events')
-        commands[Command.LOG_EVENT] = ('POST', '/session/$sessionId/appium/log_event')
+        self.command_executor.add_command(Command.GET_EVENTS, 'POST', '/session/$sessionId/appium/events')
+        self.command_executor.add_command(Command.LOG_EVENT, 'POST', '/session/$sessionId/appium/log_event')

--- a/appium/webdriver/extensions/remote_fs.py
+++ b/appium/webdriver/extensions/remote_fs.py
@@ -105,8 +105,6 @@ class RemoteFS(CanExecuteCommands, CanExecuteScripts, CanRememberExtensionPresen
         return self
 
     def _add_commands(self) -> None:
-        # noinspection PyProtectedMember,PyUnresolvedReferences
-        commands = self.command_executor._commands
-        commands[Command.PULL_FILE] = ('POST', '/session/$sessionId/appium/device/pull_file')
-        commands[Command.PULL_FOLDER] = ('POST', '/session/$sessionId/appium/device/pull_folder')
-        commands[Command.PUSH_FILE] = ('POST', '/session/$sessionId/appium/device/push_file')
+        self.command_executor.add_command(Command.PULL_FILE, 'POST', '/session/$sessionId/appium/device/pull_file')
+        self.command_executor.add_command(Command.PULL_FOLDER, 'POST', '/session/$sessionId/appium/device/pull_folder')
+        self.command_executor.add_command(Command.PUSH_FILE, 'POST', '/session/$sessionId/appium/device/push_file')

--- a/appium/webdriver/extensions/screen_record.py
+++ b/appium/webdriver/extensions/screen_record.py
@@ -195,13 +195,13 @@ class ScreenRecord(CanExecuteCommands):
         return self.execute(Command.STOP_RECORDING_SCREEN, {'options': options})['value']
 
     def _add_commands(self) -> None:
-        # noinspection PyProtectedMember
-        commands = self.command_executor._commands
-        commands[Command.START_RECORDING_SCREEN] = (
+        self.command_executor.add_command(
+            Command.START_RECORDING_SCREEN,
             'POST',
             '/session/$sessionId/appium/start_recording_screen',
         )
-        commands[Command.STOP_RECORDING_SCREEN] = (
+        self.command_executor.add_command(
+            Command.STOP_RECORDING_SCREEN,
             'POST',
             '/session/$sessionId/appium/stop_recording_screen',
         )

--- a/appium/webdriver/extensions/session.py
+++ b/appium/webdriver/extensions/session.py
@@ -38,6 +38,4 @@ class Session(CanExecuteCommands):
             return {}
 
     def _add_commands(self) -> None:
-        # noinspection PyProtectedMember,PyUnresolvedReferences
-        commands = self.command_executor._commands
-        commands[Command.GET_SESSION] = ('GET', '/session/$sessionId')
+        self.command_executor.add_command(Command.GET_SESSION, 'GET', '/session/$sessionId')

--- a/appium/webdriver/extensions/settings.py
+++ b/appium/webdriver/extensions/settings.py
@@ -45,7 +45,5 @@ class Settings(CanExecuteCommands):
         return self
 
     def _add_commands(self) -> None:
-        # noinspection PyProtectedMember,PyUnresolvedReferences
-        commands = self.command_executor._commands
-        commands[Command.GET_SETTINGS] = ('GET', '/session/$sessionId/appium/settings')
-        commands[Command.UPDATE_SETTINGS] = ('POST', '/session/$sessionId/appium/settings')
+        self.command_executor.add_command(Command.GET_SETTINGS, 'GET', '/session/$sessionId/appium/settings')
+        self.command_executor.add_command(Command.UPDATE_SETTINGS, 'POST', '/session/$sessionId/appium/settings')

--- a/appium/webdriver/locator_converter.py
+++ b/appium/webdriver/locator_converter.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Tuple
+
+from selenium.webdriver.remote.locator_converter import LocatorConverter
+
+
+class AppiumLocatorConverter(LocatorConverter):
+    """A custom locator converter in Appium.
+
+    Appium supports locators which are not defined in W3C WebDriver,
+    so Appium Python client wants to keep the given locators
+    to the Appium server as-is.
+    """
+
+    def convert(self, by: str, value: str) -> Tuple[str, str]:
+        return (by, value)

--- a/appium/webdriver/webdriver.py
+++ b/appium/webdriver/webdriver.py
@@ -260,8 +260,7 @@ class WebDriver(
             # add a new method named 'instance.method_name()' and call it
             setattr(WebDriver, method_name, getattr(instance, method_name))
             method, url_cmd = instance.add_command()
-            # noinspection PyProtectedMember
-            self.command_executor._commands[method_name] = (method.upper(), url_cmd)  # type: ignore
+            self.command_executor.add_command(method_name, method.upper(), url_cmd)
 
     def delete_extensions(self) -> None:
         """Delete extensions added in the class with 'setattr'"""
@@ -440,31 +439,29 @@ class WebDriver(
                 if get_atter:
                     get_atter(self)
 
-        # noinspection PyProtectedMember,PyUnresolvedReferences
-        commands = self.command_executor._commands
-
-        commands[Command.GET_STATUS] = ('GET', '/status')
+        self.command_executor.add_command(Command.GET_STATUS, 'GET', '/status')
 
         # FIXME: remove after a while as MJSONWP
-        commands[Command.TOUCH_ACTION] = ('POST', '/session/$sessionId/touch/perform')
-        commands[Command.MULTI_ACTION] = ('POST', '/session/$sessionId/touch/multi/perform')
+        self.command_executor.add_command(Command.TOUCH_ACTION, 'POST', '/session/$sessionId/touch/perform')
+        self.command_executor.add_command(Command.MULTI_ACTION, 'POST', '/session/$sessionId/touch/multi/perform')
 
         # TODO Move commands for element to webelement
-        commands[Command.CLEAR] = ('POST', '/session/$sessionId/element/$id/clear')
-        commands[Command.LOCATION_IN_VIEW] = (
+        self.command_executor.add_command(Command.CLEAR, 'POST', '/session/$sessionId/element/$id/clear')
+        self.command_executor.add_command(
+            Command.LOCATION_IN_VIEW,
             'GET',
             '/session/$sessionId/element/$id/location_in_view',
         )
 
         # MJSONWP for Selenium v4
-        commands[Command.IS_ELEMENT_DISPLAYED] = ('GET', '/session/$sessionId/element/$id/displayed')
-        commands[Command.GET_CAPABILITIES] = ('GET', '/session/$sessionId')
+        self.command_executor.add_command(Command.IS_ELEMENT_DISPLAYED, 'GET', '/session/$sessionId/element/$id/displayed')
+        self.command_executor.add_command(Command.GET_CAPABILITIES, 'GET', '/session/$sessionId')
 
-        commands[Command.GET_SCREEN_ORIENTATION] = ('GET', '/session/$sessionId/orientation')
-        commands[Command.SET_SCREEN_ORIENTATION] = ('POST', '/session/$sessionId/orientation')
+        self.command_executor.add_command(Command.GET_SCREEN_ORIENTATION, 'GET', '/session/$sessionId/orientation')
+        self.command_executor.add_command(Command.SET_SCREEN_ORIENTATION, 'POST', '/session/$sessionId/orientation')
 
         # override for Appium 1.x
         # Appium 2.0 and Appium 1.22 work with `/se/log` and `/se/log/types`
         # FIXME: remove after a while
-        commands[Command.GET_LOG] = ('POST', '/session/$sessionId/log')
-        commands[Command.GET_AVAILABLE_LOG_TYPES] = ('GET', '/session/$sessionId/log/types')
+        self.command_executor.add_command(Command.GET_LOG, 'POST', '/session/$sessionId/log')
+        self.command_executor.add_command(Command.GET_AVAILABLE_LOG_TYPES, 'GET', '/session/$sessionId/log/types')

--- a/appium/webdriver/webdriver.py
+++ b/appium/webdriver/webdriver.py
@@ -71,7 +71,7 @@ class AppiumLocatorConverter:
     to the Appium server as-is.
     """
 
-    def convert(self, by: str, value: str) -> tuple[str, str]:
+    def convert(self, by: str, value: str) -> Tuple[str, str]:
         return (by, value)
 
 

--- a/appium/webdriver/webdriver.py
+++ b/appium/webdriver/webdriver.py
@@ -64,7 +64,14 @@ from .webelement import WebElement as MobileWebElement
 
 
 class AppiumLocatorConverter:
-    def convert(self, by, value):
+    """A custom locator converter in Appium.
+
+    Appium supports locators which are not defined in W3C WebDriver,
+    so Appium Python client wants to keep the given locators
+    to the Appium server as-is.
+    """
+
+    def convert(self, by: str, value: str) -> tuple[str, str]:
         return (by, value)
 
 
@@ -222,6 +229,11 @@ class WebDriver(
             )
             client_config.remote_server_addr = command_executor
             command_executor = AppiumConnection(remote_server_addr=command_executor, client_config=client_config)
+        elif isinstance(command_executor, AppiumConnection) and strict_ssl is False:
+            logger.warning(
+                "Please set 'ignore_certificates' in the given 'appium.webdriver.appium_connection.AppiumConnection' or "
+                "'selenium.webdriver.remote.client_config.ClientConfig' instead. Ignoring."
+            )
 
         super().__init__(
             command_executor=command_executor,

--- a/appium/webdriver/webdriver.py
+++ b/appium/webdriver/webdriver.py
@@ -58,21 +58,10 @@ from .extensions.remote_fs import RemoteFS
 from .extensions.screen_record import ScreenRecord
 from .extensions.session import Session
 from .extensions.settings import Settings
+from .locator_converter import AppiumLocatorConverter
 from .mobilecommand import MobileCommand as Command
 from .switch_to import MobileSwitchTo
 from .webelement import WebElement as MobileWebElement
-
-
-class AppiumLocatorConverter:
-    """A custom locator converter in Appium.
-
-    Appium supports locators which are not defined in W3C WebDriver,
-    so Appium Python client wants to keep the given locators
-    to the Appium server as-is.
-    """
-
-    def convert(self, by: str, value: str) -> Tuple[str, str]:
-        return (by, value)
 
 
 class ExtensionBase:

--- a/appium/webdriver/webdriver.py
+++ b/appium/webdriver/webdriver.py
@@ -217,10 +217,11 @@ class WebDriver(
         client_config: Optional[ClientConfig] = None,
     ):
         if isinstance(command_executor, str):
-            command_executor = AppiumConnection(command_executor, keep_alive=keep_alive)
-
-        if client_config is None:
-            client_config = ClientConfig(remote_server_addr=command_executor, ignore_certificates=not strict_ssl)
+            client_config = client_config or ClientConfig(
+                remote_server_addr=command_executor, keep_alive=keep_alive, ignore_certificates=not strict_ssl
+            )
+            client_config.remote_server_addr = command_executor
+            command_executor = AppiumConnection(remote_server_addr=command_executor, client_config=client_config)
 
         super().__init__(
             command_executor=command_executor,

--- a/appium/webdriver/webelement.py
+++ b/appium/webdriver/webelement.py
@@ -12,14 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Callable, Dict, List, Optional, Union
+from typing import Callable, Dict, Optional, Union
 
 from selenium.webdriver.common.utils import keys_to_typing
 from selenium.webdriver.remote.command import Command as RemoteCommand
 from selenium.webdriver.remote.webelement import WebElement as SeleniumWebElement
 from typing_extensions import Self
-
-from appium.webdriver.common.appiumby import AppiumBy
 
 from .mobilecommand import MobileCommand as Command
 
@@ -79,70 +77,6 @@ class WebElement(SeleniumWebElement):
         Override for Appium
         """
         return self._execute(Command.IS_ELEMENT_DISPLAYED)['value']
-
-    def find_element(self, by: str = AppiumBy.ID, value: Union[str, Dict, None] = None) -> 'WebElement':
-        """Find an element given a AppiumBy strategy and locator
-
-        Override for Appium
-
-        Prefer the find_element_by_* methods when possible.
-
-        Args:
-            by: The strategy
-            value: The locator
-
-        Usage:
-            element = element.find_element(AppiumBy.ID, 'foo')
-
-        Returns:
-            `appium.webdriver.webelement.WebElement`
-        """
-        # We prefer to patch locators in the client code
-        # Checking current context every time a locator is accessed could significantly slow down tests
-        # Check https://github.com/appium/python-client/pull/724 before submitting any issue
-        # if by == By.ID:
-        #     by = By.CSS_SELECTOR
-        #     value = '[id="%s"]' % value
-        # elif by == By.TAG_NAME:
-        #     by = By.CSS_SELECTOR
-        # elif by == By.CLASS_NAME:
-        #     by = By.CSS_SELECTOR
-        #     value = ".%s" % value
-        # elif by == By.NAME:
-        #     by = By.CSS_SELECTOR
-        #     value = '[name="%s"]' % value
-
-        return self._execute(RemoteCommand.FIND_CHILD_ELEMENT, {'using': by, 'value': value})['value']
-
-    def find_elements(self, by: str = AppiumBy.ID, value: Union[str, Dict, None] = None) -> List['WebElement']:
-        """Find elements given a AppiumBy strategy and locator
-
-        Args:
-            by: The strategy
-            value: The locator
-
-        Usage:
-            element = element.find_elements(AppiumBy.CLASS_NAME, 'foo')
-
-        Returns:
-            :obj:`list` of :obj:`appium.webdriver.webelement.WebElement`
-        """
-        # We prefer to patch locators in the client code
-        # Checking current context every time a locator is accessed could significantly slow down tests
-        # Check https://github.com/appium/python-client/pull/724 before submitting any issue
-        # if by == By.ID:
-        #     by = By.CSS_SELECTOR
-        #     value = '[id="%s"]' % value
-        # elif by == By.TAG_NAME:
-        #     by = By.CSS_SELECTOR
-        # elif by == By.CLASS_NAME:
-        #     by = By.CSS_SELECTOR
-        #     value = ".%s" % value
-        # elif by == By.NAME:
-        #     by = By.CSS_SELECTOR
-        #     value = '[name="%s"]' % value
-
-        return self._execute(RemoteCommand.FIND_CHILD_ELEMENTS, {'using': by, 'value': value})['value']
 
     def clear(self) -> Self:
         """Clears text.

--- a/setup.py
+++ b/setup.py
@@ -49,5 +49,5 @@ setup(
         'Topic :: Software Development :: Quality Assurance',
         'Topic :: Software Development :: Testing',
     ],
-    install_requires=['selenium ~= 4.12'],
+    install_requires=['selenium ~= 4.26'],
 )

--- a/setup.py
+++ b/setup.py
@@ -49,5 +49,5 @@ setup(
         'Topic :: Software Development :: Quality Assurance',
         'Topic :: Software Development :: Testing',
     ],
-    install_requires=['selenium ~= 4.26'],
+    install_requires=['selenium ~= 4.26, < 5.0'],
 )

--- a/test/unit/webdriver/appium_connection_test.py
+++ b/test/unit/webdriver/appium_connection_test.py
@@ -29,3 +29,11 @@ class AppiumConnectionTest(unittest.TestCase):
         )
         self.assertIsNone(headers.get('X-Idempotency-Key'))
         self.assertEqual(headers.get('custom'), 'header')
+
+    def test_remove_headers_case_insensitive(self):
+        for h in ['X-Idempotency-Key', 'X-idempotency-Key', 'x-idempotency-key']:
+            appium_connection.AppiumConnection.extra_headers = {h: 'value'}
+            appium_connection.AppiumConnection.get_remote_connection_headers(
+                parse.urlparse('http://http://127.0.0.1:4723/session/session_id')
+            )
+            self.assertEqual(appium_connection.AppiumConnection.extra_headers, {})

--- a/test/unit/webdriver/appium_connection_test.py
+++ b/test/unit/webdriver/appium_connection_test.py
@@ -1,0 +1,31 @@
+import unittest
+from urllib import parse
+
+from appium.webdriver import appium_connection
+
+
+class AppiumConnectionTest(unittest.TestCase):
+    def test_get_remote_connection_headers(self):
+        headers = appium_connection.AppiumConnection.get_remote_connection_headers(
+            parse.urlparse('http://http://127.0.0.1:4723/session')
+        )
+        self.assertIsNotNone(headers.get('X-Idempotency-Key'))
+
+        headers = appium_connection.AppiumConnection.get_remote_connection_headers(
+            parse.urlparse('http://http://127.0.0.1:4723/session/session_id')
+        )
+        self.assertIsNone(headers.get('X-Idempotency-Key'))
+
+        appium_connection.AppiumConnection.extra_headers = {'custom': 'header'}
+
+        headers = appium_connection.AppiumConnection.get_remote_connection_headers(
+            parse.urlparse('http://http://127.0.0.1:4723/session')
+        )
+        self.assertIsNotNone(headers.get('X-Idempotency-Key'))
+        self.assertEqual(headers.get('custom'), 'header')
+
+        headers = appium_connection.AppiumConnection.get_remote_connection_headers(
+            parse.urlparse('http://http://127.0.0.1:4723/session/session_id')
+        )
+        self.assertIsNone(headers.get('X-Idempotency-Key'))
+        self.assertEqual(headers.get('custom'), 'header')

--- a/test/unit/webdriver/search_context/android_test.py
+++ b/test/unit/webdriver/search_context/android_test.py
@@ -23,6 +23,62 @@ from test.unit.helper.test_helper import android_w3c_driver, appium_command, get
 
 class TestWebDriverAndroidSearchContext(object):
     @httpretty.activate
+    def test_find_element_by_id(self):
+        driver = android_w3c_driver()
+        httpretty.register_uri(
+            httpretty.POST,
+            appium_command('/session/1234567890/element'),
+            body='{"value": {"element-6066-11e4-a52e-4f735466cecf": "element-id"}}',
+        )
+        el = driver.find_element(
+            by=AppiumBy.ID,
+            value='id data',
+        )
+
+        d = get_httpretty_request_body(httpretty.last_request())
+        assert d['using'] == 'id'
+        assert d['value'] == 'id data'
+        assert isinstance(el, MobileWebElement)
+
+    @httpretty.activate
+    def test_find_elements_by_id(self):
+        driver = android_w3c_driver()
+        httpretty.register_uri(
+            httpretty.POST,
+            appium_command('/session/1234567890/elements'),
+            body='{"value": [{"element-6066-11e4-a52e-4f735466cecf": "element-id1"}, '
+            '{"element-6066-11e4-a52e-4f735466cecf": "element-id2"}]}',
+        )
+        els = driver.find_elements(
+            by=AppiumBy.ID,
+            value='id data',
+        )
+
+        d = get_httpretty_request_body(httpretty.last_request())
+        assert d['using'] == 'id'
+        assert d['value'] == 'id data'
+        assert isinstance(els[0], MobileWebElement)
+
+    @httpretty.activate
+    def test_find_child_element_by_id(self):
+        driver = android_w3c_driver()
+        element = MobileWebElement(driver, 'element_id')
+        httpretty.register_uri(
+            httpretty.POST,
+            appium_command('/session/1234567890/element/element_id/element'),
+            body='{"value": {"element-6066-11e4-a52e-4f735466cecf": "child-element-id"}}',
+        )
+        el = element.find_element(
+            by=AppiumBy.ID,
+            value='id data',
+        )
+
+        d = get_httpretty_request_body(httpretty.last_request())
+        assert d['using'] == 'id'
+        assert d['value'] == 'id data'
+        assert isinstance(el, MobileWebElement)
+
+    @httpretty.activate
     def test_find_element_by_android_data_matcher(self):
         driver = android_w3c_driver()
         httpretty.register_uri(

--- a/test/unit/webdriver/webdriver_test.py
+++ b/test/unit/webdriver/webdriver_test.py
@@ -348,7 +348,8 @@ class TestWebDriverWebDriver:
 
         request = httpretty.HTTPretty.latest_requests[0]
         assert request.headers['content-type'] == 'application/json;charset=UTF-8'
-        assert request.headers['user-agent'] == 'appium/4.1.0 (selenium/4.26.0 (python mac))'
+        assert request.headers['user-agent'].startswith('appium/')
+        assert '(selenium/' in request.headers['user-agent']
 
         request_json = json.loads(httpretty.HTTPretty.latest_requests[0].body.decode('utf-8'))
         assert request_json.get('capabilities') is not None

--- a/test/unit/webdriver/webdriver_test.py
+++ b/test/unit/webdriver/webdriver_test.py
@@ -18,7 +18,6 @@ import httpretty
 import urllib3
 from mock import patch
 
-from appium import version as appium_version
 from appium import webdriver
 from appium.options.android import UiAutomator2Options
 from appium.webdriver.appium_connection import AppiumConnection
@@ -54,7 +53,8 @@ class TestWebDriverWebDriver:
 
         request = httpretty.HTTPretty.latest_requests[0]
         assert request.headers['content-type'] == 'application/json;charset=UTF-8'
-        assert f'appium/{appium_version.version} (selenium' in request.headers['user-agent']
+        assert request.headers['user-agent'].startswith('appium/')
+        assert '(selenium/' in request.headers['user-agent']
 
         request_json = json.loads(httpretty.HTTPretty.latest_requests[0].body.decode('utf-8'))
         assert request_json.get('capabilities') is not None
@@ -130,7 +130,7 @@ class TestWebDriverWebDriver:
             direct_connection=True,
         )
 
-        assert 'http://localhost2:4800/special/path/wd/hub' == driver.command_executor._url
+        assert 'http://localhost2:4800/special/path/wd/hub' == driver.command_executor._client_config.remote_server_addr
         assert ['NATIVE_APP', 'CHROMIUM'] == driver.contexts
         assert isinstance(driver.command_executor, AppiumConnection)
 
@@ -170,7 +170,7 @@ class TestWebDriverWebDriver:
             direct_connection=True,
         )
 
-        assert SERVER_URL_BASE == driver.command_executor._url
+        assert SERVER_URL_BASE == driver.command_executor._client_config.remote_server_addr
         assert ['NATIVE_APP', 'CHROMIUM'] == driver.contexts
         assert isinstance(driver.command_executor, AppiumConnection)
 
@@ -303,7 +303,8 @@ class TestWebDriverWebDriver:
 
         request = httpretty.HTTPretty.latest_requests[0]
         assert request.headers['content-type'] == 'application/json;charset=UTF-8'
-        assert f'appium/{appium_version.version} (selenium' in request.headers['user-agent']
+        assert request.headers['user-agent'].startswith('appium/')
+        assert '(selenium/' in request.headers['user-agent']
 
         request_json = json.loads(httpretty.HTTPretty.latest_requests[0].body.decode('utf-8'))
         assert request_json.get('capabilities') is not None
@@ -347,7 +348,7 @@ class TestWebDriverWebDriver:
 
         request = httpretty.HTTPretty.latest_requests[0]
         assert request.headers['content-type'] == 'application/json;charset=UTF-8'
-        assert f'appium/{appium_version.version} (selenium' in request.headers['user-agent']
+        assert request.headers['user-agent'] == 'appium/4.1.0 (selenium/4.26.0 (python mac))'
 
         request_json = json.loads(httpretty.HTTPretty.latest_requests[0].body.decode('utf-8'))
         assert request_json.get('capabilities') is not None


### PR DESCRIPTION
Python selenium client has two major changes:
- https://github.com/appium/python-client/pull/1045 related
    - Removed `find_element` and `find_elements` override
    - Removed strict_ssl by this library. Refer to the selenium's implementation (code removal)
    - Used `RemoteConnection.user_agent` to define UA
    - Used `RemoteConnection.extra_headers` to define extra headers
    - Used `self.command_executor.add_command` to define methods
- Use ClientConfig for the AppiumConnection
    - https://github.com/SeleniumHQ/selenium/blob/trunk/py/selenium/webdriver/remote/client_config.py#L29
    - Maybe... https://github.com/SeleniumHQ/selenium/blob/trunk/py/selenium/webdriver/remote/client_config.py#L57C34-L57C56 would help...?
- https://github.com/SeleniumHQ/selenium/pull/14578 This PR introduced hardcoded 120 seconds request timeout
    - It breaks Appium's long new session request. https://github.com/SeleniumHQ/selenium/pull/14692 will fix this issue but we should prepare a guidance about how to set timeout since this behavior change could affect users

## test

Current unit tests cover find_element/s, user agent, extra headers and commands.
The functional tests cover session creation, do some actions and deleting the session.