### PR TITLE
test: Move `app_test.py` to pytest style

### DIFF
--- a/test/unit/webdriver/app_test.py
+++ b/test/unit/webdriver/app_test.py
@@ -11,267 +11,154 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 import httpretty
+import pytest
 
 from appium.webdriver.applicationstate import ApplicationState
 from appium.webdriver.webdriver import WebDriver
 from test.unit.helper.test_helper import android_w3c_driver, appium_command, get_httpretty_request_body, ios_w3c_driver
 
 
-class TestWebDriverAppAndroid(object):
-    @httpretty.activate
-    def test_install_app(self):
-        driver = android_w3c_driver()
-        httpretty.register_uri(httpretty.POST, appium_command('/session/1234567890/execute/sync'), body='{"value": ""}')
-        result = driver.install_app('path/to/app')
+@pytest.mark.parametrize('driver_func', [android_w3c_driver, ios_w3c_driver])
+@httpretty.activate
+def test_install_app(driver_func):
+    driver = driver_func()
+    httpretty.register_uri(httpretty.POST, appium_command('/session/1234567890/execute/sync'), body='{"value": ""}')
+    result = driver.install_app('path/to/app')
 
-        assert {
-            'args': [{'app': 'path/to/app', 'appPath': 'path/to/app'}],
-            'script': 'mobile: installApp',
-        } == get_httpretty_request_body(httpretty.last_request())
-        assert isinstance(result, WebDriver)
-
-    @httpretty.activate
-    def test_remove_app(self):
-        driver = android_w3c_driver()
-        httpretty.register_uri(httpretty.POST, appium_command('/session/1234567890/execute/sync'), body='{"value": ""}')
-        result = driver.remove_app('com.app.id')
-
-        assert {
-            'args': [{'appId': 'com.app.id', 'bundleId': 'com.app.id'}],
-            'script': 'mobile: removeApp',
-        } == get_httpretty_request_body(httpretty.last_request())
-        assert isinstance(result, WebDriver)
-
-    @httpretty.activate
-    def test_app_installed(self):
-        driver = android_w3c_driver()
-        httpretty.register_uri(httpretty.POST, appium_command('/session/1234567890/execute/sync'), body='{"value": true}')
-        result = driver.is_app_installed('com.app.id')
-
-        assert {
-            'args': [{'appId': 'com.app.id', 'bundleId': 'com.app.id'}],
-            'script': 'mobile: isAppInstalled',
-        } == get_httpretty_request_body(httpretty.last_request())
-        assert result is True
-
-    @httpretty.activate
-    def test_terminate_app(self):
-        driver = android_w3c_driver()
-        httpretty.register_uri(httpretty.POST, appium_command('/session/1234567890/execute/sync'), body='{"value": true}')
-        result = driver.terminate_app('com.app.id')
-
-        assert {
-            'args': [{'appId': 'com.app.id', 'bundleId': 'com.app.id'}],
-            'script': 'mobile: terminateApp',
-        } == get_httpretty_request_body(httpretty.last_request())
-        assert result is True
-
-    @httpretty.activate
-    def test_activate_app(self):
-        driver = android_w3c_driver()
-        httpretty.register_uri(httpretty.POST, appium_command('/session/1234567890/execute/sync'), body='{"value": ""}')
-        result = driver.activate_app('com.app.id')
-
-        assert {
-            'args': [{'appId': 'com.app.id', 'bundleId': 'com.app.id'}],
-            'script': 'mobile: activateApp',
-        } == get_httpretty_request_body(httpretty.last_request())
-        assert isinstance(result, WebDriver)
-
-    @httpretty.activate
-    def test_background_app(self):
-        driver = android_w3c_driver()
-        httpretty.register_uri(httpretty.POST, appium_command('/session/1234567890/execute/sync'), body='{"value": ""}')
-        result = driver.background_app(0)
-
-        assert {'args': [{'seconds': 0}], 'script': 'mobile: backgroundApp'} == get_httpretty_request_body(
-            httpretty.last_request()
-        )
-        assert isinstance(result, WebDriver)
-
-    @httpretty.activate
-    def test_query_app_state(self):
-        driver = android_w3c_driver()
-        httpretty.register_uri(httpretty.POST, appium_command('/session/1234567890/execute/sync'), body='{"value": 3}')
-        result = driver.query_app_state('com.app.id')
-
-        assert {
-            'args': [{'appId': 'com.app.id', 'bundleId': 'com.app.id'}],
-            'script': 'mobile: queryAppState',
-        } == get_httpretty_request_body(httpretty.last_request())
-        assert result is ApplicationState.RUNNING_IN_BACKGROUND
-
-    @httpretty.activate
-    def test_app_strings(self):
-        driver = android_w3c_driver()
-        httpretty.register_uri(
-            httpretty.POST,
-            appium_command('/session/1234567890/execute/sync'),
-            body='{"value": {"monkey_wipe_data": "You can\'t wipe my data, you are a monkey!"} }',
-        )
-        result = driver.app_strings()
-
-        assert {'args': [{}], 'script': 'mobile: getAppStrings'} == get_httpretty_request_body(httpretty.last_request())
-        assert "You can't wipe my data, you are a monkey!" == result['monkey_wipe_data'], result
-
-    @httpretty.activate
-    def test_app_strings_with_lang(self):
-        driver = android_w3c_driver()
-        httpretty.register_uri(
-            httpretty.POST,
-            appium_command('/session/1234567890/execute/sync'),
-            body='{"value": {"monkey_wipe_data": "You can\'t wipe my data, you are a monkey!"} }',
-        )
-        result = driver.app_strings('en')
-
-        assert {'args': [{'language': 'en'}], 'script': 'mobile: getAppStrings'} == get_httpretty_request_body(
-            httpretty.last_request()
-        )
-        assert "You can't wipe my data, you are a monkey!" == result['monkey_wipe_data'], result
-
-    @httpretty.activate
-    def test_app_strings_with_lang_and_file(self):
-        driver = android_w3c_driver()
-        httpretty.register_uri(
-            httpretty.POST,
-            appium_command('/session/1234567890/execute/sync'),
-            body='{"value": {"monkey_wipe_data": "You can\'t wipe my data, you are a monkey!"} }',
-        )
-        result = driver.app_strings('en', 'some_file')
-
-        assert {
-            'args': [{'language': 'en', 'stringFile': 'some_file'}],
-            'script': 'mobile: getAppStrings',
-        } == get_httpretty_request_body(httpretty.last_request())
-        assert "You can't wipe my data, you are a monkey!" == result['monkey_wipe_data'], result
+    assert {
+        'args': [{'app': 'path/to/app', 'appPath': 'path/to/app'}],
+        'script': 'mobile: installApp',
+    } == get_httpretty_request_body(httpretty.last_request())
+    assert isinstance(result, WebDriver)
 
 
-class TestWebDriverAppIOS(object):
-    @httpretty.activate
-    def test_install_app(self):
-        driver = ios_w3c_driver()
-        httpretty.register_uri(httpretty.POST, appium_command('/session/1234567890/execute/sync'), body='{"value": ""}')
-        result = driver.install_app('path/to/app')
+@pytest.mark.parametrize('driver_func', [android_w3c_driver, ios_w3c_driver])
+@httpretty.activate
+def test_remove_app(driver_func):
+    driver = android_w3c_driver()
+    httpretty.register_uri(httpretty.POST, appium_command('/session/1234567890/execute/sync'), body='{"value": ""}')
+    result = driver.remove_app('com.app.id')
 
