### PR TITLE
fix: prevent warning log when initialize a webdriver using version 4.5.0 (selenium v4.26+)

### DIFF
--- a/appium/webdriver/webdriver.py
+++ b/appium/webdriver/webdriver.py
@@ -217,7 +217,7 @@ class WebDriver(
                 remote_server_addr=command_executor, keep_alive=keep_alive, ignore_certificates=not strict_ssl
             )
             client_config.remote_server_addr = command_executor
-            command_executor = AppiumConnection(remote_server_addr=command_executor, client_config=client_config)
+            command_executor = AppiumConnection(client_config=client_config)
         elif isinstance(command_executor, AppiumConnection) and strict_ssl is False:
             logger.warning(
                 "Please set 'ignore_certificates' in the given 'appium.webdriver.appium_connection.AppiumConnection' or "


### PR DESCRIPTION
## Problem: 

When initializing a webdriver with appium/python-client version 4.5.0, I get a warning log.

## Appium version:

```2.16.2```

## Appium-Python-Client version:

```4.5.0```

## Pytest version:

```8.3.4```

## My Code:

```
APPIUM_PORT = 4723
APPIUM_HOST = '127.0.0.1'


client_config = ClientConfig(
    remote_server_addr="http://127.0.0.1:4723", 
    ignore_certificates=True
    )


@pytest.fixture(scope='session')
def appium_service():
    service = AppiumService()
    service.start(
        args=['--address', APPIUM_HOST, '-p', str(APPIUM_PORT)],
        timeout_ms=20000,
    )
    yield service
    service.stop()

def create_ios_driver(custom_opts = None):
    options = XCUITestOptions()
    options.platformVersion = '18.2'
    options.udid = 'FCD6B2FA-5C83-4069-82A4-76CE581CB1E3'
    options.no_reset = True
    if custom_opts is not None:
        options.load_capabilities(custom_opts)
    # Appium1 points to http://127.0.0.1:4723/wd/hub by default
    return webdriver.Remote(f'http://{APPIUM_HOST}:{APPIUM_PORT}', options=options)

def test_ios_click(appium_service, ios_driver_factory):
    with ios_driver_factory({
        # 'appium:app': '/Users/xxxxxxxxx/PycharmProjects/uv-demo/app/UICatalog.app'
        'appium:bundleId': 'com.example.kazumi'
    }) as driver:
        el = driver.find_element(by=AppiumBy.ACCESSIBILITY_ID, value='日常')
        el.click()
```

## Consolelog detail:

```
platform darwin -- Python 3.12.0, pytest-8.3.4, pluggy-1.5.0
rootdir: /Users/cengdong/PycharmProjects/uv-demo
configfile: pyproject.toml
collected 1 item                                                                                                                                

test_demo.py .                                                                                                                            [100%]

=============================================================== warnings summary ================================================================
test_demo.py::test_ios_click
  /Users/cengdong/PycharmProjects/uv-demo/.venv/lib/python3.12/site-packages/appium/webdriver/webdriver.py:220: DeprecationWarning: setting remote_server_addr in RemoteConnection() is deprecated, set in ClientConfig instance instead
    command_executor = AppiumConnection(remote_server_addr=command_executor, client_config=client_config)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========================================================= 1 passed, 1 warning in 5.59s ==========================================================
```

## The reason:

the parameter 'remote_ server _ addr' in selenium.RemoteConnection() is deprecated

```
        if remote_server_addr:
            warnings.warn(
                "setting remote_server_addr in RemoteConnection() is deprecated, set in ClientConfig instance instead",
                DeprecationWarning,
                stacklevel=2,
            )
```


## My solution

Remove the parameter 'remote_ server _ addr' for initializing AppiumConnection at appium/webdriver/webdriver.py file line 220