### PR TITLE
refactor: remove legacy fallback in toggle_location_services

### DIFF
--- a/appium/webdriver/extensions/location.py
+++ b/appium/webdriver/extensions/location.py
@@ -14,7 +14,6 @@
 
 from typing import Dict, Union
 
-from selenium.common.exceptions import UnknownMethodException
 from typing_extensions import Self
 
 from appium.protocols.webdriver.can_execute_commands import CanExecuteCommands
@@ -33,11 +32,7 @@ class Location(CanExecuteCommands, CanExecuteScripts):
         Returns:
             Union['WebDriver', 'Location']: Self instance
         """
-        try:
-            self.execute_script('mobile: toggleGps')
-        except UnknownMethodException:
-            # TODO: Remove the fallback
-            self.execute(Command.TOGGLE_LOCATION_SERVICES)
+        self.execute_script('mobile: toggleGps')
         return self
 
     def set_location(
@@ -89,10 +84,5 @@ class Location(CanExecuteCommands, CanExecuteScripts):
 
     def _add_commands(self) -> None:
         """Add location endpoints. They are not int w3c spec."""
-        self.command_executor.add_command(
-            Command.TOGGLE_LOCATION_SERVICES,
-            'POST',
-            '/session/$sessionId/appium/device/toggle_location_services',
-        )
         self.command_executor.add_command(Command.GET_LOCATION, 'GET', '/session/$sessionId/location')
         self.command_executor.add_command(Command.SET_LOCATION, 'POST', '/session/$sessionId/location')

--- a/appium/webdriver/mobilecommand.py
+++ b/appium/webdriver/mobilecommand.py
@@ -84,7 +84,6 @@ class MobileCommand:
     GET_SYSTEM_BARS = 'getSystemBars'
     GET_DISPLAY_DENSITY = 'getDisplayDensity'
     TOGGLE_WIFI = 'toggleWiFi'
-    TOGGLE_LOCATION_SERVICES = 'toggleLocationServices'
     GET_PERFORMANCE_DATA_TYPES = 'getPerformanceDataTypes'
     GET_PERFORMANCE_DATA = 'getPerformanceData'
     GET_NETWORK_CONNECTION = 'getNetworkConnection'

--- a/test/unit/webdriver/device/location_test.py
+++ b/test/unit/webdriver/device/location_test.py
@@ -24,9 +24,11 @@ class TestWebDriverLocation(object):
     @httpretty.activate
     def test_toggle_location_services(self):
         driver = android_w3c_driver()
-        httpretty.register_uri(httpretty.POST, appium_command('/session/1234567890/appium/device/toggle_location_services'))
         httpretty.register_uri(httpretty.POST, appium_command('/session/1234567890/execute/sync'))
         assert isinstance(driver.toggle_location_services(), WebDriver)
+
+        d = get_httpretty_request_body(httpretty.last_request())
+        assert d['script'] == 'mobile: toggleGps'
 
     @httpretty.activate
     def test_set_location_float(self):


### PR DESCRIPTION
Removed the deprecated fallback logic in `toggle_location_services` that used the `TOGGLE_LOCATION_SERVICES` command. The method now exclusively uses the `mobile: toggleGps` script.

Also removed the `TOGGLE_LOCATION_SERVICES` constant from `MobileCommand` and its registration in `Location._add_commands`, as it is no longer used.

Updated `test/unit/webdriver/device/location_test.py` to verify the new behavior.