### PR TITLE
test: remove (object) inheritance to align with pytest style (#644)

### DIFF
--- a/test/functional/mac/helper/test_helper.py
+++ b/test/functional/mac/helper/test_helper.py
@@ -20,7 +20,7 @@ from test.helpers.constants import SERVER_URL_BASE
 from .desired_capabilities import get_desired_capabilities
 
 
-class BaseTestCase(object):
+class BaseTestCase:
     def setup_method(self) -> None:
         client_config = AppiumClientConfig(remote_server_addr=SERVER_URL_BASE)
         client_config.timeout = 600

--- a/test/unit/webdriver/appium_service_test.py
+++ b/test/unit/webdriver/appium_service_test.py
@@ -15,6 +15,6 @@
 from appium.webdriver.appium_service import AppiumService
 
 
-class TestAppiumService(object):
+class TestAppiumService:
     def test_get_instance(self):
         assert AppiumService()

--- a/test/unit/webdriver/context_test.py
+++ b/test/unit/webdriver/context_test.py
@@ -17,7 +17,7 @@ import httpretty
 from test.unit.helper.test_helper import android_w3c_driver, appium_command, get_httpretty_request_body
 
 
-class TestWebDriverContext(object):
+class TestWebDriverContext:
     @httpretty.activate
     def test_current_contexts(self):
         driver = android_w3c_driver()

--- a/test/unit/webdriver/device/activities_test.py
+++ b/test/unit/webdriver/device/activities_test.py
@@ -17,7 +17,7 @@ import httpretty
 from test.unit.helper.test_helper import android_w3c_driver, appium_command
 
 
-class TestWebDriverActivities(object):
+class TestWebDriverActivities:
     @httpretty.activate
     def test_current_activity(self):
         driver = android_w3c_driver()

--- a/test/unit/webdriver/device/clipboard_test.py
+++ b/test/unit/webdriver/device/clipboard_test.py
@@ -18,7 +18,7 @@ from appium.webdriver.clipboard_content_type import ClipboardContentType
 from test.unit.helper.test_helper import android_w3c_driver, appium_command, get_httpretty_request_body, ios_w3c_driver
 
 
-class TestWebDriverClipboard(object):
+class TestWebDriverClipboard:
     @httpretty.activate
     def test_set_clipboard_with_url(self):
         driver = android_w3c_driver()

--- a/test/unit/webdriver/device/common_test.py
+++ b/test/unit/webdriver/device/common_test.py
@@ -18,7 +18,7 @@ from appium.webdriver.webdriver import WebDriver
 from test.unit.helper.test_helper import android_w3c_driver, appium_command, get_httpretty_request_body
 
 
-class TestWebDriverCommon(object):
+class TestWebDriverCommon:
     @httpretty.activate
     def test_open_notifications(self):
         driver = android_w3c_driver()

--- a/test/unit/webdriver/device/device_time_test.py
+++ b/test/unit/webdriver/device/device_time_test.py
@@ -17,7 +17,7 @@ import httpretty
 from test.unit.helper.test_helper import android_w3c_driver, appium_command, get_httpretty_request_body
 
 
-class TestWebDriverDeviceTime(object):
+class TestWebDriverDeviceTime:
     @httpretty.activate
     def test_device_time(self):
         driver = android_w3c_driver()

--- a/test/unit/webdriver/device/display_test.py
+++ b/test/unit/webdriver/device/display_test.py
@@ -17,7 +17,7 @@ import httpretty
 from test.unit.helper.test_helper import android_w3c_driver, appium_command
 
 
-class TestWebDriverDisplay(object):
+class TestWebDriverDisplay:
     @httpretty.activate
     def test_get_display_density(self):
         driver = android_w3c_driver()

--- a/test/unit/webdriver/device/fingerprint_test.py
+++ b/test/unit/webdriver/device/fingerprint_test.py
@@ -18,7 +18,7 @@ from appium.webdriver.webdriver import WebDriver
 from test.unit.helper.test_helper import android_w3c_driver, appium_command, get_httpretty_request_body
 
 
-class TestWebDriverFingerprint(object):
+class TestWebDriverFingerprint:
     @httpretty.activate
     def test_finger_print(self):
         driver = android_w3c_driver()

--- a/test/unit/webdriver/device/gsm_test.py
+++ b/test/unit/webdriver/device/gsm_test.py
@@ -19,7 +19,7 @@ from appium.webdriver.webdriver import WebDriver
 from test.unit.helper.test_helper import android_w3c_driver, appium_command, get_httpretty_request_body
 
 
-class TestWebDriveGsm(object):
+class TestWebDriveGsm:
     @httpretty.activate
     def test_make_gsm_call(self):
         driver = android_w3c_driver()

--- a/test/unit/webdriver/device/keyboard_test.py
+++ b/test/unit/webdriver/device/keyboard_test.py
@@ -19,7 +19,7 @@ from appium.webdriver.webdriver import WebDriver
 from test.unit.helper.test_helper import android_w3c_driver, appium_command, get_httpretty_request_body, ios_w3c_driver
 
 
-class TestWebDriverKeyboardAndroid(object):
+class TestWebDriverKeyboardAndroid:
     @httpretty.activate
     def test_hide_keyboard(self):
         driver = android_w3c_driver()
@@ -101,7 +101,7 @@ class TestWebDriverKeyboardAndroid(object):
         )
 
 
