### PR TITLE
fix: bracket IPv6 hosts in service status URLs

### DIFF
--- a/appium/webdriver/appium_service.py
+++ b/appium/webdriver/appium_service.py
@@ -315,7 +315,10 @@ def _make_status_path(args: list[str]) -> str:
 
 
 def _make_server_url(args: list[str]) -> str:
-    return f'{_parse_protocol(args)}://{_parse_host(args)}:{_parse_port(args)}{_make_status_path(args)}'
+    host = _parse_host(args)
+    if ':' in host and not host.startswith('['):
+        host = f'[{host}]'
+    return f'{_parse_protocol(args)}://{host}:{_parse_port(args)}{_make_status_path(args)}'
 
 
 if __name__ == '__main__':

--- a/appium/webdriver/appium_service.py
+++ b/appium/webdriver/appium_service.py
@@ -18,6 +18,7 @@ import subprocess as sp
 import sys
 import time
 from collections.abc import Callable
+from ipaddress import AddressValueError, IPv6Address
 from typing import Any
 
 from selenium.webdriver.remote.remote_connection import urllib3
@@ -316,7 +317,11 @@ def _make_status_path(args: list[str]) -> str:
 
 def _make_server_url(args: list[str]) -> str:
     host = _parse_host(args)
-    if ':' in host and not host.startswith('['):
+    try:
+        IPv6Address(host)
+    except AddressValueError:
+        pass
+    else:
         host = f'[{host}]'
     return f'{_parse_protocol(args)}://{host}:{_parse_port(args)}{_make_status_path(args)}'
 

--- a/test/unit/webdriver/appium_service_ipv6_test.py
+++ b/test/unit/webdriver/appium_service_ipv6_test.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from appium.webdriver.appium_service import _make_server_url
+
+
+@pytest.mark.parametrize(
+    ('host', 'url_host'),
+    [
+        ('::1', '[::1]'),
+        ('2001:db8::1', '[2001:db8::1]'),
+        ('[::1]', '[::1]'),
+        ('127.0.0.1', '127.0.0.1'),
+        ('appium.test', 'appium.test'),
+    ],
+)
+def test_status_url_formats_ip_literal_hosts(host, url_host):
+    args = ['--address', host, '--port', '8123', '--base-path', '/wd/hub']
+    assert _make_server_url(args) == f'http://{url_host}:8123/wd/hub/status'

--- a/test/unit/webdriver/appium_service_ipv6_test.py
+++ b/test/unit/webdriver/appium_service_ipv6_test.py
@@ -22,7 +22,9 @@ from appium.webdriver.appium_service import _make_server_url
     [
         ('::1', '[::1]'),
         ('2001:db8::1', '[2001:db8::1]'),
+        ('fe80::1%en0', '[fe80::1%en0]'),
         ('[::1]', '[::1]'),
+        ('2001:db8::g', '2001:db8::g'),
         ('127.0.0.1', '127.0.0.1'),
         ('appium.test', 'appium.test'),
     ],


### PR DESCRIPTION
## Description

Appium accepts `--address ::1`, but `AppiumService` builds the status URL without brackets around the IPv6 literal. Its probe therefore uses an invalid URL such as `http://::1:4723/status`, causing startup to fail even when the server is healthy.

Bracket IPv6 hosts when constructing the service URL, without double-bracketing an already bracketed host. IPv4 addresses, hostnames, ports, base paths, argument parsing, and polling behavior are otherwise unchanged.

## Validation

- Reproduced with a real Appium 3.7.0 process on native `::1`, an ephemeral port, and isolated `APPIUM_HOME`. An independent HTTP request confirmed the configured status endpoint was healthy, while the unmodified client's startup check failed on the unbracketed URL.
- After the fix, `AppiumService.start` succeeded over native IPv6. A real IPv4 control also passed. Both server processes were stopped afterward.
- Added five regression cases for loopback/global IPv6 literals, an already bracketed literal, IPv4, and a hostname.
- All 178 unit tests passed; `make check` passed Ruff, formatting, and Mypy over 320 source files.
- Both published files were fetched back and their hashes match the tested copies.

OpenAI Codex performed the implementation and local validation for this GitHub account; maintainer review is pending.

If accepted, please confirm whether this PR qualifies for compensation under the [Appium contributor compensation scheme](https://github.com/appium/appium/blob/master/GOVERNANCE.md#compensation-scheme) and the applicable amount. I understand that classification and payment remain at the project's discretion.