### PR TITLE
fix: replace assert with ValueError for state validation

### DIFF
--- a/appium/webdriver/webdriver.py
+++ b/appium/webdriver/webdriver.py
@@ -303,7 +303,8 @@ class WebDriver(
         direct_port = 'directConnectPort'
         direct_path = 'directConnectPath'
 
-        assert self.caps, 'Driver capabilities must be defined'
+        if not self.caps:
+            raise ValueError('Driver capabilities must be defined')
         if not {direct_protocol, direct_host, direct_port, direct_path}.issubset(set(self.caps)):
             message = 'Direct connect capabilities from server were:\n'
             for key in [direct_protocol, direct_host, direct_port, direct_path]:


### PR DESCRIPTION
The use of `assert` for application logic or state checking is discouraged because assertions are removed when Python runs with optimization (-O). This change replaces `assert self.caps` with an explicit `if` check that raises `ValueError`, ensuring that the driver capabilities are always validated even in optimized environments.