-class TestWebDriverKeyboardIOS(object):
+class TestWebDriverKeyboardIOS:
     @httpretty.activate
     def test_hide_keyboard(self):
         driver = ios_w3c_driver()

--- a/test/unit/webdriver/device/location_test.py
+++ b/test/unit/webdriver/device/location_test.py
@@ -20,7 +20,7 @@ from test.unit.helper.test_helper import android_w3c_driver, appium_command, get
 FLT_EPSILON = 1e-9
 
 
-class TestWebDriverLocation(object):
+class TestWebDriverLocation:
     @httpretty.activate
     def test_toggle_location_services(self):
         driver = android_w3c_driver()

--- a/test/unit/webdriver/device/lock_test.py
+++ b/test/unit/webdriver/device/lock_test.py
@@ -18,7 +18,7 @@ from appium.webdriver.webdriver import WebDriver
 from test.unit.helper.test_helper import android_w3c_driver, appium_command, get_httpretty_request_body, ios_w3c_driver
 
 
-class TestWebDriverLockAndroid(object):
+class TestWebDriverLockAndroid:
     @httpretty.activate
     def test_lock(self):
         driver = android_w3c_driver()
@@ -65,7 +65,7 @@ class TestWebDriverLockAndroid(object):
         assert isinstance(driver.unlock(), WebDriver)
 
 
-class TestWebDriverLockIOS(object):
+class TestWebDriverLockIOS:
     @httpretty.activate
     def test_lock(self):
         driver = ios_w3c_driver()

--- a/test/unit/webdriver/device/power_test.py
+++ b/test/unit/webdriver/device/power_test.py
@@ -19,7 +19,7 @@ from appium.webdriver.webdriver import WebDriver
 from test.unit.helper.test_helper import android_w3c_driver, appium_command, get_httpretty_request_body
 
 
-class TestWebDriverPower(object):
+class TestWebDriverPower:
     @httpretty.activate
     def test_set_power_capacity(self):
         driver = android_w3c_driver()

--- a/test/unit/webdriver/device/remote_fs_test.py
+++ b/test/unit/webdriver/device/remote_fs_test.py
@@ -22,7 +22,7 @@ from appium.webdriver.webdriver import WebDriver
 from test.unit.helper.test_helper import android_w3c_driver, appium_command, get_httpretty_request_body
 
 
-class TestWebDriverRemoteFs(object):
+class TestWebDriverRemoteFs:
     @httpretty.activate
     def test_push_file(self):
         driver = android_w3c_driver()

--- a/test/unit/webdriver/device/shake_test.py
+++ b/test/unit/webdriver/device/shake_test.py
@@ -19,7 +19,7 @@ from appium.webdriver.webdriver import WebDriver
 from test.unit.helper.test_helper import android_w3c_driver, appium_command
 
 
-class TestWebDriverShake(object):
+class TestWebDriverShake:
     @httpretty.activate
     def test_shake(self):
         driver = android_w3c_driver()

