### PR TITLE
refactor: Network extension to remove legacy command fallbacks

### DIFF
--- a/appium/webdriver/extensions/android/network.py
+++ b/appium/webdriver/extensions/android/network.py
@@ -12,15 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from selenium.common.exceptions import UnknownMethodException
 from typing_extensions import Self
 
 from appium.common.helper import extract_const_attributes
 from appium.common.logger import logger
 from appium.protocols.webdriver.can_execute_commands import CanExecuteCommands
 from appium.protocols.webdriver.can_execute_scripts import CanExecuteScripts
-from appium.protocols.webdriver.can_remember_extension_presence import CanRememberExtensionPresence
-from appium.webdriver.mobilecommand import MobileCommand as Command
 
 
 class NetSpeed:
@@ -41,7 +38,7 @@ class NetworkMask:
     AIRPLANE_MODE = 0b001
 
 
-class Network(CanExecuteCommands, CanExecuteScripts, CanRememberExtensionPresence):
+class Network(CanExecuteCommands, CanExecuteScripts):
     @property
     def network_connection(self) -> int:
         """Returns an integer bitmask specifying the network connection type.
@@ -53,16 +50,12 @@ class Network(CanExecuteCommands, CanExecuteScripts, CanRememberExtensionPresenc
         since API level 31.
         """
         ext_name = 'mobile: getConnectivity'
-        try:
-            result_map = self.assert_extension_exists(ext_name).execute_script(ext_name)
-            return (
-                (NetworkMask.WIFI if result_map['wifi'] else 0)
-                | (NetworkMask.DATA if result_map['data'] else 0)
-                | (NetworkMask.AIRPLANE_MODE if result_map['airplaneMode'] else 0)
-            )
-        except UnknownMethodException:
-            # TODO: Remove the fallback
-            return self.mark_extension_absence(ext_name).execute(Command.GET_NETWORK_CONNECTION, {})['value']
+        result_map = self.execute_script(ext_name)
+        return (
+            (NetworkMask.WIFI if result_map['wifi'] else 0)
+            | (NetworkMask.DATA if result_map['data'] else 0)
+            | (NetworkMask.AIRPLANE_MODE if result_map['airplaneMode'] else 0)
+        )
 
     def set_network_connection(self, connection_type: int) -> int:
         """Sets the network connection type. Android only.
@@ -95,20 +88,14 @@ class Network(CanExecuteCommands, CanExecuteScripts, CanRememberExtensionPresenc
             int: Set network connection type
         """
         ext_name = 'mobile: setConnectivity'
-        try:
-            return self.assert_extension_exists(ext_name).execute_script(
-                ext_name,
-                {
-                    'wifi': bool(connection_type & NetworkMask.WIFI),
-                    'data': bool(connection_type & NetworkMask.DATA),
-                    'airplaneMode': bool(connection_type & NetworkMask.AIRPLANE_MODE),
-                },
-            )
-        except UnknownMethodException:
-            # TODO: Remove the fallback
-            return self.mark_extension_absence(ext_name).execute(
-                Command.SET_NETWORK_CONNECTION, {'parameters': {'type': connection_type}}
-            )['value']
+        return self.execute_script(
+            ext_name,
+            {
+                'wifi': bool(connection_type & NetworkMask.WIFI),
+                'data': bool(connection_type & NetworkMask.DATA),
+                'airplaneMode': bool(connection_type & NetworkMask.AIRPLANE_MODE),
+            },
+        )
 
     def toggle_wifi(self) -> Self:
         """Toggle the wifi on the device, Android only.
@@ -119,12 +106,9 @@ class Network(CanExecuteCommands, CanExecuteScripts, CanRememberExtensionPresenc
             Union['WebDriver', 'Network']: Self instance
         """
         ext_name = 'mobile: setConnectivity'
-        try:
-            self.assert_extension_exists(ext_name).execute_script(
-                ext_name, {'wifi': not (self.network_connection & NetworkMask.WIFI)}
-            )
-        except UnknownMethodException:
-            self.mark_extension_absence(ext_name).execute(Command.TOGGLE_WIFI, {})
+        self.execute_script(
+            ext_name, {'wifi': not (self.network_connection & NetworkMask.WIFI)}
+        )
         return self
 
     def set_network_speed(self, speed_type: str) -> Self:
