### PR TITLE
chore: use semantic-release for most of release script execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,18 @@
 # CHANGELOG
 
+<!-- version list -->
 
 ## Unreleased
 
 ### Chores
 
-- Add python-semantic-release as the deps
-  ([`0a2ffad`](https://github.com/appium/python-client/commit/0a2ffad9f3fb37f7ef5ef6632514f07e1fc97359))
+- Revert version created by release script checking
+  ([#1164](https://github.com/appium/python-client/pull/1164),
+  [`04a8580`](https://github.com/appium/python-client/commit/04a8580f999843bc9d121c1ed4ce872761350f31))
+
+- Use semantic release changelog instead of gitchangelog
+  ([#1163](https://github.com/appium/python-client/pull/1163),
+  [`dd3709e`](https://github.com/appium/python-client/commit/dd3709e084e802d6534d51151be1bd45456a4ebd))
 
 ### Documentation
 

--- a/README.md
+++ b/README.md
@@ -530,12 +530,17 @@ uv run pytest -n 2 test/functional/ios/search_context/find_by_ios_class_chain_te
 Follow the below steps.
 
 ```bash
-uv pip install setuptools
+# Used to publish the package to pypi
 uv pip install twine
-# Type the new version number and 'yes' if you can publish it
-# You can test the command with DRY_RUN
-DRY_RUN=1 ./release.sh
+
+rm -rf dist
+# bumping the version, building a package and creating a tag.
+uv run semantic-release version --patch|--minor|--major
+
+# this 'release' script now has pushing built modules to pypi only.
 ./release.sh # release
+
+# input the same version
 ```
 
 If the `pypi` was not able to publish with user name and password, please try out `-u` and `-p` option by yourself with `twine` such as `twine upload -u <name> -p <pass> dist/Appium-Python-Client-4.1.0.tar.gz`.

--- a/README.md
+++ b/README.md
@@ -529,6 +529,8 @@ uv run pytest -n 2 test/functional/ios/search_context/find_by_ios_class_chain_te
 
 Follow the below steps.
 
+Set `GH_TOKEN` env var to update the GitHub contents.
+
 ```bash
 # Used to publish the package to pypi
 uv pip install twine

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,7 +102,7 @@ prerelease = false
 [tool.semantic_release.changelog]
 exclude_commit_patterns = []
 mode = "update"
-insertion_flag = "=========\nCHANGELOG\n========="
+insertion_flag = "<!-- version list -->"
 template_dir = "templates"
 
 [tool.semantic_release.changelog.default_templates]

--- a/script/release.py
+++ b/script/release.py
@@ -35,7 +35,7 @@ def print_current_version():
 
 
 def get_new_version():
-    print(MESSAGE_GREEN.format('new version:'))
+    print(MESSAGE_GREEN.format('Pushing version:'))
     for line in sys.stdin:
         return line.rstrip()
 
@@ -53,17 +53,6 @@ def call_bash_script(cmd):
     else:
         os.system(cmd)
 
-
-def commit_version_code(new_version_num):
-    call_bash_script('git commit pyproject.toml uv.lock -m "Bump {}"'.format(new_version_num))
-
-
-def tag_and_generate_changelog(new_version_num):
-    call_bash_script('git tag "v{}"'.format(new_version_num))
-    call_bash_script('uv run semantic-release changelog')
-    call_bash_script('git commit {} -m "Update changelog for {}"'.format(CHANGELOG_PATH, new_version_num))
-
-
 def upload_sdist(new_version_num):
     wheel_file = 'dist/appium_python_client-{}-py3-none-any.whl'.format(new_version_num)
     push_file = 'dist/appium_python_client-{}.tar.gz'.format(new_version_num)
@@ -76,12 +65,6 @@ def upload_sdist(new_version_num):
             )
         )
 
-
-def push_changes_to_master(new_version_num):
-    call_bash_script('git push origin master')
-    call_bash_script('git push origin "v{}"'.format(new_version_num))
-
-
 def ensure_publication(new_version_num):
     if os.environ.get('DRY_RUN') is not None:
         print('Run with {} mode.'.format(MESSAGE_RED.format('[DRY_RUN]')))
@@ -92,66 +75,19 @@ def ensure_publication(new_version_num):
             return
         sys.exit('Canceled release process.')
 
-
-def build_sdist():
-    call_bash_script('uv build')
-
-
-def build() -> None:
-    shutil.rmtree(BUILT_APPIUM_DIR_PATH, ignore_errors=True)
-    status, output = subprocess.getstatusoutput('uv run python setup.py install')
-    if status != 0:
-        sys.exit(f'Failed to build the package:\n{output}')
-
-
 def get_py_files_in_dir(root_dir: str) -> List[str]:
     return [
         file_path[len(root_dir) :]
         for file_path in glob.glob(f'{root_dir}/**/*.py', recursive=True) + glob.glob(f'{root_dir}/**/*.typed', recursive=True)
     ]
 
-
-def assert_files_count_in_package() -> None:
-    original_files = get_py_files_in_dir(APPIUM_DIR_PATH)
-    built_files = get_py_files_in_dir(BUILT_APPIUM_DIR_PATH)
-
-    if len(original_files) != len(built_files):
-        print(f"The count of files in '{APPIUM_DIR_PATH}' and '{BUILT_APPIUM_DIR_PATH}' were different.")
-
-        original_files_set = set(original_files)
-        built_files_set = set(built_files)
-
-        diff = original_files_set.difference(built_files_set)
-        if diff:
-            print(f"'{APPIUM_DIR_PATH}' has '{diff}' files than {BUILT_APPIUM_DIR_PATH}")
-        diff = built_files_set.difference(original_files_set)
-        if diff:
-            print(f'{BUILT_APPIUM_DIR_PATH} has {diff} files than {APPIUM_DIR_PATH}')
-
-        sys.exit(
-            f"Python files in '{BUILT_APPIUM_DIR_PATH}' may differ from '{APPIUM_DIR_PATH}'. "
-            'Please make sure setup.py is configured properly.'
-        )
-
-
 def main():
     print_current_version()
     new_version = get_new_version()
 
-    update_version_file(new_version)
-
-    build()
-    assert_files_count_in_package()
-
     ensure_publication(new_version)
 
-    commit_version_code(new_version)
-    build_sdist()
-
-    tag_and_generate_changelog(new_version)
-
     upload_sdist(new_version)
-    push_changes_to_master(new_version)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Apply https://github.com/appium/python-client/issues/1161 more

With this, the only remaining deps in `release.sh` is publishing modules to pypi. Tag/github release page handlings will be by the semantics release tag