### PR TITLE
docs: add 2026 year in copyright and actualization packageVersion

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,12 +18,12 @@ sys.path.insert(0, os.path.abspath('../appium'))
 
 # -- Project information -----------------------------------------------------
 
-project = 'Python client 1.1'
-copyright = '2020-2025, Appium'
+project = 'Python client 6.0.5'
+copyright = '2020-2026, Appium'
 author = 'Appium'
 
 # The full version, including alpha/beta/rc tags
-release = '1.1'
+release = '6.0.5'
 
 language = 'en'
 


### PR DESCRIPTION
Hello

In PR:
https://appium.github.io/python-client-sphinx/index.html
<img width="233" height="69" alt="Снимок экрана 2026-09-10 в 11 00 49" src="https://github.com/user-attachments/assets/06921874-2866-4a21-94ef-a60af24acb7b" />
<img width="331" height="86" alt="Снимок экрана 2026-09-10 в 11 01 13" src="https://github.com/user-attachments/assets/de0d8fde-134c-4509-9fe7-df3a75109f67" />

1) up 2025 -> 2026 year in copyright
2) actualize package version
