### PR TITLE
fix: preserve capability alternatives from option lists

### DIFF
--- a/appium/webdriver/webdriver.py
+++ b/appium/webdriver/webdriver.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import copy
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
@@ -244,6 +245,12 @@ class WebDriver(
         options: AppiumOptions | list[AppiumOptions] | None = None,
         client_config: AppiumClientConfig | None = None,
     ):
+        if isinstance(options, list):
+            # Normalize before Selenium separates common and alternative capabilities.
+            options = [
+                AppiumOptions().load_capabilities(AppiumOptions.as_w3c(option.to_capabilities())['capabilities']['alwaysMatch'])
+                for option in options
+            ]
         command_executor, client_config = _get_remote_connection_and_client_config(
             command_executor=command_executor, client_config=client_config
         )
@@ -340,7 +347,17 @@ class WebDriver(
         if not isinstance(capabilities, (dict, AppiumOptions)):
             raise InvalidArgumentException('Capabilities must be a dictionary or AppiumOptions instance')
 
-        w3c_caps = AppiumOptions.as_w3c(capabilities) if isinstance(capabilities, dict) else capabilities.to_w3c()
+        if isinstance(capabilities, AppiumOptions):
+            w3c_caps = capabilities.to_w3c()
+        elif (
+            set(capabilities) == {'capabilities'}
+            and isinstance(capabilities['capabilities'], dict)
+            and {'alwaysMatch', 'firstMatch'}.issubset(capabilities['capabilities'])
+        ):
+            # Selenium already creates the W3C envelope when given a list of options.
+            w3c_caps = copy.deepcopy(capabilities)
+        else:
+            w3c_caps = AppiumOptions.as_w3c(capabilities)
         response = self.execute(RemoteCommand.NEW_SESSION, w3c_caps)
         # https://w3c.github.io/webdriver/#new-session
         if not isinstance(response, dict):

--- a/test/unit/webdriver/webdriver_options_list_test.py
+++ b/test/unit/webdriver/webdriver_options_list_test.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import copy
+import json
+
+import httpretty
+
+from appium import webdriver
+from appium.options.android import UiAutomator2Options
+from appium.options.ios import XCUITestOptions
+from test.helpers.constants import SERVER_URL_BASE
+
+
+def create_session(options):
+    httpretty.register_uri(
+        httpretty.POST,
+        f'{SERVER_URL_BASE}/session',
+        body=json.dumps({'value': {'sessionId': 'options-session', 'capabilities': {}}}),
+    )
+    driver = webdriver.Remote(SERVER_URL_BASE, options=options)
+    assert driver.session_id == 'options-session'
+    return json.loads(httpretty.last_request().body.decode('utf-8'))['capabilities']
+
+
+@httpretty.activate
+def test_options_list_preserves_common_and_alternative_capabilities():
+    proxy = {'proxyType': 'manual', 'httpProxy': 'proxy.example:8080'}
+    options = [
+        UiAutomator2Options().set_capability('deviceName', name).set_capability('proxy', proxy)
+        for name in ['first-device', 'second-device']
+    ]
+    original_capabilities = copy.deepcopy([option.to_capabilities() for option in options])
+
+    assert create_session(options) == {
+        'alwaysMatch': {'platformName': 'Android', 'appium:automationName': 'UIAutomator2', 'proxy': proxy},
+        'firstMatch': [{'appium:deviceName': 'first-device'}, {'appium:deviceName': 'second-device'}],
+    }
+    assert [option.to_capabilities() for option in options] == original_capabilities
+
+
+@httpretty.activate
+def test_options_list_normalizes_automation_overrides_before_matching():
+    default_options = UiAutomator2Options()
+    overridden_options = UiAutomator2Options().set_capability('automationName', 'Espresso')
+
+    assert create_session([default_options, overridden_options]) == {
+        'alwaysMatch': {'platformName': 'Android'},
+        'firstMatch': [{'appium:automationName': 'UIAutomator2'}, {'appium:automationName': 'Espresso'}],
+    }
+
+
+@httpretty.activate
+def test_options_list_supports_different_platform_alternatives():
+    assert create_session([UiAutomator2Options(), XCUITestOptions()]) == {
+        'alwaysMatch': {},
+        'firstMatch': [
+            {'platformName': 'Android', 'appium:automationName': 'UIAutomator2'},
+            {'platformName': 'iOS', 'appium:automationName': 'XCUITest'},
+        ],
+    }
+
+
+@httpretty.activate
+def test_single_item_options_list_matches_single_options_request():
+    options = UiAutomator2Options().set_capability('deviceName', 'single-device')
+    assert create_session([options]) == create_session(options)


### PR DESCRIPTION
## Description

`Remote(options=[first, second])` is already accepted by the Appium constructor's type signature, but Selenium's generated W3C envelope is wrapped again as an `appium:capabilities` capability. The server receives one empty `firstMatch` entry instead of the requested alternatives.

Normalize each option's capability names before Selenium extracts common values, then preserve its `alwaysMatch`/`firstMatch` envelope. Normalizing first also prevents the default `automationName` and an explicit `appium:automationName` override from ending up in conflicting sections. Caller-owned options, nested capabilities such as `proxy`, and client connection settings are preserved.

## Validation

- Four new regressions fail against the original source and pass after this fix: shared/nested capabilities, automation-name overrides, different platform alternatives, and a single-item list versus one options object.
- A real localhost HTTP fixture captures the POST emitted by `Remote`. It confirms the corrected envelope, unchanged input options, and preservation of the supplied `AppiumClientConfig` and timeout. This tests request serialization and session-response handling; it does not claim physical-device or multi-driver negotiation.
- All 177 unit tests passed.
- `make check` passed Ruff, formatting, and Mypy over 320 source files.
- Both published files were fetched back and their hashes match the tested copies.

OpenAI Codex performed the implementation and local validation for this GitHub account; maintainer review is pending.

If accepted, please confirm whether this PR qualifies for compensation under the [Appium contributor compensation scheme](https://github.com/appium/appium/blob/master/GOVERNANCE.md#compensation-scheme) and the applicable amount. I understand that classification and payment remain at the project's discretion.