--- a/test/unit/webdriver/device/sms_test.py
+++ b/test/unit/webdriver/device/sms_test.py
@@ -18,7 +18,7 @@ from appium.webdriver.webdriver import WebDriver
 from test.unit.helper.test_helper import android_w3c_driver, appium_command, get_httpretty_request_body
 
 
-class TestWebDriverSms(object):
+class TestWebDriverSms:
     @httpretty.activate
     def test_send_sms(self):
         driver = android_w3c_driver()

--- a/test/unit/webdriver/device/system_bars_test.py
+++ b/test/unit/webdriver/device/system_bars_test.py
@@ -17,7 +17,7 @@ import httpretty
 from test.unit.helper.test_helper import android_w3c_driver, appium_command
 
 
-class TestWebDriverSystemBars(object):
+class TestWebDriverSystemBars:
     @httpretty.activate
     def test_get_system_bars(self):
         driver = android_w3c_driver()

--- a/test/unit/webdriver/execute_driver_test.py
+++ b/test/unit/webdriver/execute_driver_test.py
@@ -19,7 +19,7 @@ import httpretty
 from test.unit.helper.test_helper import android_w3c_driver, appium_command, get_httpretty_request_body
 
 
-class TestWebDriverExecuteDriver(object):
+class TestWebDriverExecuteDriver:
     @httpretty.activate
     def test_batch(self):
         driver = android_w3c_driver()

--- a/test/unit/webdriver/flutter_integration/flutter_actions_test.py
+++ b/test/unit/webdriver/flutter_integration/flutter_actions_test.py
@@ -24,7 +24,7 @@ from appium.webdriver.webelement import WebElement as MobileWebElement
 from test.unit.helper.test_helper import appium_command, flutter_w3c_driver, get_httpretty_request_body
 
 
-class TestFlutterActions(object):
+class TestFlutterActions:
     @httpretty.activate
     def test_double_click(self):
         driver = flutter_w3c_driver()

--- a/test/unit/webdriver/flutter_integration/flutter_search_context_test.py
+++ b/test/unit/webdriver/flutter_integration/flutter_search_context_test.py
@@ -18,7 +18,7 @@ from appium.webdriver.common.appiumby import AppiumBy
 from test.unit.helper.test_helper import appium_command, flutter_w3c_driver, get_httpretty_request_body
 
 
-class TestFlutterSearchContext(object):
+class TestFlutterSearchContext:
     @httpretty.activate
     def test_find_element_by_flutter_key(self):
         driver = flutter_w3c_driver()

--- a/test/unit/webdriver/flutter_integration/flutter_waits_test.py
+++ b/test/unit/webdriver/flutter_integration/flutter_waits_test.py
@@ -20,7 +20,7 @@ from appium.webdriver.webelement import WebElement as MobileWebElement
 from test.unit.helper.test_helper import appium_command, flutter_w3c_driver, get_httpretty_request_body
 
 
-class TestFlutterWaits(object):
+class TestFlutterWaits:
     @httpretty.activate
     def test_wait_for_visible_with_finder(self):
         driver = flutter_w3c_driver()

--- a/test/unit/webdriver/log_events_test.py
+++ b/test/unit/webdriver/log_events_test.py
@@ -20,7 +20,7 @@ from appium.webdriver.webdriver import WebDriver
 from test.unit.helper.test_helper import appium_command, get_httpretty_request_body, ios_w3c_driver
 
 
-class TestWebDriverLogEvents(object):
+class TestWebDriverLogEvents:
     @httpretty.activate
     def test_get_events(self):
         driver = ios_w3c_driver()

--- a/test/unit/webdriver/network_test.py
+++ b/test/unit/webdriver/network_test.py
@@ -20,7 +20,7 @@ from appium.webdriver.webdriver import WebDriver
 from test.unit.helper.test_helper import android_w3c_driver, appium_command, get_httpretty_request_body
 
 
-class TestWebDriverNetwork(object):
+class TestWebDriverNetwork:
     @httpretty.activate
     def test_network_connection(self):
         driver = android_w3c_driver()

