### PR TITLE
refactor: remove legacy fallback logic for android extensions

### DIFF
--- a/appium/webdriver/extensions/android/common.py
+++ b/appium/webdriver/extensions/android/common.py
@@ -12,13 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from selenium.common.exceptions import UnknownMethodException
 from typing_extensions import Self
 
 from appium.protocols.webdriver.can_execute_commands import CanExecuteCommands
 from appium.protocols.webdriver.can_execute_scripts import CanExecuteScripts
 from appium.protocols.webdriver.can_remember_extension_presence import CanRememberExtensionPresence
-from appium.webdriver.mobilecommand import MobileCommand as Command
 
 
 class Common(CanExecuteCommands, CanExecuteScripts, CanRememberExtensionPresence):
@@ -28,32 +26,13 @@ class Common(CanExecuteCommands, CanExecuteScripts, CanRememberExtensionPresence
         Returns:
             Union['WebDriver', 'Common']: Self instance
         """
-        ext_name = 'mobile: openNotifications'
-        try:
-            self.assert_extension_exists(ext_name).execute_script(ext_name)
-        except UnknownMethodException:
-            # TODO: Remove the fallback
-            self.mark_extension_absence(ext_name).execute(Command.OPEN_NOTIFICATIONS, {})
+        self.execute_script('mobile: openNotifications')
         return self
 
     @property
     def current_package(self) -> str:
         """Retrieves the current package running on the device."""
-        ext_name = 'mobile: getCurrentPackage'
-        try:
-            return self.assert_extension_exists(ext_name).execute_script(ext_name)
-        except UnknownMethodException:
-            # TODO: Remove the fallback
-            return self.mark_extension_absence(ext_name).execute(Command.GET_CURRENT_PACKAGE)['value']
+        return self.execute_script('mobile: getCurrentPackage')
 
     def _add_commands(self) -> None:
-        self.command_executor.add_command(
-            Command.GET_CURRENT_PACKAGE,
-            'GET',
-            '/session/$sessionId/appium/device/current_package',
-        )
-        self.command_executor.add_command(
-            Command.OPEN_NOTIFICATIONS,
-            'POST',
-            '/session/$sessionId/appium/device/open_notifications',
-        )
+        pass

--- a/appium/webdriver/mobilecommand.py
+++ b/appium/webdriver/mobilecommand.py
@@ -78,9 +78,7 @@ class MobileCommand:
     GET_AVAILABLE_LOG_TYPES = 'getAvailableLogTypes'
 
     # Android
-    OPEN_NOTIFICATIONS = 'openNotifications'
     GET_CURRENT_ACTIVITY = 'getCurrentActivity'
-    GET_CURRENT_PACKAGE = 'getCurrentPackage'
     GET_SYSTEM_BARS = 'getSystemBars'
     GET_DISPLAY_DENSITY = 'getDisplayDensity'
     TOGGLE_WIFI = 'toggleWiFi'

--- a/test/unit/webdriver/device/common_test.py
+++ b/test/unit/webdriver/device/common_test.py
@@ -30,13 +30,9 @@ class TestWebDriverCommon(object):
     def test_current_package(self):
         driver = android_w3c_driver()
         httpretty.register_uri(
-            httpretty.GET,
-            appium_command('/session/1234567890/appium/device/current_package'),
-            body='{"value": ".ExamplePackage"}',
-        )
-        httpretty.register_uri(
             httpretty.POST,
             appium_command('/session/1234567890/execute/sync'),
             body='{"value": ".ExamplePackage"}',
         )
         assert driver.current_package == '.ExamplePackage'
+        assert {'args': [], 'script': 'mobile: getCurrentPackage'} == get_httpretty_request_body(httpretty.last_request())


### PR DESCRIPTION
Removed fallback logic in `open_notifications` and `current_package` in `appium/webdriver/extensions/android/common.py`. These methods now exclusively use `mobile:` script extensions.

Also removed unused `OPEN_NOTIFICATIONS` and `GET_CURRENT_PACKAGE` constants from `MobileCommand` and updated unit tests accordingly.