-        assert {
-            'args': [{'app': 'path/to/app', 'appPath': 'path/to/app'}],
-            'script': 'mobile: installApp',
-        } == get_httpretty_request_body(httpretty.last_request())
-        assert isinstance(result, WebDriver)
+    assert {
+        'args': [{'appId': 'com.app.id', 'bundleId': 'com.app.id'}],
+        'script': 'mobile: removeApp',
+    } == get_httpretty_request_body(httpretty.last_request())
+    assert isinstance(result, WebDriver)
 
-    @httpretty.activate
-    def test_remove_app(self):
-        driver = ios_w3c_driver()
-        httpretty.register_uri(httpretty.POST, appium_command('/session/1234567890/execute/sync'), body='{"value": ""}')
-        result = driver.remove_app('com.app.id')
 
-        assert {
-            'args': [{'appId': 'com.app.id', 'bundleId': 'com.app.id'}],
-            'script': 'mobile: removeApp',
-        } == get_httpretty_request_body(httpretty.last_request())
-        assert isinstance(result, WebDriver)
+@pytest.mark.parametrize('driver_func', [android_w3c_driver, ios_w3c_driver])
+@httpretty.activate
+def test_app_installed(driver_func):
+    driver = driver_func()
+    httpretty.register_uri(httpretty.POST, appium_command('/session/1234567890/execute/sync'), body='{"value": true}')
+    result = driver.is_app_installed('com.app.id')
 
-    @httpretty.activate
-    def test_app_installed(self):
-        driver = ios_w3c_driver()
-        httpretty.register_uri(httpretty.POST, appium_command('/session/1234567890/execute/sync'), body='{"value": true}')
-        result = driver.is_app_installed('com.app.id')
+    assert {
+        'args': [{'appId': 'com.app.id', 'bundleId': 'com.app.id'}],
+        'script': 'mobile: isAppInstalled',
+    } == get_httpretty_request_body(httpretty.last_request())
+    assert result is True
 