@@ -149,27 +133,8 @@ class Network(CanExecuteCommands, CanExecuteScripts, CanRememberExtensionPresenc
                 f'(e.g. {NetSpeed.__name__}.LTE)'
             )
         ext_name = 'mobile: networkSpeed'
-        try:
-            self.assert_extension_exists(ext_name).execute_script(ext_name, {'speed': speed_type})
-        except UnknownMethodException:
-            # TODO: Remove the fallback
-            self.mark_extension_absence(ext_name).execute(Command.SET_NETWORK_SPEED, {'netspeed': speed_type})
+        self.execute_script(ext_name, {'speed': speed_type})
         return self
 
     def _add_commands(self) -> None:
-        self.command_executor.add_command(Command.TOGGLE_WIFI, 'POST', '/session/$sessionId/appium/device/toggle_wifi')
-        self.command_executor.add_command(
-            Command.GET_NETWORK_CONNECTION,
-            'GET',
-            '/session/$sessionId/network_connection',
-        )
-        self.command_executor.add_command(
-            Command.SET_NETWORK_CONNECTION,
-            'POST',
-            '/session/$sessionId/network_connection',
-        )
-        self.command_executor.add_command(
-            Command.SET_NETWORK_SPEED,
-            'POST',
-            '/session/$sessionId/appium/device/network_speed',
-        )
+        pass

--- a/appium/webdriver/extensions/android/network.py
+++ b/appium/webdriver/extensions/android/network.py
@@ -106,9 +106,7 @@ class Network(CanExecuteCommands, CanExecuteScripts):
             Union['WebDriver', 'Network']: Self instance
         """
         ext_name = 'mobile: setConnectivity'
-        self.execute_script(
-            ext_name, {'wifi': not (self.network_connection & NetworkMask.WIFI)}
-        )
+        self.execute_script(ext_name, {'wifi': not (self.network_connection & NetworkMask.WIFI)})
         return self
 
     def set_network_speed(self, speed_type: str) -> Self:

--- a/appium/webdriver/extensions/android/network.py
+++ b/appium/webdriver/extensions/android/network.py
@@ -88,7 +88,7 @@ class Network(CanExecuteCommands, CanExecuteScripts):
             int: Set network connection type
         """
         ext_name = 'mobile: setConnectivity'
