### PR TITLE
docs: add usage examples to screen recording methods

### DIFF
--- a/appium/webdriver/extensions/screen_record.py
+++ b/appium/webdriver/extensions/screen_record.py
@@ -151,6 +151,9 @@ class ScreenRecord(CanExecuteCommands):
                 Possible values are 'ultrafast', 'superfast', 'veryfast'(default), 'faster', 'fast', 'medium', 'slow',
                 'slower', 'veryslow'
 
+        Usage:
+            driver.start_recording_screen()
+
         Returns:
             bytes: Base-64 encoded content of the recorded media
                 if `stop_recording_screen` isn't called after previous `start_recording_screen`.
@@ -183,6 +186,12 @@ class ScreenRecord(CanExecuteCommands):
             formFields (dict): [multipart/form-data requests] Additional form fields mapping. If any entry has
                 the same key as `fileFieldName` then it is going to be ignored. (Since Appium 1.18.0)
             headers (dict): [multipart/form-data requests] Headers mapping (Since Appium 1.18.0)
+
+        Usage:
+            payload = driver.stop_recording_screen()
+            with open('media.mp4', "wb") as fd:
+                import base64
+                fd.write(base64.b64decode(payload))
 
         Returns:
             bytes: Base-64 encoded content of the recorded media file or an empty string


### PR DESCRIPTION
## Description
Resolves #604

Adds clear usage examples to the docstrings of `start_recording_screen` and `stop_recording_screen` methods in `appium/webdriver/extensions/screen_record.py`, demonstrating how to start a recording, stop it, and decode the resulting base64 payload into a playable media file (`.mp4`).

## Changes
- Add `Usage:` section to `start_recording_screen`
- Add `Usage:` section with base64 decoding example to `stop_recording_screen`