### PR TITLE
chore: fix some mypy errors

### DIFF
--- a/appium/webdriver/common/appiumby.py
+++ b/appium/webdriver/common/appiumby.py
@@ -49,5 +49,6 @@ ByType = Literal[
     '-flutter semantics label',
     '-flutter type',
     '-flutter key',
+    '-flutter text',
     '-flutter text containing',
 ]

--- a/appium/webdriver/extensions/android/activities.py
+++ b/appium/webdriver/extensions/android/activities.py
@@ -50,7 +50,9 @@ class Activities(CanExecuteCommands, CanExecuteScripts, CanRememberExtensionPres
             `True` if the target activity is shown
         """
         try:
-            WebDriverWait(self, timeout, interval).until(lambda d: d.current_activity == activity)
+            WebDriverWait(self, timeout, interval).until(  # type: ignore[type-var]
+                lambda d: d.current_activity == activity
+            )
             return True
         except TimeoutException:
             return False

--- a/appium/webdriver/extensions/flutter_integration/flutter_commands.py
+++ b/appium/webdriver/extensions/flutter_integration/flutter_commands.py
@@ -290,7 +290,7 @@ class FlutterCommand:
         """
         return self.driver.execute_script(f'flutter: {scriptName}', params)
 
-    def __get_locator_options(self, locator: Union[WebElement, 'FlutterFinder']) -> Dict[str, dict]:
+    def __get_locator_options(self, locator: Union[WebElement, 'FlutterFinder']) -> Dict[str, Union[dict, WebElement]]:
         if isinstance(locator, WebElement):
             return {'element': locator}
         return {'locator': locator.to_dict()}

--- a/appium/webdriver/extensions/flutter_integration/flutter_finder.py
+++ b/appium/webdriver/extensions/flutter_integration/flutter_finder.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from typing import Tuple, Union
+from typing import Tuple, Union, cast
 
 from selenium.webdriver.common.by import ByType as SeleniumByType
 
@@ -30,23 +30,23 @@ class FlutterFinder:
 
     @staticmethod
     def by_key(value: str) -> 'FlutterFinder':
-        return FlutterFinder(AppiumBy.FLUTTER_INTEGRATION_KEY, value)
+        return FlutterFinder(cast(AppiumByType, AppiumBy.FLUTTER_INTEGRATION_KEY), value)
 
     @staticmethod
     def by_text(value: str) -> 'FlutterFinder':
-        return FlutterFinder(AppiumBy.FLUTTER_INTEGRATION_TEXT, value)
+        return FlutterFinder(cast(AppiumByType, AppiumBy.FLUTTER_INTEGRATION_TEXT), value)
 
     @staticmethod
     def by_semantics_label(value: str) -> 'FlutterFinder':
-        return FlutterFinder(AppiumBy.FLUTTER_INTEGRATION_SEMANTICS_LABEL, value)
+        return FlutterFinder(cast(AppiumByType, AppiumBy.FLUTTER_INTEGRATION_SEMANTICS_LABEL), value)
 
     @staticmethod
     def by_type(value: str) -> 'FlutterFinder':
-        return FlutterFinder(AppiumBy.FLUTTER_INTEGRATION_TYPE, value)
+        return FlutterFinder(cast(AppiumByType, AppiumBy.FLUTTER_INTEGRATION_TYPE), value)
 
     @staticmethod
     def by_text_containing(value: str) -> 'FlutterFinder':
-        return FlutterFinder(AppiumBy.FLUTTER_INTEGRATION_TEXT_CONTAINING, value)
+        return FlutterFinder(cast(AppiumByType, AppiumBy.FLUTTER_INTEGRATION_TEXT_CONTAINING), value)
 
     def to_dict(self) -> dict:
         return {'using': self.using, 'value': self.value}

--- a/appium/webdriver/webdriver.py
+++ b/appium/webdriver/webdriver.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Set, Tuple, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Set, Tuple, Type, Union
 
 from selenium import webdriver
 from selenium.common.exceptions import (
@@ -21,14 +21,12 @@ from selenium.common.exceptions import (
     UnknownMethodException,
     WebDriverException,
 )
-from selenium.webdriver.common.by import By
 from selenium.webdriver.remote.command import Command as RemoteCommand
 from selenium.webdriver.remote.remote_connection import RemoteConnection
 from typing_extensions import Self
 
 from appium.common.logger import logger
 from appium.options.common.base import AppiumOptions
-from appium.webdriver.common.appiumby import AppiumBy
 
 from .appium_connection import AppiumConnection
 from .client_config import AppiumClientConfig
@@ -241,7 +239,7 @@ class WebDriver(
     def __init__(
         self,
         command_executor: Union[str, AppiumConnection] = 'http://127.0.0.1:4723',
-        extensions: Optional[List['WebDriver']] = None,
+        extensions: Optional[List[Type['ExtensionBase']]] = None,
         options: Union[AppiumOptions, List[AppiumOptions], None] = None,
         client_config: Optional[AppiumClientConfig] = None,
     ):
@@ -265,15 +263,6 @@ class WebDriver(
 
         if client_config and client_config.direct_connection:
             self._update_command_executor(keep_alive=client_config.keep_alive)
-
-        # add new method to the `find_by_*` pantheon
-        By.IOS_PREDICATE = AppiumBy.IOS_PREDICATE
-        By.IOS_CLASS_CHAIN = AppiumBy.IOS_CLASS_CHAIN
-        By.ANDROID_UIAUTOMATOR = AppiumBy.ANDROID_UIAUTOMATOR
-        By.ANDROID_VIEWTAG = AppiumBy.ANDROID_VIEWTAG
-        By.ACCESSIBILITY_ID = AppiumBy.ACCESSIBILITY_ID
-        By.IMAGE = AppiumBy.IMAGE
-        By.CUSTOM = AppiumBy.CUSTOM
 
         self._absent_extensions: Set[str] = set()
 

--- a/appium/webdriver/webdriver.py
+++ b/appium/webdriver/webdriver.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Set, Tuple, Union
 
 from selenium import webdriver
 from selenium.common.exceptions import (
@@ -250,11 +250,14 @@ class WebDriver(
         )
         super().__init__(
             command_executor=command_executor,
-            options=options,
+            options=options,  # type: ignore[arg-type]
             locator_converter=AppiumLocatorConverter(),
             web_element_cls=MobileWebElement,
             client_config=client_config,
         )
+
+        # to explicitly set type after the initialization
+        self.command_executor: RemoteConnection
 
         self._add_commands()
 
@@ -285,6 +288,14 @@ class WebDriver(
             setattr(WebDriver, method_name, getattr(instance, method_name))
             method, url_cmd = instance.add_command()
             self.command_executor.add_command(method_name, method.upper(), url_cmd)
+
+    if TYPE_CHECKING:
+
+        def find_element(self, by: str, value: Union[str, Dict, None] = None) -> 'MobileWebElement':  # type: ignore[override]
+            ...
+
+        def find_elements(self, by: str, value: Union[str, Dict, None] = None) -> List['MobileWebElement']:  # type: ignore[override]
+            ...
 
     def delete_extensions(self) -> None:
         """Delete extensions added in the class with 'setattr'"""

--- a/appium/webdriver/webelement.py
+++ b/appium/webdriver/webelement.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Callable, Dict, Optional, Union
+from typing import TYPE_CHECKING, Callable, Dict, Optional, Union
 
 from selenium.webdriver.common.utils import keys_to_typing
 from selenium.webdriver.remote.command import Command as RemoteCommand
@@ -25,6 +25,14 @@ from .mobilecommand import MobileCommand as Command
 class WebElement(SeleniumWebElement):
     _execute: Callable
     _id: str
+
+    if TYPE_CHECKING:
+
+        def find_element(self, by: str, value: Union[str, Dict, None] = None) -> Self:  # type: ignore[override]
+            ...
+
+        def find_elements(self, by: str, value: Union[str, Dict, None] = None) -> Self:  # type: ignore[override]
+            ...
 
     def get_attribute(self, name: str) -> Optional[Union[str, Dict]]:  # type: ignore[override]
         """Gets the given attribute or property of the element.
@@ -108,7 +116,7 @@ class WebElement(SeleniumWebElement):
         return self._execute(Command.LOCATION_IN_VIEW)['value']
 
     # Override
-    def send_keys(self, *value: str) -> Self:
+    def send_keys(self, *value: str) -> Self:  # type: ignore[override]
         """Simulates typing into the element.
 
         Args:

--- a/appium/webdriver/webelement.py
+++ b/appium/webdriver/webelement.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import TYPE_CHECKING, Callable, Dict, Optional, Union
+from typing import TYPE_CHECKING, Callable, Dict, Optional, Union, List
 
 from selenium.webdriver.common.utils import keys_to_typing
 from selenium.webdriver.remote.command import Command as RemoteCommand

--- a/appium/webdriver/webelement.py
+++ b/appium/webdriver/webelement.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import TYPE_CHECKING, Callable, Dict, Optional, Union, List
+from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Union
 
 from selenium.webdriver.common.utils import keys_to_typing
 from selenium.webdriver.remote.command import Command as RemoteCommand

--- a/appium/webdriver/webelement.py
+++ b/appium/webdriver/webelement.py
@@ -31,7 +31,7 @@ class WebElement(SeleniumWebElement):
         def find_element(self, by: str, value: Union[str, Dict, None] = None) -> Self:  # type: ignore[override]
             ...
 
-        def find_elements(self, by: str, value: Union[str, Dict, None] = None) -> Self:  # type: ignore[override]
+        def find_elements(self, by: str, value: Union[str, Dict, None] = None) -> List[Self]:  # type: ignore[override]
             ...
 
     def get_attribute(self, name: str) -> Optional[Union[str, Dict]]:  # type: ignore[override]


### PR DESCRIPTION
Fixes some mypy errors.

- Add `# type: ignore[override]` to ignore incompatible type errors because of our lirbary's override to let users chain methods
- Add `type: ignore[arg-type]` for ignorable errors for selenium lib
- Add `find_element` and `find_elements` for typehint usage
   - The actual implementation returns the given `web_element_cls=MobileWebElement` so they are necessary only for typehint


After

```
appium/webdriver/switch_to.py:29: error: Definition of "_driver" in base class "SwitchTo" is incompatible with definition in base class "HasDriver"  [misc]
```

Before

```
$ mypy appium 
appium/webdriver/extensions/flutter_integration/flutter_finder.py:33: error: Argument 1 to "FlutterFinder" has incompatible type "str"; expected "Literal['id', 'xpath', 'link text', 'partial link text', 'name', 'tag name', 'class name', 'css selector'] | Literal['-ios predicate string', '-ios class chain', '-android uiautomator', '-android viewtag', '-android datamatcher', '-android viewmatcher', 'accessibility id', '-image', '-custom', '-flutter semantics label', '-flutter type', '-flutter key', '-flutter text containing']"  [arg-type]
appium/webdriver/extensions/flutter_integration/flutter_finder.py:37: error: Argument 1 to "FlutterFinder" has incompatible type "str"; expected "Literal['id', 'xpath', 'link text', 'partial link text', 'name', 'tag name', 'class name', 'css selector'] | Literal['-ios predicate string', '-ios class chain', '-android uiautomator', '-android viewtag', '-android datamatcher', '-android viewmatcher', 'accessibility id', '-image', '-custom', '-flutter semantics label', '-flutter type', '-flutter key', '-flutter text containing']"  [arg-type]
appium/webdriver/extensions/flutter_integration/flutter_finder.py:41: error: Argument 1 to "FlutterFinder" has incompatible type "str"; expected "Literal['id', 'xpath', 'link text', 'partial link text', 'name', 'tag name', 'class name', 'css selector'] | Literal['-ios predicate string', '-ios class chain', '-android uiautomator', '-android viewtag', '-android datamatcher', '-android viewmatcher', 'accessibility id', '-image', '-custom', '-flutter semantics label', '-flutter type', '-flutter key', '-flutter text containing']"  [arg-type]
appium/webdriver/extensions/flutter_integration/flutter_finder.py:45: error: Argument 1 to "FlutterFinder" has incompatible type "str"; expected "Literal['id', 'xpath', 'link text', 'partial link text', 'name', 'tag name', 'class name', 'css selector'] | Literal['-ios predicate string', '-ios class chain', '-android uiautomator', '-android viewtag', '-android datamatcher', '-android viewmatcher', 'accessibility id', '-image', '-custom', '-flutter semantics label', '-flutter type', '-flutter key', '-flutter text containing']"  [arg-type]
appium/webdriver/extensions/flutter_integration/flutter_finder.py:49: error: Argument 1 to "FlutterFinder" has incompatible type "str"; expected "Literal['id', 'xpath', 'link text', 'partial link text', 'name', 'tag name', 'class name', 'css selector'] | Literal['-ios predicate string', '-ios class chain', '-android uiautomator', '-android viewtag', '-android datamatcher', '-android viewmatcher', 'accessibility id', '-image', '-custom', '-flutter semantics label', '-flutter type', '-flutter key', '-flutter text containing']"  [arg-type]
appium/webdriver/webelement.py:111: error: Return type "WebElement" of "send_keys" incompatible with return type "None" in supertype "WebElement"  [override]
appium/webdriver/switch_to.py:29: error: Definition of "_driver" in base class "SwitchTo" is incompatible with definition in base class "HasDriver"  [misc]
appium/webdriver/extensions/android/activities.py:53: error: Value of type variable "D" of "WebDriverWait" cannot be "Activities"  [type-var]
appium/webdriver/webdriver.py:212: error: Definition of "command_executor" in base class "WebDriver" is incompatible with definition in base class "CanExecuteCommands"  [misc]
appium/webdriver/webdriver.py:253: error: Argument "options" to "__init__" of "WebDriver" has incompatible type "AppiumOptions | list[AppiumOptions] | None"; expected "BaseOptions | list[BaseOptions] | None"  [arg-type]
appium/webdriver/webdriver.py:267: error: "type[By]" has no attribute "IOS_PREDICATE"  [attr-defined]
appium/webdriver/webdriver.py:268: error: "type[By]" has no attribute "IOS_CLASS_CHAIN"  [attr-defined]
appium/webdriver/webdriver.py:269: error: "type[By]" has no attribute "ANDROID_UIAUTOMATOR"  [attr-defined]
appium/webdriver/webdriver.py:270: error: "type[By]" has no attribute "ANDROID_VIEWTAG"  [attr-defined]
appium/webdriver/webdriver.py:271: error: "type[By]" has no attribute "ACCESSIBILITY_ID"  [attr-defined]
appium/webdriver/webdriver.py:272: error: "type[By]" has no attribute "IMAGE"  [attr-defined]
appium/webdriver/webdriver.py:273: error: "type[By]" has no attribute "CUSTOM"  [attr-defined]
appium/webdriver/webdriver.py:279: error: "WebDriver" not callable  [operator]
appium/webdriver/webdriver.py:287: error: Item "str" of "str | RemoteConnection" has no attribute "add_command"  [union-attr]
appium/webdriver/webdriver.py:292: error: "WebDriver" not callable  [operator]
appium/webdriver/webdriver.py:480: error: Item "str" of "str | RemoteConnection" has no attribute "add_command"  [union-attr]
appium/webdriver/webdriver.py:483: error: Item "str" of "str | RemoteConnection" has no attribute "add_command"  [union-attr]
appium/webdriver/webdriver.py:484: error: Item "str" of "str | RemoteConnection" has no attribute "add_command"  [union-attr]
appium/webdriver/webdriver.py:491: error: Item "str" of "str | RemoteConnection" has no attribute "add_command"  [union-attr]
appium/webdriver/webdriver.py:492: error: Item "str" of "str | RemoteConnection" has no attribute "add_command"  [union-attr]
appium/webdriver/webdriver.py:494: error: Item "str" of "str | RemoteConnection" has no attribute "add_command"  [union-attr]
appium/webdriver/webdriver.py:495: error: Item "str" of "str | RemoteConnection" has no attribute "add_command"  [union-attr]
appium/webdriver/extensions/flutter_integration/flutter_commands.py:295: error: Dict entry 0 has incompatible type "str": "WebElement"; expected "str": "dict[Any, Any]"  [dict-item]
```
