### PR TITLE
fix: use seconds for service listening polling timeout

### DIFF
--- a/appium/webdriver/appium_service.py
+++ b/appium/webdriver/appium_service.py
@@ -184,7 +184,7 @@ class AppiumService:
         try:
             return is_service_listening(
                 _make_server_url(self._cmd),
-                timeout=STATE_CHECK_INTERVAL_MS,
+                timeout=STATE_CHECK_INTERVAL_MS / 1000.0,
                 custom_validator=self._assert_is_running,
             )
         except AppiumStartupError:

--- a/test/unit/webdriver/appium_service_test.py
+++ b/test/unit/webdriver/appium_service_test.py
@@ -12,9 +12,42 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from unittest.mock import Mock
+
+import pytest
+
+from appium.webdriver import appium_service
 from appium.webdriver.appium_service import AppiumService
 
 
 class TestAppiumService:
     def test_get_instance(self):
         assert AppiumService()
+
+    @pytest.mark.parametrize(
+        ('status', 'expected_result', 'expected_elapsed'),
+        [(200, True, 0.0), (503, False, 0.5)],
+    )
+    def test_is_listening_uses_short_polling_timeout(self, monkeypatch, status, expected_result, expected_elapsed):
+        process = Mock()
+        process.poll.return_value = None
+        monkeypatch.setattr(appium_service.sp, 'Popen', Mock(return_value=process))
+        service = AppiumService()
+        service.start(node='node', npm='npm', main_script='appium.js', timeout_ms=0)
+
+        clock = Mock()
+        clock.perf_counter.return_value = 0.0
+
+        def advance_time(seconds):
+            clock.perf_counter.return_value += seconds
+
+        clock.sleep.side_effect = advance_time
+        monkeypatch.setattr(appium_service, 'time', clock)
+
+        connection = Mock()
+        connection.request.return_value.status = status
+        monkeypatch.setattr(appium_service.urllib3, 'PoolManager', Mock(return_value=connection))
+
+        assert service.is_listening is expected_result
+        assert clock.perf_counter.return_value == expected_elapsed
+        connection.request.assert_called_once_with('HEAD', 'http://127.0.0.1:4723/status')


### PR DESCRIPTION
## Description

`AppiumService.is_listening` passes `STATE_CHECK_INTERVAL_MS` directly to `is_service_listening`, whose timeout is in seconds. When the service process remains alive but its status endpoint is unavailable, the polling budget is therefore 500 seconds instead of 500 milliseconds.

Convert the interval to seconds, consistently with the service startup path. This restores the intended polling budget; individual HTTP request timeouts and retries are unchanged and may extend the overall call duration.

## Validation

- Added a regression that exercises `is_listening` through the real polling helper with a simulated clock. Before the fix, HTTP503 advanced the clock by 500 seconds; afterward it advances by 0.5 seconds. HTTP200 still returns immediately.
- Local subprocess/HTTP fixture: HTTP503 did not finish within 1.5 seconds before the fix and returned `False` in 0.503 seconds afterward. HTTP200 returned `True` in 0.001 seconds.
- All 175 unit tests passed.
- `make check` passed: Ruff, formatting, and Mypy over 320 source files.
- Both published files were fetched back and their hashes match the tested copies.

OpenAI Codex performed the implementation and local validation for this GitHub account; maintainer review is pending.

If accepted, please confirm whether this PR qualifies for compensation under the [Appium contributor compensation scheme](https://github.com/appium/appium/blob/master/GOVERNANCE.md#compensation-scheme) and the applicable amount. I understand that classification and payment remain at the project's discretion.