-        return self.execute_script(
+        self.execute_script(
             ext_name,
             {
                 'wifi': bool(connection_type & NetworkMask.WIFI),
@@ -96,6 +96,7 @@ class Network(CanExecuteCommands, CanExecuteScripts):
                 'airplaneMode': bool(connection_type & NetworkMask.AIRPLANE_MODE),
             },
         )
+        return self.network_connection
 
     def toggle_wifi(self) -> Self:
         """Toggle the wifi on the device, Android only.

--- a/test/unit/webdriver/network_test.py
+++ b/test/unit/webdriver/network_test.py
@@ -39,9 +39,10 @@ class TestWebDriverNetwork:
             appium_command('/session/1234567890/execute/sync'),
             body='{"value": {"wifi": true, "data": false, "airplaneMode": false}}',
         )
-        driver.set_network_connection(2)
+        assert driver.set_network_connection(2) == 2
 
-        d = get_httpretty_request_body(httpretty.last_request())
+        d = get_httpretty_request_body(httpretty.latest_requests()[-4])
+        assert d['script'] == 'mobile: setConnectivity'
         assert d['args'][0]['wifi'] is True
 
     @httpretty.activate

--- a/test/unit/webdriver/network_test.py
+++ b/test/unit/webdriver/network_test.py
@@ -24,7 +24,6 @@ class TestWebDriverNetwork:
     @httpretty.activate
     def test_network_connection(self):
         driver = android_w3c_driver()
-        httpretty.register_uri(httpretty.GET, appium_command('/session/1234567890/network_connection'), body='{"value": 2}')
         httpretty.register_uri(
             httpretty.POST,
             appium_command('/session/1234567890/execute/sync'),
@@ -35,7 +34,6 @@ class TestWebDriverNetwork:
     @httpretty.activate
     def test_set_network_connection(self):
         driver = android_w3c_driver()
-        httpretty.register_uri(httpretty.POST, appium_command('/session/1234567890/network_connection'), body='{"value": ""}')
         httpretty.register_uri(
             httpretty.POST,
             appium_command('/session/1234567890/execute/sync'),
@@ -51,10 +49,6 @@ class TestWebDriverNetwork:
         driver = android_w3c_driver()
         httpretty.register_uri(
             httpretty.POST,
-            appium_command('/session/1234567890/appium/device/network_speed'),
-        )
-        httpretty.register_uri(
-            httpretty.POST,
             appium_command('/session/1234567890/execute/sync'),
         )
         assert isinstance(driver.set_network_speed(NetSpeed.LTE), WebDriver)
@@ -65,10 +59,6 @@ class TestWebDriverNetwork:
     @httpretty.activate
     def test_toggle_wifi(self):
         driver = android_w3c_driver()
-        httpretty.register_uri(
-            httpretty.POST,
-            appium_command('/session/1234567890/appium/device/toggle_wifi'),
-        )
         httpretty.register_uri(
             httpretty.POST,
             appium_command('/session/1234567890/execute/sync'),


### PR DESCRIPTION
This pull request refactors the Android network extension in the Appium Python client to remove legacy MJSONWP (Mobile JSON Wire Protocol) code paths and dependencies, standardizing all network-related commands to use W3C WebDriver extension scripts. The code is simplified by removing fallback logic, unused imports, and direct command registrations. Corresponding unit tests are updated to reflect these changes.

**Refactoring to W3C-only network commands:**

* Removed all fallback logic and dependencies related to MJSONWP commands in the `Network` class; now only W3C extension scripts are used for network operations such as getting/setting network connection, toggling WiFi, and setting network speed (`appium/webdriver/extensions/android/network.py`). [[1]](diffhunk://#diff-034dc4af1753e3e6e05d00e68a62dfac619d84fe23543f0585bf8d1edb76c544L15-L23) [[2]](diffhunk://#diff-034dc4af1753e3e6e05d00e68a62dfac619d84fe23543f0585bf8d1edb76c544L44-R41) [[3]](diffhunk://#diff-034dc4af1753e3e6e05d00e68a62dfac619d84fe23543f0585bf8d1edb76c544L56-L65) [[4]](diffhunk://#diff-034dc4af1753e3e6e05d00e68a62dfac619d84fe23543f0585bf8d1edb76c544L98-R99) [[5]](diffhunk://#diff-034dc4af1753e3e6e05d00e68a62dfac619d84fe23543f0585bf8d1edb76c544L122-R110) [[6]](diffhunk://#diff-034dc4af1753e3e6e05d00e68a62dfac619d84fe23543f0585bf8d1edb76c544L152-R139)

**Code cleanup:**

* Removed unused imports and the `CanRememberExtensionPresence` mixin from the `Network` class, as well as command registration for legacy endpoints (`appium/webdriver/extensions/android/network.py`). [[1]](diffhunk://#diff-034dc4af1753e3e6e05d00e68a62dfac619d84fe23543f0585bf8d1edb76c544L15-L23) [[2]](diffhunk://#diff-034dc4af1753e3e6e05d00e68a62dfac619d84fe23543f0585bf8d1edb76c544L44-R41) [[3]](diffhunk://#diff-034dc4af1753e3e6e05d00e68a62dfac619d84fe23543f0585bf8d1edb76c544L152-R139)

**Unit test updates:**

* Updated tests to remove references to MJSONWP endpoints and ensure assertions match the new W3C-only behavior, including checking the correct script and arguments are sent (`test/unit/webdriver/network_test.py`). [[1]](diffhunk://#diff-01ddda9faab7a0e667d099f4dbdee8290cb78277856bc8a88916f7e3f4b509faL27) [[2]](diffhunk://#diff-01ddda9faab7a0e667d099f4dbdee8290cb78277856bc8a88916f7e3f4b509faL38-L55) [[3]](diffhunk://#diff-01ddda9faab7a0e667d099f4dbdee8290cb78277856bc8a88916f7e3f4b509faL68-L71)