-        assert {
-            'args': [{'appId': 'com.app.id', 'bundleId': 'com.app.id'}],
-            'script': 'mobile: isAppInstalled',
-        } == get_httpretty_request_body(httpretty.last_request())
-        assert result is True
 
-    @httpretty.activate
-    def test_terminate_app(self):
-        driver = ios_w3c_driver()
-        httpretty.register_uri(httpretty.POST, appium_command('/session/1234567890/execute/sync'), body='{"value": true}')
-        result = driver.terminate_app('com.app.id')
+@pytest.mark.parametrize('driver_func', [android_w3c_driver, ios_w3c_driver])
+@httpretty.activate
+def test_terminate_app(driver_func):
+    driver = driver_func()
+    httpretty.register_uri(httpretty.POST, appium_command('/session/1234567890/execute/sync'), body='{"value": true}')
+    result = driver.terminate_app('com.app.id')
 
-        assert {
-            'args': [{'appId': 'com.app.id', 'bundleId': 'com.app.id'}],
-            'script': 'mobile: terminateApp',
-        } == get_httpretty_request_body(httpretty.last_request())
-        assert result is True
+    assert {
+        'args': [{'appId': 'com.app.id', 'bundleId': 'com.app.id'}],
+        'script': 'mobile: terminateApp',
+    } == get_httpretty_request_body(httpretty.last_request())
+    assert result is True
 
-    @httpretty.activate
-    def test_activate_app(self):
-        driver = ios_w3c_driver()
-        httpretty.register_uri(httpretty.POST, appium_command('/session/1234567890/execute/sync'), body='{"value": ""}')
-        result = driver.activate_app('com.app.id')
 
-        assert {
-            'args': [{'appId': 'com.app.id', 'bundleId': 'com.app.id'}],
-            'script': 'mobile: activateApp',
-        } == get_httpretty_request_body(httpretty.last_request())
-        assert isinstance(result, WebDriver)
+@pytest.mark.parametrize('driver_func', [android_w3c_driver, ios_w3c_driver])
+@httpretty.activate
+def test_activate_app(driver_func):
+    driver = driver_func()
+    httpretty.register_uri(httpretty.POST, appium_command('/session/1234567890/execute/sync'), body='{"value": ""}')
+    result = driver.activate_app('com.app.id')
 
-    @httpretty.activate
-    def test_background_app(self):
-        driver = ios_w3c_driver()
-        httpretty.register_uri(httpretty.POST, appium_command('/session/1234567890/execute/sync'), body='{"value": ""}')
-        result = driver.background_app(0)
+    assert {
+        'args': [{'appId': 'com.app.id', 'bundleId': 'com.app.id'}],
+        'script': 'mobile: activateApp',
+    } == get_httpretty_request_body(httpretty.last_request())
+    assert isinstance(result, WebDriver)
 
-        assert {'args': [{'seconds': 0}], 'script': 'mobile: backgroundApp'} == get_httpretty_request_body(
-            httpretty.last_request()
-        )
-        assert isinstance(result, WebDriver)
 
-    @httpretty.activate
-    def test_query_app_state(self):
-        driver = ios_w3c_driver()
-        httpretty.register_uri(httpretty.POST, appium_command('/session/1234567890/execute/sync'), body='{"value": 3}')
-        result = driver.query_app_state('com.app.id')
+@pytest.mark.parametrize('driver_func', [android_w3c_driver, ios_w3c_driver])
+@httpretty.activate
+def test_background_app(driver_func):
+    driver = driver_func()
+    httpretty.register_uri(httpretty.POST, appium_command('/session/1234567890/execute/sync'), body='{"value": ""}')
+    result = driver.background_app(0)
 
-        assert {
-            'args': [{'appId': 'com.app.id', 'bundleId': 'com.app.id'}],
-            'script': 'mobile: queryAppState',
-        } == get_httpretty_request_body(httpretty.last_request())
-        assert result is ApplicationState.RUNNING_IN_BACKGROUND
+    assert {'args': [{'seconds': 0}], 'script': 'mobile: backgroundApp'} == get_httpretty_request_body(httpretty.last_request())
+    assert isinstance(result, WebDriver)
 
-    @httpretty.activate
-    def test_app_strings(self):
-        driver = ios_w3c_driver()
-        httpretty.register_uri(
-            httpretty.POST,
-            appium_command('/session/1234567890/execute/sync'),
-            body='{"value": {"monkey_wipe_data": "You can\'t wipe my data, you are a monkey!"} }',
-        )
-        result = driver.app_strings()
 
