### PR TITLE
chore: update pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
-  rev: v0.6.9
+  rev: v0.7.2
   hooks:
     # Run the linter.
     - id: ruff

--- a/Pipfile
+++ b/Pipfile
@@ -6,7 +6,7 @@ verify_ssl = true
 [dev-packages]
 httpretty = "~=1.1"
 mock = "~=5.1"
-pre-commit = "~=2.21"
+pre-commit = "~=4.0"
 pytest = "~=8.3"
 pytest-cov = "~=5.0"
 python-dateutil = "~=2.9"

--- a/Pipfile
+++ b/Pipfile
@@ -6,7 +6,7 @@ verify_ssl = true
 [dev-packages]
 httpretty = "~=1.1"
 mock = "~=5.1"
-pre-commit = "~=4.0"
+pre-commit = "~=3.5"
 pytest = "~=8.3"
 pytest-cov = "~=5.0"
 python-dateutil = "~=2.9"


### PR DESCRIPTION
instead of https://github.com/appium/python-client/pull/1041

The pre-commit v3.5.0 can work with python 3.8