--- a/test/unit/webdriver/performance_test.py
+++ b/test/unit/webdriver/performance_test.py
@@ -17,7 +17,7 @@ import httpretty
 from test.unit.helper.test_helper import android_w3c_driver, appium_command, get_httpretty_request_body
 
 
-class TestWebDriverPerformance(object):
+class TestWebDriverPerformance:
     @httpretty.activate
     def test_get_performance_data(self):
         driver = android_w3c_driver()

--- a/test/unit/webdriver/screen_record_test.py
+++ b/test/unit/webdriver/screen_record_test.py
@@ -12,7 +12,7 @@ import httpretty
 from test.unit.helper.test_helper import android_w3c_driver, appium_command, get_httpretty_request_body, ios_w3c_driver
 
 
-class TestWebDriverScreenRecordAndroid(object):
+class TestWebDriverScreenRecordAndroid:
     @httpretty.activate
     def test_start_recording_screen(self):
         driver = android_w3c_driver()
@@ -43,7 +43,7 @@ class TestWebDriverScreenRecordAndroid(object):
         assert 'password' not in d['options'].keys()
 
 
-class TestWebDriverScreenRecordIOS(object):
+class TestWebDriverScreenRecordIOS:
     @httpretty.activate
     def test_start_recording_screen(self):
         driver = ios_w3c_driver()

--- a/test/unit/webdriver/search_context/android_test.py
+++ b/test/unit/webdriver/search_context/android_test.py
@@ -21,7 +21,7 @@ from appium.webdriver.webelement import WebElement as MobileWebElement
 from test.unit.helper.test_helper import android_w3c_driver, appium_command, get_httpretty_request_body
 
 
-class TestWebDriverAndroidSearchContext(object):
+class TestWebDriverAndroidSearchContext:
     @httpretty.activate
     def test_find_element_by_id(self):
         driver = android_w3c_driver()

--- a/test/unit/webdriver/search_context/ios_test.py
+++ b/test/unit/webdriver/search_context/ios_test.py
@@ -19,7 +19,7 @@ from appium.webdriver.webelement import WebElement as MobileWebElement
 from test.unit.helper.test_helper import appium_command, get_httpretty_request_body, ios_w3c_driver
 
 
-class TestWebDriverIOSSearchContext(object):
+class TestWebDriverIOSSearchContext:
     @httpretty.activate
     def test_find_element_by_ios_predicate(self):
         driver = ios_w3c_driver()

--- a/test/unit/webdriver/settings_test.py
+++ b/test/unit/webdriver/settings_test.py
@@ -18,7 +18,7 @@ from appium.webdriver.webdriver import WebDriver
 from test.unit.helper.test_helper import android_w3c_driver, appium_command, get_httpretty_request_body
 
 
-class TestWebDriverSettings(object):
+class TestWebDriverSettings:
     @httpretty.activate
     def test_get_settings_bool(self):
         driver = android_w3c_driver()

--- a/test/unit/webdriver/webdriver_test.py
+++ b/test/unit/webdriver/webdriver_test.py
@@ -472,7 +472,7 @@ class SubSubWebDriver(SubWebDriver):
         )
 
 
-class TestSubModuleWebDriver(object):
+class TestSubModuleWebDriver:
     def android_w3c_driver(self, driver_class):
         response_body_json = json.dumps(
             {

--- a/test/unit/webdriver/webelement_test.py
+++ b/test/unit/webdriver/webelement_test.py
@@ -21,7 +21,7 @@ from appium.webdriver.webelement import WebElement as MobileWebElement
 from test.unit.helper.test_helper import android_w3c_driver, appium_command, get_httpretty_request_body
 
 
-class TestWebElement(object):
+class TestWebElement:
     @httpretty.activate
     def test_status(self):
         driver = android_w3c_driver()


### PR DESCRIPTION
## Description
This PR removes the explicit `(object)` inheritance from test classes across the `test/` directory.

Since the codebase is now on Python 3, explicitly inheriting from `object` (a relic of Python 2's "new-style" classes) is redundant. Removing this boilerplate aligns the test suite with standard `pytest` idioms and modern Python conventions.

Fixes #644

## Changes Made
* Performed a global find and replace to update `class Test*(object):` to `class Test*:` in all test files.
* No changes to test logic or assertions were made.