### PR TITLE
fix: parse inline Appium service arguments

### DIFF
--- a/appium/webdriver/appium_service.py
+++ b/appium/webdriver/appium_service.py
@@ -286,6 +286,9 @@ def _parse_arg_value(args: list[str], arg_names: set[str], default: str) -> str:
     for idx, arg in enumerate(args):
         if arg in arg_names and idx < len(args) - 1:
             return args[idx + 1]
+        name, separator, value = arg.partition('=')
+        if separator and name in arg_names:
+            return value
     return default
 
 

--- a/test/unit/webdriver/appium_service_args_test.py
+++ b/test/unit/webdriver/appium_service_args_test.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from appium.webdriver.appium_service import _make_server_url
+
+
+@pytest.mark.parametrize(
+    ('args', 'expected_url'),
+    [
+        ([], 'http://127.0.0.1:4723/status'),
+        (['--port=1234'], 'http://127.0.0.1:1234/status'),
+        (['--address=appium.test'], 'http://appium.test:4723/status'),
+        (['--base-path=/wd/hub'], 'http://127.0.0.1:4723/wd/hub/status'),
+        (
+            ['--address=appium.test', '--port=1234', '--base-path=/wd/hub'],
+            'http://appium.test:1234/wd/hub/status',
+        ),
+        (
+            ['--address', 'appium.test', '--port', '1234', '--base-path', '/wd/hub'],
+            'http://appium.test:1234/wd/hub/status',
+        ),
+        (['-a', 'appium.test', '-p', '1234', '-pa', '/wd/hub'], 'http://appium.test:1234/wd/hub/status'),
+        (['-a=appium.test', '-p=1234', '-pa=/wd/hub'], 'http://appium.test:1234/wd/hub/status'),
+        (['-p', '1234', '--base-path=/wd/hub'], 'http://127.0.0.1:1234/wd/hub/status'),
+        (['--base-path=/value=with=equals/'], 'http://127.0.0.1:4723/value=with=equals/status'),
+        (['--port-extra=1234', '--address-extra=appium.test'], 'http://127.0.0.1:4723/status'),
+    ],
+)
+def test_status_url_uses_cli_argument_values(args, expected_url):
+    assert _make_server_url(args) == expected_url


### PR DESCRIPTION
## Description

`AppiumService` forwards `--option=value` arguments to Appium, but its status URL parser only recognizes separate option/value tokens. For example, Appium starts successfully with `--base-path=/wd/hub`, while the client polls `/status` and reports a startup timeout.

Recognize inline values when extracting service arguments. Separate values and short aliases retain their existing behavior; values containing additional `=` characters are preserved. The change only affects argument parsing.

## Validation

- Reproduced through `AppiumService.start` against Appium 3.7.0 on an ephemeral localhost port with isolated `APPIUM_HOME`: before the fix, startup timed out while an independent request to the configured status endpoint received HTTP 200.
- After the fix, real-server startup passed with inline values, separate long options, mixed forms, and separate short aliases.
- Added 11 argument-to-status-URL cases, including individual inline host/port/base-path options, aliases, embedded `=`, defaults, and unrelated option names.
- All 184 unit tests and `make check` passed (Ruff, formatting, Mypy over 320 source files).
- Both published files were fetched back and their hashes match the tested copies.

OpenAI Codex performed the implementation and local validation for this GitHub account; maintainer review is pending.

If accepted, please confirm whether this PR qualifies for compensation under the [Appium contributor compensation scheme](https://github.com/appium/appium/blob/master/GOVERNANCE.md#compensation-scheme) and the applicable amount. I understand that classification and payment remain at the project's discretion.