-        assert {'args': [{}], 'script': 'mobile: getAppStrings'} == get_httpretty_request_body(httpretty.last_request())
-        assert "You can't wipe my data, you are a monkey!" == result['monkey_wipe_data'], result
+@pytest.mark.parametrize('driver_func', [android_w3c_driver, ios_w3c_driver])
+@httpretty.activate
+def test_query_app_state(driver_func):
+    driver = driver_func()
+    httpretty.register_uri(httpretty.POST, appium_command('/session/1234567890/execute/sync'), body='{"value": 3}')
+    result = driver.query_app_state('com.app.id')
 
-    @httpretty.activate
-    def test_app_strings_with_lang(self):
-        driver = ios_w3c_driver()
-        httpretty.register_uri(
-            httpretty.POST,
-            appium_command('/session/1234567890/execute/sync'),
-            body='{"value": {"monkey_wipe_data": "You can\'t wipe my data, you are a monkey!"} }',
-        )
-        result = driver.app_strings('en')
+    assert {
+        'args': [{'appId': 'com.app.id', 'bundleId': 'com.app.id'}],
+        'script': 'mobile: queryAppState',
+    } == get_httpretty_request_body(httpretty.last_request())
+    assert result is ApplicationState.RUNNING_IN_BACKGROUND
 
-        assert {'args': [{'language': 'en'}], 'script': 'mobile: getAppStrings'} == get_httpretty_request_body(
-            httpretty.last_request()
-        )
-        assert "You can't wipe my data, you are a monkey!" == result['monkey_wipe_data'], result
 
-    @httpretty.activate
-    def test_app_strings_with_lang_and_file(self):
-        driver = ios_w3c_driver()
-        httpretty.register_uri(
-            httpretty.POST,
-            appium_command('/session/1234567890/execute/sync'),
-            body='{"value": {"monkey_wipe_data": "You can\'t wipe my data, you are a monkey!"} }',
-        )
-        result = driver.app_strings('en', 'some_file')
+@pytest.mark.parametrize('driver_func', [android_w3c_driver, ios_w3c_driver])
+@httpretty.activate
+def test_app_strings(driver_func):
+    driver = driver_func()
+    httpretty.register_uri(
+        httpretty.POST,
+        appium_command('/session/1234567890/execute/sync'),
+        body='{"value": {"monkey_wipe_data": "You can\'t wipe my data, you are a monkey!"} }',
+    )
+    result = driver.app_strings()
 
-        assert {
-            'args': [{'language': 'en', 'stringFile': 'some_file'}],
-            'script': 'mobile: getAppStrings',
-        } == get_httpretty_request_body(httpretty.last_request())
-        assert "You can't wipe my data, you are a monkey!" == result['monkey_wipe_data'], result
+    assert {'args': [{}], 'script': 'mobile: getAppStrings'} == get_httpretty_request_body(httpretty.last_request())
+    assert "You can't wipe my data, you are a monkey!" == result['monkey_wipe_data'], result
+
+
+@pytest.mark.parametrize('driver_func', [android_w3c_driver, ios_w3c_driver])
+@httpretty.activate
+def test_app_strings_with_lang(driver_func):
+    driver = driver_func()
+    httpretty.register_uri(
+        httpretty.POST,
+        appium_command('/session/1234567890/execute/sync'),
+        body='{"value": {"monkey_wipe_data": "You can\'t wipe my data, you are a monkey!"} }',
+    )
+    result = driver.app_strings('en')
+
+    assert {'args': [{'language': 'en'}], 'script': 'mobile: getAppStrings'} == get_httpretty_request_body(
+        httpretty.last_request()
+    )
+    assert "You can't wipe my data, you are a monkey!" == result['monkey_wipe_data'], result
+
+
+@pytest.mark.parametrize('driver_func', [android_w3c_driver, ios_w3c_driver])
+@httpretty.activate
+def test_app_strings_with_lang_and_file(driver_func):
+    driver = driver_func()
+    httpretty.register_uri(
+        httpretty.POST,
+        appium_command('/session/1234567890/execute/sync'),
+        body='{"value": {"monkey_wipe_data": "You can\'t wipe my data, you are a monkey!"} }',
+    )
+    result = driver.app_strings('en', 'some_file')
+
+    assert {
+        'args': [{'language': 'en', 'stringFile': 'some_file'}],
+        'script': 'mobile: getAppStrings',
+    } == get_httpretty_request_body(httpretty.last_request())
+    assert "You can't wipe my data, you are a monkey!" == result['monkey_wipe_data'], result


### PR DESCRIPTION
use pytest without class-based structures, using parameterization for better reusability.

Partly address https://github.com/appium/python-client/issues/644