### PR TITLE
chore: unify ruff version in pyproject.toml and pre-commit-config.yaml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,15 @@
 repos:
-- repo: https://github.com/astral-sh/ruff-pre-commit
-  # Ruff version.
-  rev: v0.9.0
-  hooks:
-    # Run the linter.
-    - id: ruff
-      args: [ --fix ]
-    # Run the formatter.
-    - id: ruff-format
+  - repo: local
+    hooks:
+      - id: ruff-check
+        name: ruff check
+        entry: uv run ruff check
+        language: system
+        types_or: [python, pyi]
+        args: [--fix, --show-fixes]
+
+      - id: ruff-format
+        name: ruff format
+        entry: uv run ruff format
+        language: system
+        types_or: [python, pyi]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dev = [
   "pytest-cov>=6.2,<8.0",
   "pytest-xdist~=3.8",
   "python-dateutil~=2.9",
-  "ruff~=0.12",
+  "ruff~=0.15",
   "types-python-dateutil~=2.9",
 
   # for release

--- a/uv.lock
+++ b/uv.lock
@@ -89,7 +89,7 @@ dev = [
     { name = "pytest-xdist", specifier = "~=3.8" },
     { name = "python-dateutil", specifier = "~=2.9" },
     { name = "python-semantic-release", specifier = ">=10.3.1,<10.6.0" },
-    { name = "ruff", specifier = "~=0.12" },
+    { name = "ruff", specifier = "~=0.15" },
     { name = "sphinx", specifier = ">=4.0,<9.0" },
     { name = "sphinx-rtd-theme", specifier = "~=3.0" },
     { name = "sphinxcontrib-apidoc", specifier = "~=0.6" },


### PR DESCRIPTION
Hello
In PR use the same version of ruff in pre-commits from dependencies