### PR TITLE
feat: add method for interacting with the Flutter integration driver

### DIFF
--- a/appium/webdriver/extensions/flutter_integration/flutter_commands.py
+++ b/appium/webdriver/extensions/flutter_integration/flutter_commands.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import os
-from typing import Any, Dict, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 from appium.common.helper import encode_file_to_base64
 from appium.webdriver.extensions.flutter_integration.flutter_finder import FlutterFinder
@@ -171,6 +171,33 @@ class FlutterCommand:
             None:
         """
         self.execute_flutter_command('activateInjectedImage', {'imageId': image_id})
+
+    def get_render_tree(
+        self,
+        widget_type: Optional[str] = None,
+        key: Optional[str] = None,
+        text: Optional[str] = None,
+    ) -> List[Optional[Dict]]:
+        """
+        Returns the render tree of the root widget.
+
+        Args:
+            widget_type (Optional[str]): The type of the widget to primary filter by.
+            key (Optional[str]): The key of the widget to filter by.
+            text (Optional[str]): The text of the widget to filter by.
+
+        Returns:
+            str: The render tree of the current screen.
+        """
+        opts = {}
+        if widget_type is not None:
+            opts['widgetType'] = widget_type
+        if key is not None:
+            opts['key'] = key
+        if text is not None:
+            opts['text'] = text
+
+        return self.execute_flutter_command('renderTree', opts)
 
     def execute_flutter_command(self, scriptName: str, params: dict) -> Any:
         """

--- a/test/unit/webdriver/flutter_integration/flutter_render_tree_test.py
+++ b/test/unit/webdriver/flutter_integration/flutter_render_tree_test.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+
+import httpretty
+
+from appium.webdriver.extensions.flutter_integration.flutter_commands import (
+    FlutterCommand,
+)
+from test.unit.helper.test_helper import (
+    appium_command,
+    flutter_w3c_driver,
+    get_httpretty_request_body,
+)
+
+
+class TestFlutterRenderTree:
+    @httpretty.activate
+    def test_get_render_tree_with_all_filters(self):
+        expected_body = [{'<partial_tree>': 'LoginButton'}]
+        httpretty.register_uri(
+            httpretty.POST,
+            appium_command('/session/1234567890/execute/sync'),
+            body=json.dumps({'value': expected_body}),
+        )
+
+        driver = flutter_w3c_driver()
+        flutter = FlutterCommand(driver)
+
+        result = flutter.get_render_tree(widget_type='ElevatedButton', key='LoginButton', text='Login')
+
+        request_body = get_httpretty_request_body(httpretty.last_request())
+        assert request_body['script'] == 'flutter: renderTree'
+        assert request_body['args'] == [
+            {
+                'widgetType': 'ElevatedButton',
+                'key': 'LoginButton',
+                'text': 'Login',
+            }
+        ]
+
+        assert result == expected_body
+
+    @httpretty.activate
+    def test_get_render_tree_with_partial_filters(self):
+        expected_body = [{'<partial_tree>': 'LoginScreen'}]
+
+        httpretty.register_uri(
+            httpretty.POST,
+            appium_command('/session/1234567890/execute/sync'),
+            body=json.dumps({'value': expected_body}),
+        )
+
+        driver = flutter_w3c_driver()
+        flutter = FlutterCommand(driver)
+
+        result = flutter.get_render_tree(widget_type='LoginScreen')
+
+        request_body = get_httpretty_request_body(httpretty.last_request())
+        assert request_body['script'] == 'flutter: renderTree'
+        assert request_body['args'] == [{'widgetType': 'LoginScreen'}]
+
+        assert result == expected_body
+
+    @httpretty.activate
+    def test_get_render_tree_with_no_filters(self):
+        expected_body = [{'<full_tree>': 'RootWidget'}]
+        httpretty.register_uri(
+            httpretty.POST,
+            appium_command('/session/1234567890/execute/sync'),
+            body=json.dumps({'value': expected_body}),
+        )
+
+        driver = flutter_w3c_driver()
+        flutter = FlutterCommand(driver)
+
+        result = flutter.get_render_tree()
+
+        request_body = get_httpretty_request_body(httpretty.last_request())
+        assert request_body['script'] == 'flutter: renderTree'
+        assert request_body['args'] == [{}]
+
+        assert result == expected_body


### PR DESCRIPTION
Hi,
This PR adds a method for interacting with the [Flutter integration driver.](https://github.com/AppiumTestDistribution/appium-flutter-integration-driver/releases/tag/v1.2.0) It adds partial filter support and render tree retrieval.

Please let me know if any changes or improvements are needed.
Thanks!